### PR TITLE
BM-565: fix: order stream connections mapping

### DIFF
--- a/crates/order-stream/src/order_db.rs
+++ b/crates/order-stream/src/order_db.rs
@@ -16,15 +16,13 @@ use thiserror::Error as ThisError;
 
 /// Order DB Errors
 #[derive(ThisError, Debug)]
+#[non_exhaustive]
 pub enum OrderDbErr {
     #[error("Missing env var {0}")]
     MissingEnv(&'static str),
 
     #[error("Invalid DB_POOL_SIZE")]
     InvalidPoolSize(#[from] std::num::ParseIntError),
-
-    #[error("Max concurrent connections")]
-    MaxConnections,
 
     #[error("Address not found: {0}")]
     AddrNotFound(Address),
@@ -55,7 +53,6 @@ pub struct OrderDb {
 }
 
 const ORDER_CHANNEL: &str = "new_orders";
-const MAX_BROKER_CONNECTIONS: i32 = 1;
 
 pub type OrderStream = Pin<Box<dyn Stream<Item = Result<DbOrder, OrderDbErr>> + Send>>;
 
@@ -109,55 +106,6 @@ impl OrderDb {
         }
 
         Ok(nonce)
-    }
-
-    /// Connects a broker
-    ///
-    /// Increments a brokers connection count, and faults if over connection MAX
-    pub async fn connect_broker(&self, addr: Address) -> Result<(), OrderDbErr> {
-        let mut txn = self.pool.begin().await?;
-
-        let connections: i32 =
-            sqlx::query_scalar("SELECT connections FROM brokers WHERE addr = $1")
-                .bind(addr.as_slice())
-                .fetch_one(&mut *txn)
-                .await?;
-
-        if connections >= MAX_BROKER_CONNECTIONS {
-            return Err(OrderDbErr::MaxConnections);
-        }
-
-        let res = sqlx::query(
-            "UPDATE brokers SET connections = connections + 1, updated_at = NOW() WHERE addr = $1 AND connections < $2",
-        )
-        .bind(addr.as_slice())
-        .bind(MAX_BROKER_CONNECTIONS)
-        .execute(&mut *txn)
-        .await?;
-
-        if res.rows_affected() == 0 {
-            return Err(OrderDbErr::NoRows("connect broker"));
-        }
-
-        txn.commit().await?;
-
-        Ok(())
-    }
-
-    /// Disconnects a broker, decreasing connection count
-    pub async fn disconnect_broker(&self, addr: Address) -> Result<(), OrderDbErr> {
-        let res = sqlx::query(
-            "UPDATE brokers SET connections = connections - 1, updated_at = NOW() WHERE addr = $1",
-        )
-        .bind(addr.as_slice())
-        .execute(&self.pool)
-        .await?;
-
-        if res.rows_affected() == 0 {
-            return Err(OrderDbErr::NoRows("disconnect broker"));
-        }
-
-        Ok(())
     }
 
     /// Mark the broker as updated by setting the update_at time
@@ -348,42 +296,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count, 1);
-    }
-
-    #[sqlx::test]
-    async fn connect_broker(pool: PgPool) {
-        let db = OrderDb::from_pool(pool.clone()).await.unwrap();
-        let addr = Address::ZERO;
-
-        db.add_broker(addr).await.unwrap();
-        db.connect_broker(addr).await.unwrap();
-        let conns: i32 = sqlx::query_scalar("SELECT connections FROM brokers WHERE addr = $1")
-            .bind(addr.as_slice())
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-        assert_eq!(conns, 1);
-    }
-
-    #[sqlx::test]
-    #[should_panic(expected = "MaxConnections")]
-    async fn connect_max(pool: PgPool) {
-        let db = OrderDb::from_pool(pool.clone()).await.unwrap();
-        let addr = Address::ZERO;
-
-        db.add_broker(addr).await.unwrap();
-        db.connect_broker(addr).await.unwrap();
-        db.connect_broker(addr).await.unwrap();
-    }
-
-    #[sqlx::test]
-    async fn disconnect_broker(pool: PgPool) {
-        let db = OrderDb::from_pool(pool.clone()).await.unwrap();
-        let addr = Address::ZERO;
-
-        db.add_broker(addr).await.unwrap();
-        db.connect_broker(addr).await.unwrap();
-        db.disconnect_broker(addr).await.unwrap();
     }
 
     #[sqlx::test]

--- a/crates/order-stream/src/ws.rs
+++ b/crates/order-stream/src/ws.rs
@@ -18,7 +18,7 @@ use boundless_market::{
 };
 use futures_util::{SinkExt, StreamExt};
 use rand::{seq::SliceRandom, Rng};
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::sync::Arc;
 use tokio::{sync::mpsc, task::JoinHandle};
 
@@ -40,7 +40,10 @@ fn parse_auth_msg(value: &HeaderValue) -> Result<AuthMsg> {
     get,
     path = ORDER_WS_PATH,
     params(
-        ("X-Auth-Data" = AuthMsg, description = "SIWE authentication message (AuthMsg) as a JSON object")
+        (
+            "X-Auth-Data" = AuthMsg, 
+            description = "SIWE authentication message (AuthMsg) as a JSON object"
+        )
     ),
     responses(
         (status = 200, description = "Websocket upgrade body", body = ()),
@@ -96,19 +99,23 @@ pub(crate) async fn websocket_handler(
 
     // Check if the address is already connected
     {
-        match state.db.connect_broker(client_addr).await {
-            Err(OrderDbErr::MaxConnections) => {
-                tracing::warn!("{client_addr} at max connections");
-                return Ok(
-                    (StatusCode::CONFLICT, "Max connections hit".to_string()).into_response()
-                );
-            }
-            Err(err) => return Err(AppError::InternalErr(anyhow::anyhow!(err))),
-            _ => {}
+        let connections = state.connections.read().await;
+        if connections.contains_key(&client_addr) {
+            return Ok((StatusCode::CONFLICT, "Max connections hit (1)").into_response());
         }
-        let connections = state.connections.lock().await;
         if connections.len() >= state.config.max_connections {
             return Ok((StatusCode::SERVICE_UNAVAILABLE, "Server at capacity").into_response());
+        }
+    }
+
+    {
+        // Connection does not exist, add to pending connections.
+        // Note: This is done without holding the lock to state.connections to minimize lock
+        // contention. At worst, the server will upgrade the connection and immediately drop it.
+        let mut pending_connections = state.pending_connections.lock().await;
+        if !pending_connections.insert(client_addr) {
+            // If the connection is already pending, return an error as max connections is 1.
+            return Ok((StatusCode::CONFLICT, "Connection in progress").into_response());
         }
     }
 
@@ -126,7 +133,6 @@ pub(crate) async fn websocket_handler(
             IBoundlessMarket::new(state.config.market_address, state.rpc_provider.clone());
         let balance = boundless_market.balanceOfStake(client_addr).call().await.unwrap()._0;
         if balance < state.config.min_balance {
-            state.db.disconnect_broker(client_addr).await.context("Failed to disconnect broker")?;
             tracing::warn!("Insufficient stake balance for addr: {client_addr}");
             return Ok((
                 StatusCode::UNAUTHORIZED,
@@ -155,7 +161,7 @@ async fn broadcast_order(db_order: &DbOrder, state: Arc<AppState>) {
 
     // Shuffle the connections
     let connections_list = {
-        let connections = state.connections.lock().await;
+        let connections = state.connections.read().await;
         let mut connections_list: Vec<_> =
             connections.iter().map(|(addr, conn)| (*addr, conn.sender.clone())).collect();
         connections_list.shuffle(&mut rand::rng());
@@ -179,14 +185,9 @@ async fn broadcast_order(db_order: &DbOrder, state: Arc<AppState>) {
     // Remove the clients that have closed their connections
     if !clients_to_remove.is_empty() {
         {
-            let mut connections = state.connections.lock().await;
+            let mut connections = state.connections.write().await;
             for address in clients_to_remove {
                 connections.remove(&address);
-                if let Err(err) = state.db.disconnect_broker(address).await {
-                    tracing::error!(
-                        "Failed to remove broker connection from DB: {address} - {err:?}"
-                    );
-                }
             }
         }
     }
@@ -203,8 +204,22 @@ async fn websocket_connection(socket: WebSocket, address: Address, state: Arc<Ap
 
         // Add sender to the list of connections
         {
-            let mut connections = state.connections.lock().await;
-            connections.insert(address, ClientConnection { sender: sender_channel.clone() });
+            let mut connections = state.connections.write().await;
+            match connections.entry(address) {
+                Entry::Occupied(_) => {
+                    tracing::warn!("Client {address} already connected");
+                    return;
+                },
+                Entry::Vacant(entry) => {
+                        entry.insert(ClientConnection { sender: sender_channel.clone()});
+                },
+            }
+        }
+
+        // Clean up the pending connection entry before upgrading
+        {
+            let mut pending_connections = state.pending_connections.lock().await;
+            pending_connections.remove(&address);
         }
 
         let mut errors_counter = 0usize;
@@ -292,11 +307,8 @@ async fn websocket_connection(socket: WebSocket, address: Address, state: Arc<Ap
             }
         }
         // Remove the connection when the send loop exits
-        let mut connections = state.connections.lock().await;
+        let mut connections = state.connections.write().await;
         connections.remove(&address);
-        if let Err(err) = state.db.disconnect_broker(address).await {
-            tracing::error!("Failed to remove broker connection from DB: {address} - {err:?}");
-        }
         tracing::debug!("WebSocket connection closed: {}", address);
     });
 }

--- a/justfile
+++ b/justfile
@@ -25,9 +25,9 @@ cargo-test-example-counter:
     RISC0_DEV_MODE=1 cargo test
 
 cargo-test-db $DATABASE_URL=DEFAULT_DATABASE_URL: setup-db
-    sqlx migrate run --source ./crates/bento/taskdb/migrations/
+    sqlx migrate run --source ./bento/crates/taskdb/migrations/
     cd bento && RISC0_DEV_MODE=1 cargo test -p taskdb
-    cd bento && RISC0_DEV_MODE=1 cargo test -p order-stream
+    RISC0_DEV_MODE=1 cargo test -p order-stream
     just clean-db
 
 cargo-clippy:


### PR DESCRIPTION
There is an edge case currently where a broker address will be marked in the db as connected, even though there is no active websocket connection.

There are at least a few ways this could have happened:
- Write to DB to lower the connections failed
- Get balance on chain failed, panicked, which does not update the db for that pending connection
- Service crashed for some other reason, and these marked connections in the db aren't handled in this case

Decided to just simplify the logic such that all the data around pending connections is just kept in memory, as there doesn't seem to be any reason to persist it. I kept the pending connections in a separate map to reduce lock contention on the actual connections (don't want people spamming to DOS the active connections). The logic also is changed such that it will not overwrite an existing active connection, so less worried about this having race conditions to replace connections.

Tested on test suites (fixed justfile as well) and tested manually as best I could, although integration tests for this don't really exist _yet_.