### PR TITLE
BM-569: Add retries for batch submission

### DIFF
--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -34,6 +34,10 @@ mod defaults {
     pub const fn fulfill_gas_estimate() -> u64 {
         300_000_000
     }
+
+    pub const fn max_submission_attempts() -> u32 {
+        3
+    }
 }
 /// All configuration related to markets mechanics
 #[derive(Deserialize, Serialize)]
@@ -174,6 +178,9 @@ pub struct BatcherConfig {
     /// be present on the deployed contract
     #[serde(default)]
     pub single_txn_fulfill: bool,
+    /// Number of attempts to make to submit a batch before abandoning
+    #[serde(default = "defaults::max_submission_attempts")]
+    pub max_submission_attempts: u32,
 }
 
 impl Default for BatcherConfig {
@@ -187,6 +194,7 @@ impl Default for BatcherConfig {
             txn_timeout: None,
             batch_poll_time_ms: Some(1000),
             single_txn_fulfill: false,
+            max_submission_attempts: defaults::max_submission_attempts(),
         }
     }
 }


### PR DESCRIPTION
Previously if a batch submission transaction failed for any reason (e.g. a connection reset on the RPC) the broker would never attempt to resubmit the batch and all tasks in that batch would fail.

This adds some resilience by adding a configurable parameter for number of attempts to resubmit a batch. Batches that fail will retry for the given number of attempts before setting their status to Failed.

- Adds new config field for BatcherConfig - max_submission_attempts (default=3)
- Adds test for multiple retries timing out

> Note: This solution avoids storing the number of submission attempts in the DB and so is not resilient to failures that trigger a panic and restart. In this case the batch will still be dropped. If this comes up as in issue in the future we can move the storage of submission attempts to the db