### PR TITLE
BM-138: Rename "market guest" to "assessor"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To build it and serve it locally, run the following commands
 
 ```console
 cargo install mdbook
-mdbook serve docs --open
+mdbook serve docs --open -p 3031
 ```
 
 to serve locally the docs.

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -140,7 +140,7 @@ where
 
         // TODO: Check config.market.peak_prove_khz (or maybe min khz?)
         // to make sure we can prove this quickly enough to get within the deadline
-        // this is tricky because we also need to account for the market guest AND aggregation
+        // this is tricky because we also need to account for the assessor AND aggregation
         // proving time
 
         // TODO: Move URI handling like this into the prover impls


### PR DESCRIPTION
fixes https://linear.app/risczero/issue/BM-138/rename-market-guest-assessor (at least all I can spot)
