### PR TITLE
BM-195: Fixed set-verify-params

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -515,6 +515,7 @@ where
             self.provider.clone(),
             self.args.set_verifier_addr,
             self.args.proof_market_addr,
+            agg_img_data.0,
         ));
         supervisor_tasks.spawn(async move {
             task::supervisor(1, submitter).await.context("Failed to start submitter service")?;


### PR DESCRIPTION
This PR fixes a problem with set-verifier params coming from not the authoritative Image ID of the agg-set guest deployed. 