### PR TITLE
BM-469: Bail when any task exits with an error status

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -525,7 +525,7 @@ where
             let status = match res {
                 Err(join_err) if join_err.is_cancelled() => {
                     tracing::info!("Tokio task exited with cancellation status: {join_err:?}");
-                    continue
+                    continue;
                 }
                 Err(join_err) => {
                     tracing::error!("Tokio task exited with error status: {join_err:?}");


### PR DESCRIPTION
As a first step to addressing the most common cause of prolonged downtime, this PR bails from the service loop, and so brings down the whole process, when any tasks exits with error status. This prevents the service from continuing in a "zombie" state, where e.g. it does not have a connection to the chain or order service anymore but is continuing anyway. With the assumption that there is a another layer of retry logic above the process (true in any kind of production deployment) then that outer layer will recreate the process. When it does, the service is designed to find and restart work that was dropped.

The next step in this effort is to address BM-470, to make the shutdown more orderly.