### PR TITLE
BM-362: Upgrade Artifacts Actions using `@v3` to `@v4`

### DIFF
--- a/.github/workflows/gas-comparison.yml
+++ b/.github/workflows/gas-comparison.yml
@@ -54,7 +54,7 @@ jobs:
           forge test -vv --gas-report | grep -iE "\| |gas used" > pr-gas-report.txt
 
       - name: Upload PR Gas Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-gas-report
           path: pr-gas-report.txt
@@ -71,7 +71,7 @@ jobs:
           forge test -vv --gas-report | grep -iE "\| |gas used" > main-gas-report.txt
 
       - name: Download PR Gas Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pr-gas-report
           path: .


### PR DESCRIPTION
- Artifacts actions `@v3` being deprecated.
- All `actions/upload-artifact` and `actions/download-artifact` uses must be upgraded to `@v4` before brownout dates (now in January):
  - https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/

<img src="https://github.com/user-attachments/assets/e1f86962-652f-46ac-a35d-2a9eb7c1db34" width="400"/>
