### PR TITLE
BM-471: Fix: re-enable rust-analyzer for all crates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
     "--target-dir=target/analyzer"
   ],
   "rust-analyzer.linkedProjects": [
-    "bento/Cargo.toml", 
+    "./bento/Cargo.toml", 
     "./Cargo.toml",
     "./crates/guest/assessor/Cargo.toml",
     "./crates/guest/assessor/assessor-guest/Cargo.toml",


### PR DESCRIPTION
With default setup, rust-analyzer does not support two separate workspaces in one project (we now have the main project, and bento as its own project)

This is the minimal config I could find to get it running on both workspaces. Note the guest crates structure is non-standard, so I had to list out each sub crate individually.