### PR TITLE
BM-602: Remove fillsLength variable; no effect on gas cost

### DIFF
--- a/contracts/src/BoundlessMarket.sol
+++ b/contracts/src/BoundlessMarket.sol
@@ -244,15 +244,14 @@ contract BoundlessMarket is
     /// @inheritdoc IBoundlessMarket
     function verifyBatchDelivery(Fulfillment[] calldata fills, AssessorReceipt calldata assessorReceipt) public view {
         // TODO(#242): Figure out how much the memory here is costing. If it's significant, we can do some tricks to reduce memory pressure.
-        uint256 fillsLength = fills.length;
         // We can't handle more than 65535 fills in a single batch.
         // This is a limitation of the current Selector implementation,
         // that uses a uint16 for the index, and can be increased in the future.
-        if (fillsLength > type(uint16).max) {
-            revert BatchSizeExceedsLimit(fillsLength, type(uint16).max);
+        if (fills.length > type(uint16).max) {
+            revert BatchSizeExceedsLimit(fills.length, type(uint16).max);
         }
-        bytes32[] memory claimDigests = new bytes32[](fillsLength);
-        bytes32[] memory requestDigests = new bytes32[](fillsLength);
+        bytes32[] memory claimDigests = new bytes32[](fills.length);
+        bytes32[] memory requestDigests = new bytes32[](fills.length);
 
         // Check the selector constraints.
         // NOTE: The assessor guest adds non-zero selector values to the list.
@@ -266,7 +265,7 @@ contract BoundlessMarket is
         }
 
         // Verify the application receipts.
-        for (uint256 i = 0; i < fillsLength; i++) {
+        for (uint256 i = 0; i < fills.length; i++) {
             Fulfillment calldata fill = fills[i];
 
             requestDigests[i] = fill.requestDigest;


### PR DESCRIPTION
A very minor change I made in the process of making other changes. I don't think there is any reason to have a `fillsLength` vairable in `fulfillBatch` when `fills.length` can be used instead. Benchamrks show no difference in gas cost.
