### PR TITLE
BM-251: Expand .vscode/settings.json and add .watchmanconfig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
-    "rust-analyzer.check.extraEnv": {
-        "RISC0_SKIP_BUILD": "1",
-    }
+  "rust-analyzer.check.allTargets": true,
+  "rust-analyzer.check.features": [],
+  "rust-analyzer.check.extraEnv": {
+    "RISC0_SKIP_BUILD": "1",
+    "RISC0_SKIP_BUILD_KERNELS": "1"
+  }
 }

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,11 @@
+{
+  "ignore_dirs": [
+    "target",
+    "crates/guest/resolve/resolve-guest/target",
+    "crates/guest/util/echo/target",
+    "crates/guest/util/identity/target",
+    "crates/guest/assessor/assessor-guest/target",
+    "crates/guest/set-builder/set-builder-guest/target",
+    "examples/counter/target"
+  ]
+}


### PR DESCRIPTION
Updates the VSCode `settings.json` to match the `.vim/coc-settings.json`. In particular, this adds `RISC0_SKIP_BUILD_KERNEL` to the check config. It also adds a `.watchmanconfig` file. See https://github.com/risc0/risc0/pull/2428 for more context.
