### PR TITLE
BM-506: Use 10^18 units in deposit and withdraw stake CLI commands

### DIFF
--- a/crates/boundless-cli/src/bin/boundless-cli.rs
+++ b/crates/boundless-cli/src/bin/boundless-cli.rs
@@ -80,12 +80,18 @@ enum Command {
     },
     /// Deposit stake funds into the market
     DepositStake {
-        /// Amount in ether to deposit
+        /// Amount in HP to deposit.
+        ///
+        /// e.g. 10 is uint256(10 * 10**18).
+        #[clap(value_parser = parse_ether)]
         amount: U256,
     },
     /// Withdraw stake funds from the market
     WithdrawStake {
-        /// Amount in ether to withdraw
+        /// Amount in HP to withdraw.
+        ///
+        /// e.g. 10 is uint256(10 * 10**18).
+        #[clap(value_parser = parse_ether)]
         amount: U256,
     },
     /// Check the stake balance of an account in the market


### PR DESCRIPTION
In the docs we give the example

```
# Example: 'deposit-stake 100'
boundless-cli deposit-stake <HP_TO_DEPOSIT>
```

We would like this to deposit 100 HP. Really, it deposits 100 * 10^-18 HP. This PR added unit parsing to fix this.
