### PR TITLE
BM-567: fix: retry temporal bonsai poll errors

### DIFF
--- a/crates/broker/src/provers.rs
+++ b/crates/broker/src/provers.rs
@@ -125,6 +125,64 @@ impl Bonsai {
     }
 }
 
+struct StatusPoller {
+    poll_sleep: u64,
+    retry_counts: u64,
+}
+
+impl StatusPoller {
+    async fn poll_with_retries(&self, proof_id: &SessionId, client: &BonsaiClient) -> Result<ProofResult, ProverError> {
+        loop {
+            let mut status = None;
+            for retry_count in 0..self.retry_counts {
+                match proof_id.status(client).await {
+                    Ok(res) => {
+                        status = Some(res);
+                        break;
+                    }
+                    Err(err) => {
+                        tracing::warn!("Failed to get status: {err:?}, retrying {retry_count} / {}", self.retry_counts);
+                        tokio::time::sleep(tokio::time::Duration::from_secs(self.poll_sleep)).await;
+                        continue;
+                    }
+                }
+            }
+
+            let Some(status) = status else {
+                return Err(ProverError::StatusFailure);
+            };
+
+            match status.status.as_ref() {
+                "RUNNING" => {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(self.poll_sleep)).await;
+                    continue;
+                }
+                "SUCCEEDED" => {
+                    let Some(stats) = status.stats else {
+                        return Err(ProverError::MissingStatus);
+                    };
+                    return Ok(ProofResult {
+                        id: proof_id.uuid.clone(),
+                        stats: ExecutorResp {
+                            assumption_count: 0,
+                            segments: stats.segments as u64,
+                            user_cycles: stats.cycles,
+                            total_cycles: stats.total_cycles,
+                        },
+                        elapsed_time: status.elapsed_time.unwrap_or(f64::NAN),
+                    });
+                }
+                _ => {
+                    let err_msg = status.error_msg.unwrap_or_default();
+                    return Err(ProverError::ProvingFailed(format!(
+                        "{proof_id:?} failed: {err_msg}"
+                    )));
+                }
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl Prover for Bonsai {
     async fn upload_input(&self, input: Vec<u8>) -> Result<String, ProverError> {
@@ -157,53 +215,9 @@ impl Prover for Bonsai {
             let config = self.config.lock_all()?;
             (config.prover.status_poll_ms, config.prover.req_retry_count)
         };
-
-        loop {
-            let mut status = None;
-            for retry_count in 0..retry_counts {
-                match preflight_id.status(&self.client).await {
-                    Ok(res) => {
-                        status = Some(res);
-                        break;
-                    }
-                    Err(err) => {
-                        tracing::warn!("Failed to get status: {err:?}, retrying {retry_count} / {retry_counts}");
-                        tokio::time::sleep(tokio::time::Duration::from_secs(poll_sleep)).await;
-                        continue;
-                    }
-                }
-            }
-
-            let Some(status) = status else {
-                return Err(ProverError::StatusFailure);
-            };
-
-            match status.status.as_ref() {
-                "RUNNING" => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(poll_sleep)).await;
-                    continue;
-                }
-                "SUCCEEDED" => {
-                    let Some(stats) = status.stats else {
-                        return Err(ProverError::MissingStatus);
-                    };
-                    return Ok(ProofResult {
-                        id: preflight_id.uuid,
-                        stats: ExecutorResp {
-                            assumption_count: 0,
-                            segments: stats.segments as u64,
-                            user_cycles: stats.cycles,
-                            total_cycles: stats.total_cycles,
-                        },
-                        elapsed_time: status.elapsed_time.unwrap_or(f64::NAN),
-                    });
-                }
-                _ => {
-                    let err_msg = status.error_msg.unwrap_or_default();
-                    return Err(ProverError::ProvingFailed(format!("preflight failed: {err_msg}")));
-                }
-            }
-        }
+        StatusPoller { poll_sleep, retry_counts }
+            .poll_with_retries(&preflight_id, &self.client)
+            .await
     }
 
     async fn prove_stark(
@@ -236,55 +250,9 @@ impl Prover for Bonsai {
             let config = self.config.lock_all()?;
             (config.prover.status_poll_ms, config.prover.req_retry_count)
         };
+        let poller = StatusPoller { poll_sleep, retry_counts };
 
-        loop {
-            let mut status = None;
-            for retry_count in 0..retry_counts {
-                match proof_id.status(&self.client).await {
-                    Ok(res) => {
-                        status = Some(res);
-                        break;
-                    }
-                    Err(err) => {
-                        tracing::warn!("Failed to get status: {err:?}, retrying {retry_count} / {retry_counts}");
-                        tokio::time::sleep(tokio::time::Duration::from_secs(poll_sleep)).await;
-                        continue;
-                    }
-                }
-            }
-
-            let Some(status) = status else {
-                return Err(ProverError::StatusFailure);
-            };
-
-            match status.status.as_ref() {
-                "RUNNING" => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(poll_sleep)).await;
-                    continue;
-                }
-                "SUCCEEDED" => {
-                    let Some(stats) = status.stats else {
-                        return Err(ProverError::MissingStatus);
-                    };
-                    return Ok(ProofResult {
-                        id: proof_id.uuid,
-                        stats: ExecutorResp {
-                            assumption_count: 0,
-                            segments: stats.segments as u64,
-                            user_cycles: stats.cycles,
-                            total_cycles: stats.total_cycles,
-                        },
-                        elapsed_time: status.elapsed_time.unwrap_or(f64::NAN),
-                    });
-                }
-                _ => {
-                    let err_msg = status.error_msg.unwrap_or_default();
-                    return Err(ProverError::ProvingFailed(format!(
-                        "stark proving failed: {err_msg}"
-                    )));
-                }
-            }
-        }
+        poller.poll_with_retries(&proof_id, &self.client).await
     }
 
     async fn get_receipt(&self, proof_id: &str) -> Result<Option<Receipt>, ProverError> {

--- a/crates/broker/src/provers.rs
+++ b/crates/broker/src/provers.rs
@@ -131,7 +131,11 @@ struct StatusPoller {
 }
 
 impl StatusPoller {
-    async fn poll_with_retries(&self, proof_id: &SessionId, client: &BonsaiClient) -> Result<ProofResult, ProverError> {
+    async fn poll_with_retries(
+        &self,
+        proof_id: &SessionId,
+        client: &BonsaiClient,
+    ) -> Result<ProofResult, ProverError> {
         loop {
             let mut status = None;
             for retry_count in 0..self.retry_counts {
@@ -141,7 +145,10 @@ impl StatusPoller {
                         break;
                     }
                     Err(err) => {
-                        tracing::warn!("Failed to get status: {err:?}, retrying {retry_count} / {}", self.retry_counts);
+                        tracing::warn!(
+                            "Failed to get status: {err:?}, retrying {retry_count} / {}",
+                            self.retry_counts
+                        );
                         tokio::time::sleep(tokio::time::Duration::from_secs(self.poll_sleep)).await;
                         continue;
                     }


### PR DESCRIPTION
Prompted by connection reset by bonsai status poll error. This retry is currently done in preflight, but not done in the actual proving call. This abstracts the logic to be used with both.