### PR TITLE
BM-356: Fix and improve guest build.rs scripts

### DIFF
--- a/crates/guest/assessor/build.rs
+++ b/crates/guest/assessor/build.rs
@@ -2,7 +2,7 @@
 //
 // All rights reserved.
 
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, path::PathBuf};
 
 use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 use risc0_build_ethereum::generate_solidity_files;
@@ -15,9 +15,11 @@ fn main() {
     // Builds can be made deterministic, and thereby reproducible, by using Docker to build the
     // guest. Check the RISC0_USE_DOCKER variable and use Docker to build the guest if set.
     println!("cargo:rerun-if-env-changed=RISC0_USE_DOCKER");
+    println!("cargo:rerun-if-changed=build.rs");
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let use_docker = env::var("RISC0_USE_DOCKER")
         .ok()
-        .map(|_| DockerOptions { root_dir: Some("../../../".into()) });
+        .map(|_| DockerOptions { root_dir: Some(manifest_dir.join("../../..")) });
 
     // Generate Rust source files for the methods crate.
     let guests = embed_methods_with_options(HashMap::from([(

--- a/crates/guest/set-builder/build.rs
+++ b/crates/guest/set-builder/build.rs
@@ -2,7 +2,7 @@
 //
 // All rights reserved.
 
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, path::PathBuf};
 
 use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 use risc0_build_ethereum::generate_solidity_files;
@@ -15,9 +15,11 @@ fn main() {
     // Builds can be made deterministic, and thereby reproducible, by using Docker to build the
     // guest. Check the RISC0_USE_DOCKER variable and use Docker to build the guest if set.
     println!("cargo:rerun-if-env-changed=RISC0_USE_DOCKER");
+    println!("cargo:rerun-if-changed=build.rs");
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let use_docker = env::var("RISC0_USE_DOCKER")
         .ok()
-        .map(|_| DockerOptions { root_dir: Some("../../../".into()) });
+        .map(|_| DockerOptions { root_dir: Some(manifest_dir.join("../../..")) });
 
     // Generate Rust source files for the methods crate.
     let guests = embed_methods_with_options(HashMap::from([(

--- a/crates/guest/util/build.rs
+++ b/crates/guest/util/build.rs
@@ -2,7 +2,7 @@
 //
 // All rights reserved.
 
-use std::{collections::HashMap, env};
+use std::{collections::HashMap, env, path::PathBuf};
 
 use risc0_build::{embed_methods_with_options, DockerOptions, GuestOptions};
 use risc0_build_ethereum::generate_solidity_files;
@@ -15,9 +15,11 @@ fn main() {
     // Builds can be made deterministic, and thereby reproducible, by using Docker to build the
     // guest. Check the RISC0_USE_DOCKER variable and use Docker to build the guest if set.
     println!("cargo:rerun-if-env-changed=RISC0_USE_DOCKER");
+    println!("cargo:rerun-if-changed=build.rs");
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let use_docker = env::var("RISC0_USE_DOCKER")
         .ok()
-        .map(|_| DockerOptions { root_dir: Some("../../../".into()) });
+        .map(|_| DockerOptions { root_dir: Some(manifest_dir.join("../../..")) });
 
     // Generate Rust source files for the methods crate.
     let guests = embed_methods_with_options(HashMap::from([


### PR DESCRIPTION
Based on feedback from @Walloc on https://github.com/risc0/risc0-ethereum/pull/336, this PR includes improvements and fixes to guest `build.rs` scripts. At least for me, this also fixes `cargo clippy`, which has not need working in my editor.
