### PR TITLE
BM-672: simplify skip order logic in order picker

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -1366,8 +1366,8 @@ mod tests {
         assert_eq!(pricing_tasks.len(), 2);
 
         // Finish pricing an order and mark it as complete to free up capacity
-        let (order, priced) = pricing_tasks.join_next().await.unwrap().unwrap().unwrap();
-        assert!(priced);
+        let (order, priced) = pricing_tasks.join_next().await.unwrap().unwrap();
+        assert!(priced.unwrap());
         ctx.db.set_order_complete(order).await.unwrap();
 
         let capacity = ctx.picker.get_pricing_order_capacity().await.unwrap();


### PR DESCRIPTION
avoids case where a skip order set in DB is missed, also had misleading errors. Log levels were also set too high for some of the logs that would warn on expected behaviour. Kept the warnings for low gas/stake levels, though.