### PR TITLE
WEB3-240: Re-export alloy from boundless-market

### DIFF
--- a/crates/boundless-market/src/lib.rs
+++ b/crates/boundless-market/src/lib.rs
@@ -2,6 +2,13 @@
 //
 // All rights reserved.
 
+/// Re-export of [alloy], provided to ensure that the correct version of the types used in the
+/// public API are available in case multiple versions of [alloy] are in use.
+///
+/// Because [alloy] is a v0.x crate, it is not covered under the semver policy of this crate.
+#[cfg(not(target_os = "zkvm"))]
+pub use alloy;
+
 #[cfg(not(target_os = "zkvm"))]
 pub mod client;
 pub mod contracts;


### PR DESCRIPTION
One the common pieces of feedback we do from the Boundless private devnet was that alloy versioning was one of the biggest challenges. In particular, a developer would encounter a type mismatch error where "alloy::Foo is the not the same as alloy::Foo", which is a somewhat difficult to debug issue related to having two version of alloy in your crates tree. Because alloy is pre-1.0 and changing often, there is no silver bullet here.

One rule of thumb though is that an types that appear in the public interface of a crate should be (re-)exported from that crate. In our case, we do have alloy types in our public interface. So, if we apply this rule, we should export the types we use from alloy, and the easiest way to do so is to re-export the alloy crate. This helps with the versioning challenges because if the project ends up needing two distinct versions of alloy (e.g. one dependency specifies 0.4 and another 0.6) then the developer can use the re-exported alloy as an anchor for any places they are using boundless-market.

Related to https://github.com/risc0/risc0-ethereum/pull/337
Related to WEB3-240