### PR TITLE
BM-598: Limit concurrent locked orders

### DIFF
--- a/broker.toml
+++ b/broker.toml
@@ -7,6 +7,7 @@ lookback_blocks = 100
 max_stake = "5" # HP
 skip_preflight_ids = []
 max_file_size = 50_000_000
+max_concurrent_locks = 2
 # max_fetch_retries = 2
 # allow_client_addresses = []
 # lockin_priority_gas = 100

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -41,6 +41,7 @@ mod defaults {
 }
 /// All configuration related to markets mechanics
 #[derive(Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct MarketConf {
     /// Mega Cycle price (in native token)
     pub mcycle_price: String,
@@ -105,6 +106,10 @@ pub struct MarketConf {
     /// Stake balance error threshold (in stake tokens)
     /// if the stake balance drops below this the broker will issue error logs
     pub stake_balance_error_threshold: Option<String>,
+    /// Max concurrent locks
+    ///
+    /// Maximum number of concurrent lockin requests that can be processed at once
+    pub max_concurrent_locks: Option<u32>,
 }
 
 impl Default for MarketConf {
@@ -129,6 +134,7 @@ impl Default for MarketConf {
             balance_error_threshold: None,
             stake_balance_warn_threshold: None,
             stake_balance_error_threshold: None,
+            max_concurrent_locks: None,
         }
     }
 }

--- a/crates/broker/src/db/fuzz_db.rs
+++ b/crates/broker/src/db/fuzz_db.rs
@@ -292,7 +292,7 @@ proptest! {
                                 }
                             },
                             DbOperation::GetOrderForPricing => {
-                                db.get_order_for_pricing().await.unwrap();
+                                db.update_orders_for_pricing(1).await.unwrap();
                             },
                             DbOperation::GetActivePricingOrders => {
                                 db.get_active_pricing_orders().await.unwrap();

--- a/crates/broker/src/db/mod.rs
+++ b/crates/broker/src/db/mod.rs
@@ -1069,10 +1069,8 @@ mod tests {
         let id = U256::ZERO;
         let order = create_order();
         db.add_order(id, order.clone()).await.unwrap();
-        let order2 = create_order();
-        db.add_order(id + U256::from(1), order2.clone()).await.unwrap();
-        let order3 = create_order();
-        db.add_order(id + U256::from(2), order3.clone()).await.unwrap();
+        db.add_order(id + U256::from(1), order.clone()).await.unwrap();
+        db.add_order(id + U256::from(2), order.clone()).await.unwrap();
 
         let price_order = db.update_orders_for_pricing(1).await.unwrap();
         assert_eq!(price_order.len(), 1);

--- a/crates/broker/src/db/mod.rs
+++ b/crates/broker/src/db/mod.rs
@@ -80,7 +80,7 @@ pub trait BrokerDb {
         &self,
         id: U256,
     ) -> Result<(ProofRequest, String, B256, U256), DbError>;
-    async fn get_order_for_pricing(&self) -> Result<Option<(U256, Order)>, DbError>;
+    async fn update_orders_for_pricing(&self, limit: u32) -> Result<Vec<(U256, Order)>, DbError>;
     async fn get_active_pricing_orders(&self) -> Result<Vec<(U256, Order)>, DbError>;
     async fn set_order_lock(
         &self,
@@ -98,7 +98,7 @@ pub trait BrokerDb {
         &self,
         end_timestamp: u64,
     ) -> Result<Vec<(U256, Order)>, DbError>;
-    async fn get_orders_committed_to_fulfill_count(&self) -> Result<u64, DbError>;
+    async fn get_orders_committed_to_fulfill_count(&self) -> Result<u32, DbError>;
     async fn get_proving_order(&self) -> Result<Option<(U256, Order)>, DbError>;
     async fn get_active_proofs(&self) -> Result<Vec<(U256, Order)>, DbError>;
     async fn set_order_proof_id(&self, order_id: U256, proof_id: &str) -> Result<(), DbError>;
@@ -246,30 +246,34 @@ impl BrokerDb for SqliteDb {
         }
     }
 
-    async fn get_order_for_pricing(&self) -> Result<Option<(U256, Order)>, DbError> {
-        let elm: Option<DbOrder> = sqlx::query_as(
+    async fn update_orders_for_pricing(&self, limit: u32) -> Result<Vec<(U256, Order)>, DbError> {
+        let orders: Vec<DbOrder> = sqlx::query_as(
             r#"
-            UPDATE orders
-            SET data = json_set(json_set(data, '$.status', $1), '$.update_at', $2)
-            WHERE id =
-                (SELECT id
+            WITH orders_to_update AS (
+                SELECT id
                 FROM orders
-                WHERE data->>'status' = $3
-                LIMIT 1)
+                WHERE data->>'status' = $1
+                LIMIT $2
+            )
+            UPDATE orders
+            SET data = json_set(json_set(data, '$.status', $3), '$.updated_at', $4)
+            WHERE id IN (SELECT id FROM orders_to_update)
             RETURNING *
             "#,
         )
+        .bind(OrderStatus::New)
+        .bind(i64::from(limit))
         .bind(OrderStatus::Pricing)
         .bind(Utc::now().timestamp())
-        .bind(OrderStatus::New)
-        .fetch_optional(&self.pool)
+        .fetch_all(&self.pool)
         .await?;
 
-        let Some(order) = elm else {
-            return Ok(None);
-        };
+        let result: Result<Vec<_>, _> = orders
+            .into_iter()
+            .map(|order| Ok((U256::from_str_radix(&order.id, 16)?, order.data)))
+            .collect();
 
-        Ok(Some((U256::from_str_radix(&order.id, 16)?, order.data)))
+        result
     }
 
     async fn get_active_pricing_orders(&self) -> Result<Vec<(U256, Order)>, DbError> {
@@ -484,7 +488,7 @@ impl BrokerDb for SqliteDb {
         orders
     }
 
-    async fn get_orders_committed_to_fulfill_count(&self) -> Result<u64, DbError> {
+    async fn get_orders_committed_to_fulfill_count(&self) -> Result<u32, DbError> {
         let count: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM orders WHERE data->>'status' IN ($1, $2, $3, $4, $5, $6)",
         )
@@ -497,7 +501,7 @@ impl BrokerDb for SqliteDb {
         .fetch_one(&self.pool)
         .await?;
 
-        Ok(count as u64)
+        Ok(u32::try_from(count).expect("count should never be negative"))
     }
 
     async fn get_proving_order(&self) -> Result<Option<(U256, Order)>, DbError> {
@@ -1060,17 +1064,29 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn get_order_for_pricing(pool: SqlitePool) {
+    async fn update_orders_for_pricing(pool: SqlitePool) {
         let db: DbObj = Arc::new(SqliteDb::from(pool).await.unwrap());
         let id = U256::ZERO;
         let order = create_order();
         db.add_order(id, order.clone()).await.unwrap();
+        let order2 = create_order();
+        db.add_order(id + U256::from(1), order2.clone()).await.unwrap();
+        let order3 = create_order();
+        db.add_order(id + U256::from(2), order3.clone()).await.unwrap();
 
-        let price_order = db.get_order_for_pricing().await.unwrap();
-        let price_order = price_order.unwrap();
-        assert_eq!(price_order.0, id);
-        assert_eq!(price_order.1.status, OrderStatus::Pricing);
-        assert_ne!(price_order.1.updated_at, order.updated_at);
+        let price_order = db.update_orders_for_pricing(1).await.unwrap();
+        assert_eq!(price_order.len(), 1);
+        assert_eq!(price_order[0].0, id);
+        assert_eq!(price_order[0].1.status, OrderStatus::Pricing);
+        assert_ne!(price_order[0].1.updated_at, order.updated_at);
+
+        // Request the next two orders, which should skip the first
+        let price_order = db.update_orders_for_pricing(2).await.unwrap();
+        assert_eq!(price_order.len(), 2);
+        assert_eq!(price_order[0].0, id + U256::from(1));
+        assert_eq!(price_order[0].1.status, OrderStatus::Pricing);
+        assert_eq!(price_order[1].0, id + U256::from(2));
+        assert_eq!(price_order[1].1.status, OrderStatus::Pricing);
     }
 
     #[sqlx::test]

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -541,8 +541,13 @@ where
                     _ = pricing_check_timer.tick() => {
                         // Queue up orders that can be added to capacity.
                         let order_size = if let Some(capacity) = capacity {
-                            capacity.saturating_sub(
-                                u32::try_from(pricing_tasks.len()).expect("tasks u32 overflow"),
+                            // Calculcate the amount of orders that can be filled, with a maximum
+                            // of 10 orders at a time to avoid pricing using too much resources.
+                            std::cmp::min(
+                                capacity.saturating_sub(
+                                    u32::try_from(pricing_tasks.len()).expect("tasks u32 overflow"),
+                                ),
+                                10
                             )
                         } else {
                             // If no maximum lock capacity, request a max of 10 orders at a time.

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -520,6 +520,11 @@ where
             let mut config_check_timer = tokio::time::interval(config_check_interval);
 
             loop {
+                // TODO issue with this pattern is that for unbounded orders, this requeueing
+                // pricing tasks will only be called when pricing tasks complete, and may get in
+                // scenarios where either too many tasks are scheduled at once, or some orders will
+                // be delayed until the config timer tick to price orders, increasing latency.
+                
                 // Queue up orders that can be added to capacity.
                 let order_size = if let Some(capacity) = capacity {
                     capacity.saturating_sub(

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -518,7 +518,7 @@ where
             // Check for config updates and current lock count periodically
             let config_check_interval = tokio::time::Duration::from_secs(10);
             let mut config_check_timer = tokio::time::interval(config_check_interval);
-            
+
             // 5 second interval with a 2.5 second delay so config is checked first,
             // and that the requests are interleaved between config checks.
             let pricing_check_interval = tokio::time::Duration::from_secs(5);
@@ -548,7 +548,7 @@ where
                             // If no maximum lock capacity, request a max of 10 orders at a time.
                             10
                         };
-                        
+
                         picker_copy
                             .spawn_pricing_tasks(&mut pricing_tasks, order_size)
                             .await

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -532,7 +532,10 @@ where
                     _ = config_check_timer.tick() => {
                         // Get updated max concurrent locks and calculate capacity based on orders
                         // that are locked but not fulfilled yet.
-                        capacity = picker_copy.get_pricing_order_capacity().await.map_err(SupervisorErr::Fault)?;
+                        capacity = picker_copy
+                            .get_pricing_order_capacity()
+                            .await
+                            .map_err(SupervisorErr::Recover)?;
                     }
 
                     _ = pricing_check_timer.tick() => {


### PR DESCRIPTION
Solves part of BM-598 in that we need multiple ways to limit the capacity of orders taken on by the broker, and limiting the amount of current locks is not a perfect solution but a reasonable mechanism that would be useful in the short term or to limit risk.

Will open PR for review once more thoroughly tested and will try to make sure no edge cases and minimimal overhead. Basically how this works is querying the database for orders that have been selected to be locked but not fulfilled, and then spawning tasks to handle pricing each. The capacity is calculated on an interval, every 10s, where the config and db will be checked, which will pick up when orders are fulfilled and more capacity available. Whenever pricing successful, it will reduce from the capacity to avoid extra tasks from being marked as locked.

May also refactor the design to do this, as this doesn't handle the case where the order is planned to be locked in the future very well. The issue with having the concurrent locks be monitored in the order monitor (which actually calls lock) is that it isn't clear when the broker needs to lock the order in by to make sure that it will complete it in time, because that is done in pricing.