### PR TITLE
BM-540: Set allow_internal_expect_revert

### DIFF
--- a/contracts/test/types/Offer.t.sol
+++ b/contracts/test/types/Offer.t.sol
@@ -11,6 +11,7 @@ import {IBoundlessMarket} from "../../src/IBoundlessMarket.sol";
 import {Offer} from "../../src/types/Offer.sol";
 
 contract OfferTest is Test {
+    /// forge-config: default.allow_internal_expect_revert = true
     function testBlockAtPrice() public {
         Offer memory offer = Offer({
             minPrice: 1 ether,


### PR DESCRIPTION
Recently, foundry-toolchain did an update that required to set `allow_internal_expect_revert` to true in one of our test (see: https://book.getfoundry.sh/cheatcodes/expect-revert#error)