### PR TITLE
BM-504: Use clap Parse::parse rather than try_parse

### DIFF
--- a/crates/boundless-cli/src/bin/boundless-cli.rs
+++ b/crates/boundless-cli/src/bin/boundless-cli.rs
@@ -280,7 +280,7 @@ async fn main() -> Result<()> {
         Err(e) => bail!("failed to load .env file: {}", e),
     }
 
-    let args = MainArgs::try_parse()?;
+    let args = MainArgs::parse();
     run(&args).await.unwrap();
 
     Ok(())

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let args = Args::try_parse()?;
+    let args = Args::parse();
 
     let wallet = EthereumWallet::from(args.private_key.clone());
 


### PR DESCRIPTION
I noticed that `boundles-cli --help` or `boundles-cli --version` says `Error`. We are using `try_parse` instead of `parse`, but exiting anyway, so I switched it to `parse` to address this.
