### PR TITLE
BM-552: fix: avoid upload image id check on empty bytes case

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -276,6 +276,15 @@ async fn image_upload_put(
     let body_bytes =
         to_bytes(body, MAX_UPLOAD_SIZE).await.context("Failed to convert body to bytes")?;
 
+    if body_bytes.is_empty() {
+        // Note: this is currently a hack to short-circuit the upload if empty bytes.
+        // This is done to match Bonsai's behavior, but also because `Prover::has_image`
+        // needs to check if an image exists before downloading, and does this currently by calling
+        // upload with empty bytes.
+        // See https://github.com/risc0/risc0/pull/2851 for a potential way to avoid this pattern.
+        return Ok(());
+    }
+
     let comp_img_id =
         compute_image_id(&body_bytes).context("Failed to compute image id")?.to_string();
     if comp_img_id != image_id {

--- a/scripts/boundless_service.sh
+++ b/scripts/boundless_service.sh
@@ -160,7 +160,7 @@ start_services() {
 
     log_info "Starting Docker Compose services using environment file: $ENV_FILE"
 
-    # Start Docker Compose in foreground mode
+    # Start Docker Compose in background/detached mode
     docker compose --profile broker --env-file "$ENV_FILE" up --build -d
 
     # After docker compose up exits normally (without interruption)


### PR DESCRIPTION
This seems to match the behavior needed for `Prover::has_image`, and was not ideal to make the http calls directly to avoid this hack so decided to just handle this case specifically for now

Also using the following env vars to hit testnet:
```
BOUNDLESS_MARKET_ADDR=0x69c7943DA0D7e45D44Bd0cE7a2412DCdAe423788
SET_VERIFIER_ADDR=0xEf0A93B2310d52358F1eCA0C946aD7D25596e7dd
```