### PR TITLE
BM-542: Add an extra condition to catch connection reset errors in retry layer

### DIFF
--- a/crates/broker/src/rpc_retry_policy.rs
+++ b/crates/broker/src/rpc_retry_policy.rs
@@ -20,8 +20,9 @@ impl RetryPolicy for CustomRetryPolicy {
     fn should_retry(&self, error: &TransportError) -> bool {
         let should_retry = match error {
             TransportError::Transport(TransportErrorKind::Custom(err)) => {
-                let msg = err.to_string();
-                msg.contains("os error 104")
+                // easier to match against the debug format string because this is what we see in the logs
+                let err_debug_str = format!("{:?}", err);
+                err_debug_str.contains("os error 104") || err_debug_str.contains("reset by peer")
             }
             _ => false,
         };
@@ -30,5 +31,39 @@ impl RetryPolicy for CustomRetryPolicy {
 
     fn backoff_hint(&self, error: &TransportError) -> Option<Duration> {
         RateLimitRetryPolicy::default().backoff_hint(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::transports::{layers::RetryPolicy, RpcError, TransportErrorKind};
+    use std::fmt;
+
+    struct MockError;
+
+    impl fmt::Debug for MockError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(Io, Os { code: 104, kind: ConnectionReset, message: \"Connection reset by peer\" })) }")
+        }
+    }
+
+    impl fmt::Display for MockError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("Mock Error")
+        }
+    }
+
+    impl std::error::Error for MockError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            None
+        }
+    }
+
+    #[test]
+    fn retries_on_os_error_104() {
+        let policy = CustomRetryPolicy;
+        let error = RpcError::Transport(TransportErrorKind::Custom(Box::new(MockError)));
+        assert!(policy.should_retry(&error));
     }
 }


### PR DESCRIPTION
As shown in BM-542 some connection reset errors were not being correctly picked up and retried by the retry layer. This adds an extra match for detecting these and a test showing it should catch the specific error that issues highlighted