### PR TITLE
chore: fix typo - correct "assesor" to "assessor"

### DIFF
--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -210,7 +210,7 @@ impl AggregatorService {
             .prover
             .prove_and_monitor_stark(&self.assessor_guest_id.to_string(), &input_id, assumptions)
             .await
-            .context("Failed to prove assesor stark")?;
+            .context("Failed to prove assessor stark")?;
 
         tracing::info!(
             "Assessor proof completed, count: {} cycles: {} time: {}",


### PR DESCRIPTION
<img width="462" alt="Снимок экрана 2025-03-09 в 13 38 14" src="https://github.com/user-attachments/assets/b0d210a5-f50c-4c91-ac03-abb93af384cd" />

a typo in the code where "assesor" was misspelled.
this PR corrects it to "assessor" to ensure consistency and accuracy in the codebase.