### PR TITLE
BM-535: Disable docker build for order-generator-zeth, fix retry bug

### DIFF
--- a/crates/order-generator/Cargo.toml
+++ b/crates/order-generator/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 zeth = { git = "https://github.com/risc0/zeth", optional = true }
-zeth-guests = { git = "https://github.com/risc0/zeth", optional = true, features =[ "debug-guest-build" ] }
+zeth-guests = { git = "https://github.com/risc0/zeth", optional = true, features = [ "debug-guest-build" ] }
 zeth-preflight = { git = "https://github.com/risc0/zeth", optional = true }
 zeth-preflight-ethereum = { git = "https://github.com/risc0/zeth", optional = true }
 

--- a/crates/order-generator/Cargo.toml
+++ b/crates/order-generator/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 zeth = { git = "https://github.com/risc0/zeth", optional = true }
-zeth-guests = { git = "https://github.com/risc0/zeth", optional = true }
+zeth-guests = { git = "https://github.com/risc0/zeth", optional = true, features =[ "debug-guest-build" ] }
 zeth-preflight = { git = "https://github.com/risc0/zeth", optional = true }
 zeth-preflight-ethereum = { git = "https://github.com/risc0/zeth", optional = true }
 

--- a/dockerfiles/order_generator_zeth.dockerfile
+++ b/dockerfiles/order_generator_zeth.dockerfile
@@ -2,9 +2,7 @@
 FROM rust:1.81.0-bookworm AS init
 
 RUN apt-get -qq update && \
-    apt-get install -y -q clang
-
-SHELL ["/bin/bash", "-c"]
+    apt-get install -y -q clang 
 
 # TODO: Update once rzup 0.3 is released. Current live version does not install due to symlink issue.
 # Full install of rzup to get r0vm
@@ -13,6 +11,8 @@ RUN curl -L https://risc0-artifacts.s3.us-west-2.amazonaws.com/rzup/test/install
 ENV RISC0_SERVER_PATH=/usr/local/cargo/bin/r0vm
 
 FROM init AS builder
+
+SHELL ["/bin/bash", "-c"]
 
 WORKDIR /src
 
@@ -27,6 +27,7 @@ COPY remappings.txt .
 COPY foundry.toml .
 
 SHELL ["/bin/bash", "-c"]
+
 
 RUN cargo build --release --bin order-generator-zeth -F zeth
 


### PR DESCRIPTION
By default building zeth requires docker in order to create a reproducible build of the guests. This means that when building order-generator-zeth in docker, the build process then tries to spawn Docker within Docker when it compiles zeth. Docker within Docker [is not recommended](https://stackoverflow.com/a/33003273), and requires Docker to be run in privileged mode which causes problems for our deployments. 

Also fixing a bug where the Zeth build would fail, reducing the number of retries remaining, but the call to getBlock would succeed which resets the retry count to 0, causing the task to loop forever.