### PR TITLE
BM-383: Improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*.*.*"
   pull_request:
-    # *branches: ["release-*"]
+    *branches: ["release-*"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- Pin assessor ELF on IPFS only when the `image-id-check` fails

Closes BM-365