### PR TITLE
BM-325: Fix gas-comparison filter

### DIFF
--- a/.github/workflows/gas-comparison.yml
+++ b/.github/workflows/gas-comparison.yml
@@ -31,12 +31,13 @@ jobs:
           filters: |
             src:
               - 'contracts/src/**'
+            foundry:
               - 'foundry.toml'
 
   gas-comparison:
     runs-on: ubuntu-latest
     needs: contracts-changed
-    if: needs.contracts-changed.outputs.contracts != '[]'
+    if: needs.contracts-changed.outputs.src == true || needs.contracts-changed.outputs.foundry == true
     steps:
       - name: checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR ensures that the gas comparison workflow runs only if some file in the contracts/src folder has changed or the foundry.toml changed