### PR TITLE
BM-336: Reduce the number of Solidity optimizer runs to speed up builds

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ evm_version = 'cancun'
 via_ir = true
 optimizer = true
 # Use 10k runs because it doesn't seem to slow down compilation, and does shave off a bit of gas.
-optimizer_runs = 10000
+optimizer_runs = 1000
 ast = true
 build_info = true
 extra_output = ["storageLayout"]


### PR DESCRIPTION
I've been notizing `forge build` is taking longer now. Let's try reducing the number of optimzer passes to see the difference in gas costs and compile time.
