### PR TITLE
rename batch_size to min_batch_size

### DIFF
--- a/broker.toml
+++ b/broker.toml
@@ -25,7 +25,7 @@ proof_retry_sleep_ms = 500
 
 [batcher]
 batch_max_time = 1000
-batch_size = 1
+min_batch_size = 1
 block_deadline_buffer_secs = 120
 txn_timeout = 45
 single_txn_fulfill = true

--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -269,7 +269,7 @@ impl AggregatorService {
                 None => None,
             };
             (
-                config.batcher.batch_size,
+                config.batcher.min_batch_size,
                 config.batcher.batch_max_time,
                 batch_max_fees,
                 config.batcher.batch_max_journal_bytes,
@@ -585,7 +585,7 @@ mod tests {
         let config = ConfigLock::default();
         {
             let mut config = config.load_write().unwrap();
-            config.batcher.batch_size = Some(2);
+            config.batcher.min_batch_size = Some(2);
         }
 
         let prover: ProverObj = Arc::new(MockProver::default());
@@ -739,7 +739,7 @@ mod tests {
         let config = ConfigLock::default();
         {
             let mut config = config.load_write().unwrap();
-            config.batcher.batch_size = Some(2);
+            config.batcher.min_batch_size = Some(2);
         }
 
         let prover: ProverObj = Arc::new(MockProver::default());
@@ -908,7 +908,7 @@ mod tests {
         let config = ConfigLock::default();
         {
             let mut config = config.load_write().unwrap();
-            config.batcher.batch_size = Some(2);
+            config.batcher.min_batch_size = Some(2);
             config.batcher.batch_max_fees = Some("0.1".into());
         }
 
@@ -1013,7 +1013,7 @@ mod tests {
         let config = ConfigLock::default();
         {
             let mut config = config.load_write().unwrap();
-            config.batcher.batch_size = Some(2);
+            config.batcher.min_batch_size = Some(2);
             config.batcher.block_deadline_buffer_secs = 100;
         }
 
@@ -1125,7 +1125,7 @@ mod tests {
         let config = ConfigLock::default();
         {
             let mut config = config.load_write().unwrap();
-            config.batcher.batch_size = Some(10);
+            config.batcher.min_batch_size = Some(10);
             // set config such that the batch max journal size is exceeded
             // if two ECHO sized journals are included in a batch
             config.market.max_journal_bytes = 20;

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -195,6 +195,7 @@ pub struct BatcherConfig {
     /// Max batch duration before publishing (in seconds)
     pub batch_max_time: Option<u64>,
     /// Batch size (in proofs) before publishing
+    #[serde(alias = "batch_size")]
     pub min_batch_size: Option<u64>,
     /// Max combined journal size (in bytes) that once exceeded will trigger a publish
     #[serde(default = "defaults::batch_max_journal_bytes")]
@@ -449,7 +450,7 @@ proof_retry_sleep_ms = 500
 
 [batcher]
 batch_max_time = 300
-min_batch_size = 2
+batch_size = 3
 block_deadline_buffer_secs = 120
 txn_timeout = 45
 batch_poll_time_ms = 1200
@@ -553,6 +554,7 @@ error = ?"#;
             assert!(config.prover.bonsai_r0_zkvm_ver.is_none());
             assert_eq!(config.batcher.txn_timeout, Some(45));
             assert_eq!(config.batcher.batch_poll_time_ms, Some(1200));
+            assert_eq!(config.batcher.min_batch_size, Some(3));
             assert!(config.batcher.single_txn_fulfill);
         }
         tracing::debug!("closing...");

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -195,7 +195,7 @@ pub struct BatcherConfig {
     /// Max batch duration before publishing (in seconds)
     pub batch_max_time: Option<u64>,
     /// Batch size (in proofs) before publishing
-    pub batch_size: Option<u64>,
+    pub min_batch_size: Option<u64>,
     /// Max combined journal size (in bytes) that once exceeded will trigger a publish
     #[serde(default = "defaults::batch_max_journal_bytes")]
     pub batch_max_journal_bytes: usize,
@@ -227,7 +227,7 @@ impl Default for BatcherConfig {
     fn default() -> Self {
         Self {
             batch_max_time: None,
-            batch_size: Some(2),
+            min_batch_size: Some(2),
             batch_max_journal_bytes: defaults::batch_max_journal_bytes(),
             batch_max_fees: None,
             block_deadline_buffer_secs: 120,
@@ -419,7 +419,7 @@ proof_retry_sleep_ms = 500
 
 [batcher]
 batch_max_time = 300
-batch_size = 2
+min_batch_size = 2
 batch_max_fees = "0.1"
 block_deadline_buffer_secs = 120"#;
 
@@ -449,7 +449,7 @@ proof_retry_sleep_ms = 500
 
 [batcher]
 batch_max_time = 300
-batch_size = 2
+min_batch_size = 2
 block_deadline_buffer_secs = 120
 txn_timeout = 45
 batch_poll_time_ms = 1200
@@ -496,7 +496,7 @@ error = ?"#;
         assert_eq!(config.prover.assessor_set_guest_path, None);
 
         assert_eq!(config.batcher.batch_max_time, Some(300));
-        assert_eq!(config.batcher.batch_size, Some(2));
+        assert_eq!(config.batcher.min_batch_size, Some(2));
         assert_eq!(config.batcher.batch_max_fees, Some("0.1".into()));
         assert_eq!(config.batcher.block_deadline_buffer_secs, 120);
         assert_eq!(config.batcher.txn_timeout, None);

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -695,7 +695,7 @@ pub mod test_utils {
             config.prover.set_builder_guest_path = Some(SET_BUILDER_PATH.into());
             config.prover.assessor_set_guest_path = Some(ASSESSOR_GUEST_PATH.into());
             config.market.mcycle_price = "0.00001".into();
-            config.batcher.batch_size = Some(1);
+            config.batcher.min_batch_size = Some(1);
             config.write(config_file.path()).await.unwrap();
 
             let args = Args {

--- a/crates/broker/src/tests/e2e.rs
+++ b/crates/broker/src/tests/e2e.rs
@@ -52,7 +52,7 @@ fn generate_request(id: u32, addr: &Address, unaggregated: bool) -> ProofRequest
     )
 }
 
-async fn new_config(batch_size: u64) -> NamedTempFile {
+async fn new_config(min_batch_size: u64) -> NamedTempFile {
     let config_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
     let mut config = Config::default();
     config.prover.set_builder_guest_path = Some(SET_BUILDER_PATH.into());
@@ -64,7 +64,7 @@ async fn new_config(batch_size: u64) -> NamedTempFile {
     config.prover.req_retry_count = 3;
     config.market.mcycle_price = "0.00001".into();
     config.market.min_deadline = 100;
-    config.batcher.batch_size = Some(batch_size);
+    config.batcher.min_batch_size = Some(min_batch_size);
     config.write(config_file.path()).await.unwrap();
     config_file
 }


### PR DESCRIPTION
This was confusing to me, but also was an assumption of an external party that this would limit the amount of orders locked. Indicating this is a minimum might make it more clear what it's configuring.

This is semver breaking, but backwards compatible with the previous `broker.toml` naming, such as to not break previous configs on update. Can also have this be non-api breaking, but probably better to break now rather than later.