### PR TITLE
BM-668: Bump `risc0-ethereum` to 1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ version = "0.6.0"
 dependencies = [
  "hex",
  "risc0-build",
- "risc0-build-ethereum 1.4.0",
+ "risc0-build-ethereum 1.4.3",
 ]
 
 [[package]]
@@ -4117,7 +4117,7 @@ version = "0.6.0"
 dependencies = [
  "hex",
  "risc0-build",
- "risc0-build-ethereum 1.4.0",
+ "risc0-build-ethereum 1.4.3",
 ]
 
 [[package]]
@@ -6125,7 +6125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -7056,12 +7056,12 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39b6a66fa37ac33a97ee48dff3cbcaf7c842d4b859bf383d0c5b2c4f8bb5b48"
+version = "1.4.2"
+source = "git+https://github.com/risc0/risc0-ethereum?tag=aggregation-v0.3.2#7cf3661a1d1d5cf8b3573e2ac574374562972331"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "bytemuck_derive",
  "hex",
  "risc0-build",
  "risc0-zkp",
@@ -7069,8 +7069,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.2"
-source = "git+https://github.com/risc0/risc0-ethereum?tag=aggregation-v0.3.2#7cf3661a1d1d5cf8b3573e2ac574374562972331"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9736cd73ee851bf00515777d8bf3f61272d5bdb6ff2a99332fa2d1781636ec53"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -7233,14 +7234,15 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7158b09db4043f8169dcc7c161d662e22080cd1bf6fe2ba79c1358ee80ba599"
+checksum = "9bc9406a64e5945b3122a4bd2615222ad740efc3b6e86be04a89f98460acdcb6"
 dependencies = [
  "alloy 0.11.1",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
+ "bytemuck_derive",
  "cfg-if",
  "hex",
  "risc0-aggregation",

--- a/crates/boundless-market/src/contracts/mod.rs
+++ b/crates/boundless-market/src/contracts/mod.rs
@@ -827,7 +827,7 @@ pub mod test_utils {
     }
 
     pub async fn deploy_mock_verifier<P: Provider>(deployer_provider: P) -> Result<Address> {
-        let instance = RiscZeroMockVerifier::deploy(deployer_provider, FixedBytes::ZERO)
+        let instance = RiscZeroMockVerifier::deploy(deployer_provider, FixedBytes([0xFFu8; 4]))
             .await
             .context("failed to deploy RiscZeroMockVerifier")?;
         Ok(*instance.address())

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2626,7 +2626,7 @@ version = "0.6.0"
 dependencies = [
  "hex",
  "risc0-build",
- "risc0-build-ethereum 1.4.0",
+ "risc0-build-ethereum 1.4.3",
 ]
 
 [[package]]
@@ -2644,7 +2644,7 @@ version = "0.6.0"
 dependencies = [
  "hex",
  "risc0-build",
- "risc0-build-ethereum 1.4.0",
+ "risc0-build-ethereum 1.4.3",
 ]
 
 [[package]]
@@ -4456,12 +4456,12 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39b6a66fa37ac33a97ee48dff3cbcaf7c842d4b859bf383d0c5b2c4f8bb5b48"
+version = "1.4.2"
+source = "git+https://github.com/risc0/risc0-ethereum?tag=aggregation-v0.3.2#7cf3661a1d1d5cf8b3573e2ac574374562972331"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "bytemuck_derive",
  "hex",
  "risc0-build",
  "risc0-zkp",
@@ -4469,8 +4469,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build-ethereum"
-version = "1.4.2"
-source = "git+https://github.com/risc0/risc0-ethereum?tag=aggregation-v0.3.2#7cf3661a1d1d5cf8b3573e2ac574374562972331"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9736cd73ee851bf00515777d8bf3f61272d5bdb6ff2a99332fa2d1781636ec53"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4523,14 +4524,15 @@ dependencies = [
 
 [[package]]
 name = "risc0-ethereum-contracts"
-version = "1.4.0"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7158b09db4043f8169dcc7c161d662e22080cd1bf6fe2ba79c1358ee80ba599"
+checksum = "9bc9406a64e5945b3122a4bd2615222ad740efc3b6e86be04a89f98460acdcb6"
 dependencies = [
  "alloy",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
+ "bytemuck_derive",
  "cfg-if",
  "hex",
  "risc0-aggregation",


### PR DESCRIPTION
This update contains the default selector for a FakeReceipt's seal as 0xFFFFFFFF