### PR TITLE
BM-581: order-stream: fix pending connections and add timeout

### DIFF
--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -506,6 +506,10 @@ mod tests {
         let pending_connection = app_state.set_pending_connection(addr).await;
         assert!(pending_connection, "Should return true for a timed out connection");
 
+        // Newly set connection should result in pending_connection == false
+        let pending_connection = app_state.set_pending_connection(addr).await;
+        assert!(!pending_connection, "Should return false for a replaced connection within timeout");
+
         // Test removing a pending connection
         app_state.remove_pending_connection(&addr).await;
         let pending_connection = app_state.set_pending_connection(addr).await;

--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -2,7 +2,9 @@
 //
 // All rights reserved.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use alloy::{
     primitives::{utils::parse_ether, Address, U256},
@@ -180,8 +182,8 @@ pub struct AppState {
     db: OrderDb,
     /// Map of WebSocket connections by address
     connections: Arc<RwLock<ConnectionsMap>>,
-    /// Map of pending connections by address
-    pending_connections: Arc<Mutex<HashSet<Address>>>,
+    /// Map of pending connections by address with their timestamp
+    pending_connections: Arc<Mutex<HashMap<Address, Instant>>>,
     /// Ethereum RPC provider
     rpc_provider: RootProvider<Http<Client>>,
     /// Configuration
@@ -208,7 +210,7 @@ impl AppState {
         Ok(Arc::new(Self {
             db,
             connections: Arc::new(RwLock::new(HashMap::new())),
-            pending_connections: Arc::new(Mutex::new(HashSet::new())),
+            pending_connections: Arc::new(Mutex::new(HashMap::new())),
             rpc_provider: ProviderBuilder::new().on_http(config.rpc_url.clone()),
             config: config.clone(),
             chain_id,
@@ -217,10 +219,31 @@ impl AppState {
         }))
     }
 
-    /// Set a pending connection and return true if the connection is not already pending.
+    /// Pending connection timeout on failed upgrade.
+    const PENDING_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Set a pending connection and return true if the connection is not already pending
+    /// or if the existing pending connection has timed out.
     pub(crate) async fn set_pending_connection(&self, addr: Address) -> bool {
         let mut pending_connections = self.pending_connections.lock().await;
-        pending_connections.insert(addr)
+        let now = Instant::now();
+
+        match pending_connections.entry(addr) {
+            Entry::Occupied(mut entry) => {
+                if now.duration_since(*entry.get()) < Self::PENDING_CONNECTION_TIMEOUT {
+                    // Connection is still pending and within timeout
+                    false
+                } else {
+                    // Connection has timed out, update the timestamp
+                    entry.insert(now);
+                    true
+                }
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(now);
+                true
+            }
+        }
     }
 
     /// Remove a pending connection for a given address.
@@ -432,5 +455,60 @@ mod tests {
         let db_order = task.await.unwrap().unwrap();
 
         assert_eq!(order, db_order.order);
+    }
+
+    #[sqlx::test]
+    async fn test_pending_connection_timeout(pool: PgPool) {
+        let anvil = Anvil::new().spawn();
+        let rpc_url = anvil.endpoint_url();
+
+        let ctx =
+            TestCtx::new(&anvil, Digest::from(SET_BUILDER_ID), Digest::from(ASSESSOR_GUEST_ID))
+                .await
+                .unwrap();
+
+        ctx.prover_market
+            .deposit_stake_with_permit(default_allowance(), &ctx.prover_signer)
+            .await
+            .unwrap();
+
+        let config = Config {
+            rpc_url,
+            market_address: *ctx.prover_market.instance().address(),
+            min_balance: parse_ether("2").unwrap(),
+            max_connections: 1,
+            queue_size: 10,
+            domain: "0.0.0.0:8585".parse().unwrap(),
+            bypass_addrs: vec![],
+            ping_time: 20,
+        };
+        let app_state = AppState::new(&config, Some(pool)).await.unwrap();
+        let addr = ctx.prover_signer.address();
+
+        // Test case 1: New connection (vacant entry)
+        let pending_connection = app_state.set_pending_connection(addr).await;
+        assert!(pending_connection, "Should return true for a new connection");
+
+        // Test case 2: Existing connection within timeout (occupied entry, not timed out)
+        let pending_connection = app_state.set_pending_connection(addr).await;
+        assert!(!pending_connection, "Should return false for a connection within timeout");
+
+        // Test case 3: Existing connection that has timed out
+        // Manually set the timestamp to be older than the timeout
+        {
+            let mut pending_connections = app_state.pending_connections.lock().await;
+            let old_time =
+                Instant::now() - (AppState::PENDING_CONNECTION_TIMEOUT + Duration::from_secs(1));
+            pending_connections.insert(addr, old_time);
+        }
+
+        // Now it should allow a new connection since the old one timed out
+        let pending_connection = app_state.set_pending_connection(addr).await;
+        assert!(pending_connection, "Should return true for a timed out connection");
+
+        // Test removing a pending connection
+        app_state.remove_pending_connection(&addr).await;
+        let pending_connection = app_state.set_pending_connection(addr).await;
+        assert!(pending_connection, "Should return true after removing the connection");
     }
 }

--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -216,6 +216,24 @@ impl AppState {
             shutdown: CancellationToken::new(),
         }))
     }
+
+    /// Set a pending connection and return true if the connection is not already pending.
+    pub(crate) async fn set_pending_connection(&self, addr: Address) -> bool {
+        let mut pending_connections = self.pending_connections.lock().await;
+        pending_connections.insert(addr)
+    }
+
+    /// Remove a pending connection for a given address.
+    pub(crate) async fn remove_pending_connection(&self, addr: &Address) {
+        let mut pending_connections = self.pending_connections.lock().await;
+        pending_connections.remove(addr);
+    }
+
+    /// Removes connection for a given address.
+    pub(crate) async fn remove_connection(&self, addr: &Address) {
+        let mut connections = self.connections.write().await;
+        connections.remove(addr);
+    }
 }
 
 const MAX_ORDER_SIZE: usize = 25 * 1024 * 1024; // 25 mb

--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -508,7 +508,10 @@ mod tests {
 
         // Newly set connection should result in pending_connection == false
         let pending_connection = app_state.set_pending_connection(addr).await;
-        assert!(!pending_connection, "Should return false for a replaced connection within timeout");
+        assert!(
+            !pending_connection,
+            "Should return false for a replaced connection within timeout"
+        );
 
         // Test removing a pending connection
         app_state.remove_pending_connection(&addr).await;

--- a/crates/order-stream/src/ws.rs
+++ b/crates/order-stream/src/ws.rs
@@ -311,9 +311,11 @@ async fn websocket_connection(socket: WebSocket, address: Address, state: Arc<Ap
                         }
                         Some(Ok(msg)) => {
                             tracing::warn!("Received unexpected message from {address}: {msg:?}");
+                            break;
                         }
                         Some(Err(err)) => {
                             tracing::warn!("Error receiving message from {address}: {err:?}");
+                            break;
                         }
                         None => {
                             tracing::debug!("Empty recv from {address}, closing connections");

--- a/crates/order-stream/src/ws.rs
+++ b/crates/order-stream/src/ws.rs
@@ -108,15 +108,12 @@ pub(crate) async fn websocket_handler(
         }
     }
 
-    {
-        // Connection does not exist, add to pending connections.
-        // Note: This is done without holding the lock to state.connections to minimize lock
-        // contention. At worst, the server will upgrade the connection and immediately drop it.
-        let mut pending_connections = state.pending_connections.lock().await;
-        if !pending_connections.insert(client_addr) {
-            // If the connection is already pending, return an error as max connections is 1.
-            return Ok((StatusCode::CONFLICT, "Connection in progress").into_response());
-        }
+    // Connection does not exist, add to pending connections.
+    // Note: This is done without holding the lock to state.connections to minimize lock
+    // contention. At worst, the server will upgrade the connection and immediately drop it.
+    if !state.set_pending_connection(client_addr).await {
+        // If the connection is already pending, return an error as max connections is 1.
+        return Ok((StatusCode::CONFLICT, "Connection in progress").into_response());
     }
 
     // Check the balance
@@ -136,8 +133,7 @@ pub(crate) async fn websocket_handler(
             Err(err) => {
                 tracing::warn!("Failed to get stake balance for {client_addr}: {err}");
                 // Clean up pending connection
-                let mut pending_connections = state.pending_connections.lock().await;
-                pending_connections.remove(&client_addr);
+                state.remove_pending_connection(&client_addr).await;
                 return Ok((StatusCode::INTERNAL_SERVER_ERROR, "Failed to check stake balance")
                     .into_response());
             }
@@ -156,7 +152,11 @@ pub(crate) async fn websocket_handler(
 
     // Proceed with WebSocket upgrade
     tracing::info!("New webSocket connection from {client_addr}");
-    Ok(ws.on_upgrade(move |socket| websocket_connection(socket, client_addr, state)))
+    Ok(ws
+        .on_failed_upgrade(move |error| {
+            tracing::warn!("Failed to upgrade connection for {client_addr}: {error:?}");
+        })
+        .on_upgrade(move |socket| websocket_connection(socket, client_addr, state)))
 }
 
 // Function to broadcast an order to all WebSocket clients in random order
@@ -212,24 +212,28 @@ async fn websocket_connection(socket: WebSocket, address: Address, state: Arc<Ap
 
         let (sender_channel, mut receiver_channel) = mpsc::channel::<String>(state.config.queue_size);
 
+        let is_connected;
         // Add sender to the list of connections
         {
             let mut connections = state.connections.write().await;
             match connections.entry(address) {
                 Entry::Occupied(_) => {
+                    is_connected = true;
                     tracing::warn!("Client {address} already connected");
-                    return;
                 },
                 Entry::Vacant(entry) => {
-                        entry.insert(ClientConnection { sender: sender_channel.clone()});
+                    is_connected = false;
+                    entry.insert(ClientConnection { sender: sender_channel.clone()});
                 },
             }
         }
 
         // Clean up the pending connection entry before upgrading
-        {
-            let mut pending_connections = state.pending_connections.lock().await;
-            pending_connections.remove(&address);
+        state.remove_pending_connection(&address).await;
+
+        if is_connected {
+            // Address is already connected, drop additional connection.
+            return;
         }
 
         let mut errors_counter = 0usize;
@@ -317,8 +321,7 @@ async fn websocket_connection(socket: WebSocket, address: Address, state: Arc<Ap
             }
         }
         // Remove the connection when the send loop exits
-        let mut connections = state.connections.write().await;
-        connections.remove(&address);
+        state.remove_connection(&address).await;
         tracing::debug!("WebSocket connection closed: {}", address);
     });
 }


### PR DESCRIPTION
The issue was that previously on a failed upgrade, the pending connection was never removed or logged, so users could get in a state that rejected all future requests. 

This change adds a timeout to the pending connections such that if a request is made outside of the timeout window, it retries again, so that this doesn't get rejected permanently. This also adds a log on failure such that there is more information about failed upgrades.