### PR TITLE
BM-508: Update default max lock stake from 0.5 to 5 HP

### DIFF
--- a/broker.toml
+++ b/broker.toml
@@ -4,7 +4,7 @@ assumption_price = "0.1"
 # peak_prove_khz = 500
 min_deadline = 150
 lookback_blocks = 100
-max_stake = "0.5"
+max_stake = "5" # HP
 skip_preflight_ids = []
 max_file_size = 50_000_000
 # max_fetch_retries = 2
@@ -13,7 +13,7 @@ max_file_size = 50_000_000
 
 [prover]
 status_poll_ms = 1000
-bonsai_r0_zkvm_ver = "1.1.1"
+bonsai_r0_zkvm_ver = "1.2.1"
 req_retry_count = 3
 # set_builder_guest_path = "./target/riscv-guest/riscv32im-risc0-zkvm-elf/release/set-builder-guest"
 # assessor_set_guest_path = "./target/riscv-guest/riscv32im-risc0-zkvm-elf/release/assessor-guest"


### PR DESCRIPTION
Default was set in reference to Sepolia ETH. In reference to HP, setting it to 5 HP seems reasonable. (At least 20 failed requests before you are out of HP).