### PR TITLE
chore: update broken link in docs `extensions.mdx`

### DIFF
--- a/documentation/site/pages/introduction/extensions.mdx
+++ b/documentation/site/pages/introduction/extensions.mdx
@@ -33,7 +33,7 @@ Fast-track your ZK rollup development with a pre-built type-1 zkEVM.
 
 Steel is a production-ready smart contract execution prover designed to bring boundless runtime to all EVM apps. Using execution proofs, Steel enables EVM apps to run off-chain, while preserving on-chain security. With Steel, you can prove correct smart contract execution without re-execution, allowing blockchain developers unbounded computation over on-chain data.
 
-[Visit Steel's Getting Started guide](https://github.com/risc0/risc0-ethereum/tree/main/steel#getting-started-with-steel).
+[Visit Steel's Getting Started guide](https://github.com/risc0/risc0-ethereum/tree/main/crates/steel#getting-started-with-steel).
 
 <LinkPreview imgClassName="max-w-[364px]"url="https://risczero.com/steel"  />
 


### PR DESCRIPTION
Hi! I fixed a broken link in the documentation. In the `extensions.mdx` file, there was a link to the Steel Getting Started guide, but it was pointing to the wrong place — `https://github.com/risc0/risc0-ethereum/tree/main/steel#getting-started-with-steel`. I updated it to the correct path: `https://github.com/risc0/risc0-ethereum/tree/main/crates/steel#getting-started-with-steel`.