### PR TITLE
BM-446: Recover if failing to find orders on market monitor startup

### DIFF
--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -240,7 +240,10 @@ where
 
             Self::find_open_orders(lookback_blocks, market_addr, provider.clone(), db.clone())
                 .await
-                .map_err(SupervisorErr::Fault)?;
+                .map_err(|err| {
+                    tracing::error!("Monitor failed to find open orders on startup: {err:?}");
+                    SupervisorErr::Recover(err)
+                })?;
 
             Self::monitor_orders(market_addr, provider, db).await.map_err(|err| {
                 tracing::error!("Monitor for new blocks failed, restarting: {err:?}");


### PR DESCRIPTION
We saw RPC flakiness putting the broker in a state where is would not need orders submitted onchain. This PR makes a failure to find orders on market monitor startup a recoverable error to try to address this.
