### PR TITLE
BM-677 Migrate #[clap(...)] to #[arg(...)] / #[command(...)] in clap 4.x

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -151,50 +151,50 @@ impl IntoResponse for AppError {
 }
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[arg(author, version, about, long_about = None)]
 pub struct Args {
     /// Bind address for REST api
-    #[clap(long, default_value = "0.0.0.0:8080")]
+    #[arg(long, default_value = "0.0.0.0:8080")]
     bind_addr: String,
 
     /// SQL DB Connection pool connections
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     db_max_connections: u32,
 
     /// taskdb postgres DATABASE_URL
-    #[clap(env)]
+    #[arg(env)]
     database_url: String,
 
     /// S3 / Minio bucket
-    #[clap(env)]
+    #[arg(env)]
     s3_bucket: String,
 
     /// S3 / Minio access key
-    #[clap(env)]
+    #[arg(env)]
     s3_access_key: String,
 
     /// S3 / Minio secret key
-    #[clap(env)]
+    #[arg(env)]
     s3_secret_key: String,
 
     /// S3 / Minio url
-    #[clap(env)]
+    #[arg(env)]
     s3_url: String,
 
     /// Executor timeout in seconds
-    #[clap(long, default_value_t = 4 * 60 * 60)]
+    #[arg(long, default_value_t = 4 * 60 * 60)]
     exec_timeout: i32,
 
     /// Executor retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     exec_retries: i32,
 
     /// Snark timeout in seconds
-    #[clap(long, default_value_t = 60 * 2)]
+    #[arg(long, default_value_t = 60 * 2)]
     snark_timeout: i32,
 
     /// Snark retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     snark_retries: i32,
 }
 

--- a/bento/crates/bento-client/src/bento_cli.rs
+++ b/bento/crates/bento-client/src/bento_cli.rs
@@ -28,13 +28,13 @@ const TEST_ELF: &[u8] = include_bytes!("../method_name");
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Risc0 ZKVM elf file on disk
-    #[clap(short = 'f', long)]
+    #[arg(short = 'f', long)]
     elf_file: Option<PathBuf>,
 
     /// ZKVM encoded input to be supplied to ExecEnv .write() method
     ///
     /// Should be `risc0_zkvm::serde::to_vec` encoded binary data
-    #[clap(short, long, conflicts_with = "iter_count")]
+    #[arg(short, long, conflicts_with = "iter_count")]
     input_file: Option<PathBuf>,
 
     /// Optional test vector to run the sample guest with the supplied iteration count
@@ -42,21 +42,21 @@ pub struct Args {
     /// Allows for rapid testing of arbitrary large cycle count guests
     ///
     /// NOTE: TODO remove this flag and simplify client
-    #[clap(short = 'c', long, conflicts_with = "input_file")]
+    #[arg(short = 'c', long, conflicts_with = "input_file")]
     iter_count: Option<u64>,
 
     /// Optionally Create a SNARK proof
-    #[clap(short, long, default_value_t = false, conflicts_with = "exec_only")]
+    #[arg(short, long, default_value_t = false, conflicts_with = "exec_only")]
     snarkify: bool,
 
     /// Run a execute only job, aka preflight
     ///
     /// Useful for capturing metrics on a STARK proof like cycles.
-    #[clap(short, long, default_value_t = false, conflicts_with = "snarkify")]
+    #[arg(short, long, default_value_t = false, conflicts_with = "snarkify")]
     exec_only: bool,
 
     /// Bento HTTP API Endpoint
-    #[clap(short = 't', long, default_value = "http://localhost:8081")]
+    #[arg(short = 't', long, default_value = "http://localhost:8081")]
     endpoint: String,
 }
 

--- a/bento/crates/workflow/src/lib.rs
+++ b/bento/crates/workflow/src/lib.rs
@@ -49,92 +49,92 @@ pub struct Args {
     pub poll_time: u64,
 
     /// taskdb postgres DATABASE_URL
-    #[clap(env)]
+    #[arg(env)]
     pub database_url: String,
 
     /// redis connection URL
-    #[clap(env)]
+    #[arg(env)]
     pub redis_url: String,
 
     /// risc0 segment po2 arg
-    #[clap(short, long, default_value_t = 20)]
+    #[arg(short, long, default_value_t = 20)]
     pub segment_po2: u32,
 
     /// max connections to SQL db in connection pool
-    #[clap(long, default_value_t = 1)]
+    #[arg(long, default_value_t = 1)]
     pub db_max_connections: u32,
 
     /// Redis TTL, seconds before objects expire automatically
     ///
     /// Defaults to 8 hours
-    #[clap(long, default_value_t = 8 * 60 * 60)]
+    #[arg(long, default_value_t = 8 * 60 * 60)]
     pub redis_ttl: u64,
 
     /// Executor limit, in millions of cycles
-    #[clap(short, long, default_value_t = 100_000)]
+    #[arg(short, long, default_value_t = 100_000)]
     pub exec_cycle_limit: u64,
 
     /// S3 / Minio bucket
-    #[clap(env)]
+    #[arg(env)]
     pub s3_bucket: String,
 
     /// S3 / Minio access key
-    #[clap(env)]
+    #[arg(env)]
     pub s3_access_key: String,
 
     /// S3 / Minio secret key
-    #[clap(env)]
+    #[arg(env)]
     pub s3_secret_key: String,
 
     /// S3 / Minio url
-    #[clap(env)]
+    #[arg(env)]
     pub s3_url: String,
 
     /// Enables a background thread to monitor for tasks that need to be retried / timed-out
-    #[clap(long, default_value_t = false)]
+    #[arg(long, default_value_t = false)]
     monitor_requeue: bool,
 
     // Task flags
     /// How many times a prove+lift can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     prove_retries: i32,
 
     /// How long can a prove+lift can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 30)]
+    #[arg(long, default_value_t = 30)]
     prove_timeout: i32,
 
     /// How many times a join can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     join_retries: i32,
 
     /// How long can a join can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     join_timeout: i32,
 
     /// How many times a resolve can fail before hard failure
-    #[clap(long, default_value_t = 3)]
+    #[arg(long, default_value_t = 3)]
     resolve_retries: i32,
 
     /// How long can a resolve can be running for, before it is marked as timed-out
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     resolve_timeout: i32,
 
     /// How many times a finalize can fail before hard failure
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     finalize_retries: i32,
 
     /// How long can a finalize can be running for, before it is marked as timed-out
     ///
     /// NOTE: This value is multiplied by the assumption count
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     finalize_timeout: i32,
 
     /// Snark timeout in seconds
-    #[clap(long, default_value_t = 60 * 4)]
+    #[arg(long, default_value_t = 60 * 4)]
     snark_timeout: i32,
 
     /// Snark retries
-    #[clap(long, default_value_t = 0)]
+    #[arg(long, default_value_t = 0)]
     snark_retries: i32,
 }
 

--- a/crates/boundless-cli/src/bin/boundless-cli.rs
+++ b/crates/boundless-cli/src/bin/boundless-cli.rs
@@ -62,13 +62,13 @@ enum Command {
     /// Deposit funds into the market
     Deposit {
         /// Amount in ether to deposit
-        #[clap(value_parser = parse_ether)]
+        #[arg(value_parser = parse_ether)]
         amount: U256,
     },
     /// Withdraw funds from the market
     Withdraw {
         /// Amount in ether to withdraw
-        #[clap(value_parser = parse_ether)]
+        #[arg(value_parser = parse_ether)]
         amount: U256,
     },
     /// Check the balance of an account in the market
@@ -82,7 +82,7 @@ enum Command {
         /// Amount in HP to deposit.
         ///
         /// e.g. 10 is uint256(10 * 10**18).
-        #[clap(value_parser = parse_ether)]
+        #[arg(value_parser = parse_ether)]
         amount: U256,
     },
     /// Withdraw stake funds from the market
@@ -90,7 +90,7 @@ enum Command {
         /// Amount in HP to withdraw.
         ///
         /// e.g. 10 is uint256(10 * 10**18).
-        #[clap(value_parser = parse_ether)]
+        #[arg(value_parser = parse_ether)]
         amount: U256,
     },
     /// Check the stake balance of an account in the market
@@ -104,24 +104,24 @@ enum Command {
     /// Submit a fully specified proof request
     SubmitRequest {
         /// Storage provider to use
-        #[clap(flatten)]
+        #[command(flatten)]
         storage_config: Option<StorageProviderConfig>,
         /// Path to a YAML file containing the request
         yaml_request: PathBuf,
         /// Optional identifier for the request
         id: Option<u32>,
         /// Wait until the request is fulfilled
-        #[clap(short, long, default_value = "false")]
+        #[arg(short, long, default_value = "false")]
         wait: bool,
         /// Submit the request offchain via the provided order stream service url.
-        #[clap(short, long, requires = "order_stream_url")]
+        #[arg(short, long, requires = "order_stream_url")]
         offchain: bool,
         /// Offchain order stream service URL to submit offchain requests to.
-        #[clap(long, env)]
+        #[arg(long, env)]
         order_stream_url: Option<Url>,
         /// Preflight uses the RISC Zero zkvm executor to run the program
         /// before submitting the request. Set no-preflight to skip.
-        #[clap(long, default_value = "false")]
+        #[arg(long, default_value = "false")]
         no_preflight: bool,
     },
     /// Slash a prover for a given request
@@ -209,33 +209,33 @@ enum Command {
 #[derive(Args, Clone, Debug)]
 struct SubmitOfferArgs {
     /// Storage provider to use
-    #[clap(flatten)]
+    #[command(flatten)]
     storage_config: Option<StorageProviderConfig>,
     /// Path to a YAML file containing the offer
     yaml_offer: PathBuf,
     /// Optional identifier for the request
     id: Option<u32>,
     /// Wait until the request is fulfilled
-    #[clap(short, long, default_value = "false")]
+    #[arg(short, long, default_value = "false")]
     wait: bool,
     /// Submit the request offchain via the provided order stream service url.
-    #[clap(short, long, requires = "order_stream_url")]
+    #[arg(short, long, requires = "order_stream_url")]
     offchain: bool,
     /// Offchain order stream service URL to submit offchain requests to.
-    #[clap(long, env, default_value = "https://order-stream.beboundless.xyz")]
+    #[arg(long, env, default_value = "https://order-stream.beboundless.xyz")]
     order_stream_url: Option<Url>,
     /// Preflight uses the RISC Zero zkvm executor to run the program
     /// before submitting the request. Set no-preflight to skip.
-    #[clap(long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     no_preflight: bool,
     /// Use risc0_zkvm::serde to encode the input as a `Vec<u8>`
-    #[clap(short, long)]
+    #[arg(short, long)]
     encode_input: bool,
     /// Send the input inline (i.e. in the transaction calldata) rather than uploading it.
-    #[clap(long)]
+    #[arg(long)]
     inline_input: bool,
     /// Elf file to use as the guest image, given as a path.
-    #[clap(long)]
+    #[arg(long)]
     elf: PathBuf,
 
     #[command(flatten)]
@@ -249,10 +249,10 @@ struct SubmitOfferArgs {
 #[group(required = true, multiple = false)]
 struct SubmitOfferInput {
     /// Input for the guest, given as a string.
-    #[clap(short, long)]
+    #[arg(short, long)]
     input: Option<String>,
     /// Input for the guest, given as a path to a file.
-    #[clap(long)]
+    #[arg(long)]
     input_file: Option<PathBuf>,
 }
 
@@ -260,36 +260,36 @@ struct SubmitOfferInput {
 #[group(required = true, multiple = false)]
 struct SubmitOfferRequirements {
     /// Hex encoded journal digest to use as the predicate in the requirements.
-    #[clap(short, long)]
+    #[arg(short, long)]
     journal_digest: Option<String>,
     /// Journal prefix to use as the predicate in the requirements.
-    #[clap(long)]
+    #[arg(long)]
     journal_prefix: Option<String>,
     /// Address of the callback to use in the requirements.
-    #[clap(long, requires = "callback_gas_limit")]
+    #[arg(long, requires = "callback_gas_limit")]
     callback_address: Option<Address>,
     /// Gas limit of the callback to use in the requirements.
-    #[clap(long, requires = "callback_addr")]
+    #[arg(long, requires = "callback_addr")]
     callback_gas_limit: Option<u64>,
 }
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about)]
+#[command(author, version, about)]
 struct MainArgs {
     /// URL of the Ethereum RPC endpoint
-    #[clap(short, long, env, default_value = "http://localhost:8545")]
+    #[arg(short, long, env, default_value = "http://localhost:8545")]
     rpc_url: Url,
     /// Private key of the wallet
-    #[clap(long, env)]
+    #[arg(long, env)]
     private_key: PrivateKeySigner,
     /// Address of the market contract
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     boundless_market_address: Address,
     /// Address of the SetVerifier contract
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     set_verifier_address: Address,
     /// Tx timeout in seconds
-    #[clap(long, env, value_parser = |arg: &str| -> Result<Duration, ParseIntError> {Ok(Duration::from_secs(arg.parse()?))})]
+    #[arg(long, env, value_parser = |arg: &str| -> Result<Duration, ParseIntError> {Ok(Duration::from_secs(arg.parse()?))})]
     tx_timeout: Option<Duration>,
     /// Subcommand to run
     #[command(subcommand)]

--- a/crates/boundless-cli/src/bin/boundless-ffi.rs
+++ b/crates/boundless-cli/src/bin/boundless-ffi.rs
@@ -33,32 +33,32 @@ use boundless_market::{
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about)]
+#[command(author, version, about)]
 struct MainArgs {
     /// URL of the SetBuilder ELF
-    #[clap(long)]
+    #[arg(long)]
     set_builder_url: String,
     /// URL of the Assessor ELF
-    #[clap(long)]
+    #[arg(long)]
     assessor_url: String,
     /// Address of the prover
-    #[clap(long)]
+    #[arg(long)]
     prover_address: Address,
     /// Address of the Boundless market contract
-    #[clap(long)]
+    #[arg(long)]
     boundless_market_address: Address,
     /// Chain ID of the network where Boundless market contract is deployed
-    #[clap(long)]
+    #[arg(long)]
     chain_id: U256,
     /// Hex encoded proof request
-    #[clap(long)]
+    #[arg(long)]
     request: String,
     /// Hex encoded request' signature
-    #[clap(long)]
+    #[arg(long)]
     signature: String,
     /// Whether to revert the fulfill transaction if payment conditions are not met (e.g. the
     /// request is locked to another prover).
-    #[clap(long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     require_payment: bool,
 }
 

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -51,74 +51,74 @@ pub(crate) mod task;
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// sqlite database connection url
-    #[clap(short = 's', long, env, default_value = "sqlite::memory:")]
+    #[arg(short = 's', long, env, default_value = "sqlite::memory:")]
     pub db_url: String,
 
     /// RPC URL
-    #[clap(long, env, default_value = "http://localhost:8545")]
+    #[arg(long, env, default_value = "http://localhost:8545")]
     pub rpc_url: Url,
 
     /// Order stream server URL
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub order_stream_url: Option<Url>,
 
     /// wallet key
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub private_key: PrivateKeySigner,
 
     /// Boundless market address
-    #[clap(long, env)]
+    #[arg(long, env)]
     pub boundless_market_address: Address,
 
     /// Risc zero Set verifier address
     // TODO: Get this from the market contract via view call
-    #[clap(long, env)]
+    #[arg(long, env)]
     set_verifier_address: Address,
 
     /// local prover API (Bento)
     ///
     /// Setting this value toggles using Bento for proving and disables Bonsai
-    #[clap(long, env, default_value = "http://localhost:8081", conflicts_with_all = ["bonsai_api_url", "bonsai_api_key"])]
+    #[arg(long, env, default_value = "http://localhost:8081", conflicts_with_all = ["bonsai_api_url", "bonsai_api_key"])]
     bento_api_url: Option<Url>,
 
     /// Bonsai API URL
     ///
     /// Toggling this disables Bento proving and uses Bonsai as a backend
-    #[clap(long, env, conflicts_with = "bento_api_url")]
+    #[arg(long, env, conflicts_with = "bento_api_url")]
     bonsai_api_url: Option<Url>,
 
     /// Bonsai API Key
     ///
     /// Required if using BONSAI_API_URL
-    #[clap(long, env, conflicts_with = "bento_api_url")]
+    #[arg(long, env, conflicts_with = "bento_api_url")]
     bonsai_api_key: Option<String>,
 
     /// Config file path
-    #[clap(short, long, default_value = "broker.toml")]
+    #[arg(short, long, default_value = "broker.toml")]
     pub config_file: PathBuf,
 
     /// Pre deposit amount
     ///
     /// Amount of HP tokens to pre-deposit into the contract for staking eg: 100
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub deposit_amount: Option<U256>,
 
     /// RPC HTTP retry rate limit max retry
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     pub rpc_retry_max: u32,
 
     /// RPC HTTP retry backoff (in ms)
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 1000)]
+    #[arg(long, default_value_t = 1000)]
     pub rpc_retry_backoff: u64,
 
     /// RPC HTTP retry compute-unit per second
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 100)]
     pub rpc_retry_cu: u64,
 
     /// Set to skip caching of images
@@ -128,7 +128,7 @@ pub struct Args {
     pub nocache: bool,
 
     /// Cache directory for storing downloaded images and inputs
-    #[clap(long, default_value = "/tmp/broker_cache", conflicts_with = "nocache")]
+    #[arg(long, default_value = "/tmp/broker_cache", conflicts_with = "nocache")]
     pub cache_dir: Option<PathBuf>,
 }
 

--- a/crates/order-generator/src/bin/zeth.rs
+++ b/crates/order-generator/src/bin/zeth.rs
@@ -37,70 +37,70 @@ const RETRY_DELAY_SECS: u64 = 5;
 
 /// Arguments of order-generator-zeth CLI.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[arg(author, version, about, long_about = None)]
 struct Args {
     /// URL of the Ethereum RPC endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     rpc_url: Url,
     /// URL of the offchain order stream endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     order_stream_url: Option<Url>,
     /// Storage provider to use
-    #[clap(flatten)]
+    #[arg(flatten)]
     storage_config: Option<StorageProviderConfig>,
     /// Private key used to interact with the BoundlessMarket contract.
-    #[clap(long, env)]
+    #[arg(long, env)]
     private_key: PrivateKeySigner,
     /// Address of the SetVerifier contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     set_verifier_address: Address,
     /// Address of the BoundlessMarket contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     boundless_market_address: Address,
     /// URL of the Ethereum RPC endpoint for Zeth.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     zeth_rpc_url: Url,
     /// Block number to start from.
     ///
     /// If not provided, the current block number will be used.
-    #[clap(long)]
+    #[arg(long)]
     start_block: Option<u64>,
     /// Number of blocks to build.
-    #[clap(long, default_value = "1")]
+    #[arg(long, default_value = "1")]
     block_count: u64,
     /// Interval in seconds between requests.
-    #[clap(long, default_value = "1800")] // 30 minutes
+    #[arg(long, default_value = "1800")] // 30 minutes
     interval: u64,
     /// One shot request for a specific block number.
-    #[clap(long)]
+    #[arg(long)]
     one_shot: bool,
     /// Minimum price per mcycle in ether.
-    #[clap(long = "min", value_parser = parse_ether, default_value = "0.00001")]
+    #[arg(long = "min", value_parser = parse_ether, default_value = "0.00001")]
     min_price_per_mcycle: U256,
     /// Maximum price per mcycle in ether.
-    #[clap(long = "max", value_parser = parse_ether, default_value = "0.000011")]
+    #[arg(long = "max", value_parser = parse_ether, default_value = "0.000011")]
     max_price_per_mcycle: U256,
     /// Number of seconds, from the bidding start, before the bid expires.
-    #[clap(long, default_value = "12000")]
+    #[arg(long, default_value = "12000")]
     timeout: u32,
     /// Ramp-up period in seconds.
     ///
     /// The bid price will increase linearly from `min_price` to `max_price` over this period.
-    #[clap(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     ramp_up: u32,
     /// Amount of stake tokens required, in HP.
-    #[clap(long, value_parser = parse_ether, default_value = "5")]
+    #[arg(long, value_parser = parse_ether, default_value = "5")]
     stake: U256,
     /// Submit the request offchain.
-    #[clap(long)]
+    #[arg(long)]
     offchain: bool,
-    #[clap(long, default_value = "3")]
+    #[arg(long, default_value = "3")]
     max_retries: u32,
     /// Balance threshold at which to log a warning.
-    #[clap(long, value_parser = parse_ether, default_value = "1")]
+    #[arg(long, value_parser = parse_ether, default_value = "1")]
     warn_balance_below: Option<U256>,
     /// Balance threshold at which to log an error.
-    #[clap(long, value_parser = parse_ether, default_value = "0.1")]
+    #[arg(long, value_parser = parse_ether, default_value = "0.1")]
     error_balance_below: Option<U256>,
 }
 

--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -29,63 +29,63 @@ use url::Url;
 
 /// Arguments of the order generator.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct MainArgs {
     /// URL of the Ethereum RPC endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     rpc_url: Url,
     /// Optional URL of the offchain order stream endpoint.
     ///
     /// If set, the order-generator will submit requests off-chain.
-    #[clap(short, long)]
+    #[arg(short, long)]
     order_stream_url: Option<Url>,
     // Storage provider to use.
-    #[clap(flatten)]
+    #[command(flatten)]
     storage_config: Option<StorageProviderConfig>,
     /// Private key used to sign and submit requests.
-    #[clap(long, env)]
+    #[arg(long, env)]
     private_key: PrivateKeySigner,
     /// Address of the SetVerifier contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     set_verifier_address: Address,
     /// Address of the BoundlessMarket contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     boundless_market_address: Address,
     /// Interval in seconds between requests.
-    #[clap(short, long, default_value = "60")]
+    #[arg(short, long, default_value = "60")]
     interval: u64,
     /// Optional number of requests to submit.
     ///
     /// If unspecified, the loop will run indefinitely.
-    #[clap(short, long)]
+    #[arg(short, long)]
     count: Option<u64>,
     /// Minimum price per mcycle in ether.
-    #[clap(long = "min", value_parser = parse_ether, default_value = "0.001")]
+    #[arg(long = "min", value_parser = parse_ether, default_value = "0.001")]
     min_price_per_mcycle: U256,
     /// Maximum price per mcycle in ether.
-    #[clap(long = "max", value_parser = parse_ether, default_value = "0.002")]
+    #[arg(long = "max", value_parser = parse_ether, default_value = "0.002")]
     max_price_per_mcycle: U256,
     /// Lockin stake amount in ether.
-    #[clap(short, long, value_parser = parse_ether, default_value = "0.0")]
+    #[arg(short, long, value_parser = parse_ether, default_value = "0.0")]
     lockin_stake: U256,
     /// Number of seconds, from the current time, before the auction period starts.
-    #[clap(long, default_value = "30")]
+    #[arg(long, default_value = "30")]
     bidding_start_delay: u64,
     /// Ramp-up period in seconds.
     ///
     /// The bid price will increase linearly from `min_price` to `max_price` over this period.
-    #[clap(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     ramp_up: u32,
     /// Number of seconds before the request lock-in expires.
-    #[clap(long, default_value = "1200")]
+    #[arg(long, default_value = "1200")]
     lock_timeout: u32,
     /// Number of seconds before the request expires.
-    #[clap(long, default_value = "1800")]
+    #[arg(long, default_value = "1800")]
     timeout: u32,
     /// Elf file to use as the guest image, given as a path.
     ///
     /// If unspecified, defaults to the included echo guest.
-    #[clap(long)]
+    #[arg(long)]
     elf: Option<PathBuf>,
     /// Input for the guest, given as a string or a path to a file.
     ///
@@ -93,13 +93,13 @@ struct MainArgs {
     #[command(flatten)]
     input: OrderInput,
     /// Use risc0_zkvm::serde to encode the input as a `Vec<u8>`
-    #[clap(short, long)]
+    #[arg(short, long)]
     encode_input: bool,
     /// Balance threshold at which to log a warning.
-    #[clap(long, value_parser = parse_ether, default_value = "1")]
+    #[arg(long, value_parser = parse_ether, default_value = "1")]
     warn_balance_below: Option<U256>,
     /// Balance threshold at which to log an error.
-    #[clap(long, value_parser = parse_ether, default_value = "0.1")]
+    #[arg(long, value_parser = parse_ether, default_value = "0.1")]
     error_balance_below: Option<U256>,
 }
 
@@ -107,10 +107,10 @@ struct MainArgs {
 #[group(required = false, multiple = false)]
 struct OrderInput {
     /// Input for the guest, given as a hex-encoded string.
-    #[clap(long, value_parser = |s: &str| hex::decode(s))]
+    #[arg(long, value_parser = |s: &str| hex::decode(s))]
     input: Option<Vec<u8>>,
     /// Input for the guest, given as a path to a file.
-    #[clap(long)]
+    #[arg(long)]
     input_file: Option<PathBuf>,
 }
 

--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -106,61 +106,61 @@ impl IntoResponse for AppError {
 
 /// Command line arguments
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 #[non_exhaustive]
 pub struct Args {
     /// Bind address for REST api
-    #[clap(long, env, default_value = "0.0.0.0:8585")]
+    #[arg(long, env, default_value = "0.0.0.0:8585")]
     bind_addr: String,
 
     /// RPC URL for the Ethereum node
-    #[clap(long, env, default_value = "http://localhost:8545")]
+    #[arg(long, env, default_value = "http://localhost:8545")]
     rpc_url: Url,
 
     /// Address of the BoundlessMarket contract
-    #[clap(long, env)]
+    #[arg(long, env)]
     boundless_market_address: Address,
 
     /// Minimum stake balance required to connect to the WebSocket
-    #[clap(long, value_parser = parse_ether)]
+    #[arg(long, value_parser = parse_ether)]
     min_balance: U256,
 
     /// Maximum number of WebSocket connections
-    #[clap(long, default_value = "100")]
+    #[arg(long, default_value = "100")]
     max_connections: usize,
 
     /// Maximum size of the queue for each WebSocket connection
-    #[clap(long, default_value = "100")]
+    #[arg(long, default_value = "100")]
     queue_size: usize,
 
     /// Domain for SIWE checks
-    #[clap(long, default_value = "localhost:8585")]
+    #[arg(long, default_value = "localhost:8585")]
     domain: String,
 
     /// List of addresses to skip balance checks when connecting them as brokers
-    #[clap(long, value_delimiter = ',')]
+    #[arg(long, value_delimiter = ',')]
     bypass_addrs: Vec<Address>,
 
     /// Time between sending websocket pings (in seconds)
-    #[clap(long, default_value_t = 120)]
+    #[arg(long, default_value_t = 120)]
     ping_time: u64,
 
     /// RPC HTTP retry rate limit max retry
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 10)]
+    #[arg(long, default_value_t = 10)]
     pub rpc_retry_max: u32,
 
     /// RPC HTTP retry backoff (in ms)
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 1000)]
+    #[arg(long, default_value_t = 1000)]
     pub rpc_retry_backoff: u64,
 
     /// RPC HTTP retry compute-unit per second
     ///
     /// From the `RetryBackoffLayer` of Alloy
-    #[clap(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 100)]
     pub rpc_retry_cu: u64,
 }
 

--- a/crates/slasher/src/main.rs
+++ b/crates/slasher/src/main.rs
@@ -15,37 +15,37 @@ use url::Url;
 
 /// Arguments of the order generator.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct MainArgs {
     /// URL of the Ethereum RPC endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     rpc_url: Url,
     /// Private key used to sign and submit slash requests.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     private_key: PrivateKeySigner,
     /// Address of the BoundlessMarket contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     boundless_market_address: Address,
     /// DB connection string.
-    #[clap(long, default_value = "sqlite::memory:")]
+    #[arg(long, default_value = "sqlite::memory:")]
     db: String,
     /// Starting block number.
-    #[clap(long)]
+    #[arg(long)]
     start_block: Option<u64>,
     /// Interval in seconds between checking for expired requests.
-    #[clap(long, default_value = "5")]
+    #[arg(long, default_value = "5")]
     interval: u64,
     /// Number of retries before quitting after an error.
-    #[clap(long, default_value = "10")]
+    #[arg(long, default_value = "10")]
     retries: u32,
     /// Balance threshold at which to log a warning.
-    #[clap(long, value_parser = parse_ether, default_value = "1")]
+    #[arg(long, value_parser = parse_ether, default_value = "1")]
     warn_balance_below: Option<U256>,
     /// Balance threshold at which to log an error.
-    #[clap(long, value_parser = parse_ether, default_value = "0.1")]
+    #[arg(long, value_parser = parse_ether, default_value = "0.1")]
     error_balance_below: Option<U256>,
     /// Comma-separated list of addresses to skip when processing locked events.
-    #[clap(long, value_delimiter = ',', value_parser = parse_address)]
+    #[arg(long, value_delimiter = ',', value_parser = parse_address)]
     skip_addresses: Vec<Address>,
 }
 
@@ -57,10 +57,10 @@ fn parse_address(s: &str) -> Result<Address, String> {
 #[group(required = false, multiple = false)]
 struct OrderInput {
     /// Input for the guest, given as a hex-encoded string.
-    #[clap(long, value_parser = |s: &str| hex::decode(s))]
+    #[arg(long, value_parser = |s: &str| hex::decode(s))]
     input: Option<Vec<u8>>,
     /// Input for the guest, given as a path to a file.
-    #[clap(long)]
+    #[arg(long)]
     input_file: Option<PathBuf>,
 }
 

--- a/examples/counter/apps/src/main.rs
+++ b/examples/counter/apps/src/main.rs
@@ -36,28 +36,28 @@ mod counter {
 
 /// Arguments of the publisher CLI.
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[arg(author, version, about, long_about = None)]
 struct Args {
     /// URL of the Ethereum RPC endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     rpc_url: Url,
     /// URL of the offchain order stream endpoint.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     order_stream_url: Option<Url>,
     /// Storage provider to use
-    #[clap(flatten)]
+    #[arg(flatten)]
     storage_config: Option<StorageProviderConfig>,
     /// Private key used to interact with the Counter contract.
-    #[clap(long, env)]
+    #[arg(long, env)]
     private_key: PrivateKeySigner,
     /// Address of the Counter contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     counter_address: Address,
     /// Address of the SetVerifier contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     set_verifier_address: Address,
     /// Address of the BoundlessMarket contract.
-    #[clap(short, long, env)]
+    #[arg(short, long, env)]
     boundless_market_address: Address,
 }
 


### PR DESCRIPTION
This PR updates deprecated `#[clap(...)]` attributes to their modern equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated since version 4.0.
By making this update, we ensure compatibility with future versions and maintain code quality.

Fixes #434 

Err:
`cargo check --features clap/deprecated`

![Pasted Graphic](https://github.com/user-attachments/assets/a89e4025-274b-43a0-87b4-eda326e0d408)

Fix : 
`cargo check --features clap/deprecated`

![Pasted Graphic 2](https://github.com/user-attachments/assets/6090cb93-94f7-4e8e-acb0-1f7686d23385)


