### PR TITLE
Layer for handling "already known" error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ test-log = { version = "0.2", features = ["trace"] }
 thiserror = "2.0"
 tokio = { version = "1" }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tower = "0.5.2"
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/crates/broker/Cargo.toml
+++ b/crates/broker/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 release = false
 
 [dependencies]
-alloy = { workspace = true, features = ["network", "providers", "transports", "sol-types", "contract", "signers", "signer-local", "rpc", "rpc-types"] }
+alloy = { workspace = true, features = ["network", "providers", "transports", "sol-types", "contract", "signers", "signer-local", "json-rpc", "rpc", "rpc-types"] }
 alloy-chains = "0.1"
 anyhow = { workspace = true }
 async-channel = "2.3"
@@ -42,6 +42,7 @@ tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "fs"] }
 toml = "0.8"
+tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }

--- a/crates/broker/src/rpc_retry_policy.rs
+++ b/crates/broker/src/rpc_retry_policy.rs
@@ -2,11 +2,21 @@
 //
 // All rights reserved.
 
+use alloy::rpc::json_rpc::{ErrorPayload, Id, RequestPacket, Response, ResponsePacket};
 use alloy::transports::{
     layers::{RateLimitRetryPolicy, RetryPolicy},
     TransportError, TransportErrorKind,
 };
-use std::time::Duration;
+use alloy::transports::{BoxFuture, RpcError};
+use futures_util::FutureExt;
+use serde_json::Value;
+use std::{
+    fmt::Debug,
+    future::{Future, IntoFuture},
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct CustomRetryPolicy;
@@ -31,6 +41,83 @@ impl RetryPolicy for CustomRetryPolicy {
 
     fn backoff_hint(&self, error: &TransportError) -> Option<Duration> {
         RateLimitRetryPolicy::default().backoff_hint(error)
+    }
+}
+
+struct ErrorCatchingLayer;
+
+impl<S> Layer<S> for ErrorCatchingLayer {
+    type Service = ErrorCatchingMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ErrorCatchingMiddleware { inner }
+    }
+}
+
+struct ErrorCatchingMiddleware<S> {
+    inner: S,
+}
+
+impl<S> Service<RequestPacket> for ErrorCatchingMiddleware<S>
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>
+        + Sync
+        + Send
+        + Clone
+        + 'static,
+    S::Future: Send,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: RequestPacket) -> Self::Future {
+        let (method_name, id) = get_method_name_and_id(&request);
+
+        let fut = self.inner.call(request);
+        async move {
+            let response = fut.await;
+            let response_return = match &response {
+                Ok(_resp) => response,
+                Err(err) => {
+                    match err {
+                        TransportError::ErrorResp(ErrorPayload { code, message, data: None })
+                            if (method_name == "eth_sendTransaction" || method_name  == "eth_sendRawTransaction") && *code == -32603 && message.contains("already known") =>
+                        {
+                            tracing::warn!("Detected 'already known' rpc error suggesting that the txn has already been submitted: {err:?}, transforming to success response");
+                            // TODO: result should be the tx hash
+                            let response = format!(
+                                r#"{{
+                                    "jsonrpc": "2.0",
+                                    "result": "",
+                                    "id": {}
+                                }}"#,
+                                id
+                            );
+                            Ok(ResponsePacket::Single(serde_json::from_str(&response).unwrap()))
+                        }
+                        _ => response,
+                    }
+                }
+            };
+            response_return
+        }
+        .boxed()
+    }
+}
+
+/// Get the method name from the request
+fn get_method_name_and_id(req: &RequestPacket) -> (String, Id) {
+    match req {
+        RequestPacket::Single(request) => (request.method().to_string(), request.id().clone()),
+        RequestPacket::Batch(_) => {
+            // can't extract method name for batch.
+            ("batch".to_string(), Id::None)
+        }
     }
 }
 


### PR DESCRIPTION
Attempt to handle
```
ERROR broker::submitter: Failed to submit proofs for batch 7649: Error(decoding err, missing data, code: -32603 msg: already known
```
which leads the broker to treat it as a failure and try again, getting

```
Failed to submit proofs for batch 7649: Error(BoundlessMarket Err: RequestIsFulfilled(RequestIsFulfilled { requestId: 4777893710576536890458989649656896615860034287083700324942 })
```