### PR TITLE
BM-219: Drop double deposit

### DIFF
--- a/crates/boundless-market/src/bin/cli.rs
+++ b/crates/boundless-market/src/bin/cli.rs
@@ -383,8 +383,6 @@ where
         request.id = request_yaml.id;
     }
 
-    market.deposit(U256::from(request.offer.maxPrice)).await?;
-
     let request_id = market.submit_request(&request, &signer).await?;
     tracing::info!(
         "Proving request ID 0x{request_id:x}, bidding start at block number {}",


### PR DESCRIPTION
This PR removes a deposit in the CLI while submitting a new request as the deposit is already done by the inner submit request function