### PR TITLE
BM-626: Fix bento crash with zero keccak input request

### DIFF
--- a/bento/crates/workflow-common/src/lib.rs
+++ b/bento/crates/workflow-common/src/lib.rs
@@ -28,7 +28,7 @@ pub const SNARK_WORK_TYPE: &str = "snark";
 pub const SNARK_RETRIES: i32 = 0;
 pub const SNARK_TIMEOUT: i32 = 60 * 2;
 
-#[derive(Deserialize, Serialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
 pub enum CompressType {
     None,
     Groth16,
@@ -41,7 +41,7 @@ impl Default for CompressType {
 }
 
 /// Executor / init request
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ExecutorReq {
     /// Image uuid
     pub image: String,
@@ -75,14 +75,14 @@ pub struct ExecutorResp {
 }
 
 /// prove + lift task definition
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ProveReq {
     /// Segment index
     pub index: usize,
 }
 
 /// Join Request
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct JoinReq {
     /// Node index
     pub idx: usize,
@@ -93,21 +93,21 @@ pub struct JoinReq {
 }
 
 /// Resolve Request
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ResolveReq {
     /// Index of the final joined receipt
     pub max_idx: usize,
 }
 
 /// Input request
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct FinalizeReq {
     /// Index of the final joined receipt
     pub max_idx: usize,
 }
 
 /// Snark task definition
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SnarkReq {
     /// Stark receipt UUID to pull from minio
     pub receipt: String,
@@ -116,14 +116,14 @@ pub struct SnarkReq {
 }
 
 /// Snark task response
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SnarkResp {
     /// Snark UUID in object store snarks/{snark}
     pub snark: String,
 }
 
 /// Keccak prove request
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct KeccakReq {
     /// The digest of the claim that this keccak input is expected to produce.
     pub claim_digest: Digest,
@@ -134,7 +134,7 @@ pub struct KeccakReq {
 }
 
 /// High level enum of different sub task types and data
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum TaskType {
     /// Executor task
     Executor(ExecutorReq),

--- a/bento/crates/workflow/src/tasks/executor.rs
+++ b/bento/crates/workflow/src/tasks/executor.rs
@@ -408,6 +408,13 @@ pub async fn executor(agent: &Agent, job_id: &Uuid, request: &ExecutorReq) -> Re
 
     writer_tasks.spawn(async move {
         while let Ok(mut keccak_req) = keccak_rx.recv().await {
+            if keccak_req.input.is_empty() {
+                tracing::error!(
+                    "Received empty keccak input with claim_digest: {}, skipping",
+                    keccak_req.claim_digest
+                );
+                continue;
+            }
             let keccak_count_tmp = keccak_count.load(Ordering::Relaxed);
             let redis_key = format!("{coproc_prefix}:{}", keccak_req.claim_digest);
             redis::set_key_with_expiry(

--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -40,6 +40,13 @@ pub async fn keccak(agent: &Agent, job_id: &Uuid, request: &KeccakReq) -> Result
         input: try_keccak_bytes_to_input(&keccak_input)?,
     };
 
+    if keccak_req.input.is_empty() {
+        anyhow::bail!(
+            "Received empty keccak input with claim_digest: {}, skipping",
+            request.claim_digest
+        );
+    }
+
     tracing::info!("Keccak proving {}", request.claim_digest);
 
     let keccak_receipt = agent

--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -41,10 +41,7 @@ pub async fn keccak(agent: &Agent, job_id: &Uuid, request: &KeccakReq) -> Result
     };
 
     if keccak_req.input.is_empty() {
-        anyhow::bail!(
-            "Received empty keccak input with claim_digest: {}",
-            request.claim_digest
-        );
+        anyhow::bail!("Received empty keccak input with claim_digest: {}", request.claim_digest);
     }
 
     tracing::info!("Keccak proving {}", request.claim_digest);

--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -42,7 +42,7 @@ pub async fn keccak(agent: &Agent, job_id: &Uuid, request: &KeccakReq) -> Result
 
     if keccak_req.input.is_empty() {
         anyhow::bail!(
-            "Received empty keccak input with claim_digest: {}, skipping",
+            "Received empty keccak input with claim_digest: {}",
             request.claim_digest
         );
     }


### PR DESCRIPTION
The error would panic and crash the instance, which was indefinitely irrecoverable. This rejects that invalid case, such that the node will continue.

The part I am unsure about is the sanity check within the executor for keccak requests. This changes to error log and skip those requests, and didn't seem like a clean mechanism to fail to proof as a whole, but perhaps this should still go through to fail with the prove agent so that it errors and then perhaps the tasks get cancelled through taskdb? Haven't looked that in depth at the implications yet.