### PR TITLE
BM-327: Remove default for off-chain monitor

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -55,7 +55,7 @@ pub struct Args {
     pub rpc_url: Url,
 
     /// Order stream server URL
-    #[clap(long, env, default_value = "http://localhost:8585")]
+    #[clap(long, env)]
     pub order_stream_url: Option<Url>,
 
     /// wallet key


### PR DESCRIPTION
This PR drops the default value for the off-chain monitor so it will correctly disable the sub-service if not supplied in args