### PR TITLE
BM-209: Allow Book only changes to be approved by Nuke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 # precedence.
 
 *                                      @boundless-xyz/maintainers @capossele @Wollac @zeroecco
+/docs/                                 @nuke-web3


### PR DESCRIPTION
To help accelerate updates to the book getting published
I Think this should allow my approval to be merge-able (but need anyone else to :+1: on my own PRs to qualify)
