### PR TITLE
docs: Update documentation on how to get job status

### DIFF
--- a/documentation/site/pages/prove/performance-optimization.mdx
+++ b/documentation/site/pages/prove/performance-optimization.mdx
@@ -88,7 +88,7 @@ RUST_LOG=info cargo run --bin bento_cli -- -c 1024
 ```
 
 ```sh [Terminal]
-echo 895a996b-b0fa-4fc8-ae7a-ba92eeb6b0b1 | bash scripts/job_status.sh
+bash scripts/job_status.sh 895a996b-b0fa-4fc8-ae7a-ba92eeb6b0b1
 ```
 
 ```txt [Terminal]
@@ -240,7 +240,7 @@ RUST_LOG=info cargo run --bin bento_cli -- -c 4096
 #### Review the Effective Hz
 
 ```sh [Terminal]
-echo <JOB_ID> | bash scripts/job_status.sh
+bash scripts/job_status.sh <JOB_ID>
 ```
 
 ```txt [Example Results]


### PR DESCRIPTION
Since https://github.com/boundless-xyz/boundless/commit/6646cdba7dfaa8fc0f31052cb6171704016f3599#diff-3386414d78b149270fe6c73ec085c5e8c565c1caa4e7951de5ea45b1c4e347b8R3, the script now requires the job as an argument instead of waiting for stdin