### PR TITLE
chore: fix typo in "version"

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,7 +59,7 @@ check_os() {
             error "Unsupported operating system: $NAME. This script is intended for Ubuntu."
             exit 1
         elif [[ "${VERSION_ID,,}" != "22.04" && "${VERSION_ID,,}" != "20.04" ]]; then
-            error "Unsupported operating system verion: $VERSION. This script is intended for Ubuntu 20.04 or 22.04."
+            error "Unsupported operating system version: $VERSION. This script is intended for Ubuntu 20.04 or 22.04."
             exit 1
         else
             info "Operating System: $PRETTY_NAME"


### PR DESCRIPTION
<img width="905" alt="Снимок экрана 2025-03-09 в 15 51 11" src="https://github.com/user-attachments/assets/ed5a103e-a12f-4a83-a344-cce2eae60021" />
 
noticed a typo—"verion" instead of "version."
fixed it to keep things clean.

p.s. i know how many people feel about typos, but I'm a real user and noticed this mistake during installation.

thanks for boundless!