### PR TITLE
BM-688: use FOUNDRY_OUT env var

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -107,3 +107,4 @@ jobs:
         run: forge test -vvv
         env:
           FOUNDRY_PROFILE: reference-contract
+          FOUNDRY_OUT: contracts/reference-contract/out

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "risc0-aggregation",
  "risc0-circuit-recursion",
  "risc0-ethereum-contracts",
+ "risc0-groth16",
  "risc0-zkvm",
  "rmp-serde",
  "serde",

--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -38,6 +38,8 @@ reqwest = { workspace = true, features = ["json", "multipart"] }
 risc0-aggregation = { workspace = true }
 risc0-circuit-recursion = { workspace = true, optional = true }
 risc0-ethereum-contracts = { workspace = true, features = ["unstable"] }
+# Drop once upgrading to risc0-zkvm v2.0
+risc0-groth16 = { version = "~1.2", optional = true }
 risc0-zkvm = { workspace = true, features = ["std", "client"] }
 rmp-serde = { workspace = true }
 serde_json = { workspace = true }

--- a/foundry.toml
+++ b/foundry.toml
@@ -39,7 +39,7 @@ fs_permissions = [{ access = "read", path = "contracts/deployment.toml" }]
 isolate = true
 
 # Profile used to run upgradeability tests.
-# TIP: You can select this profile by setting env var FOUNDRY_PROFILE=reference-contract
+# TIP: You can select this profile by setting env vars FOUNDRY_PROFILE=reference-contract and FOUNDRY_OUT="contracts/reference-contract/out"
 [profile.reference-contract]
 src = "contracts/src"
 out = "contracts/reference-contract/out"
@@ -49,3 +49,4 @@ ffi = true
 ast = true
 build_info = true
 extra_output = ["storageLayout"]
+fs_permissions = [{ access = "read", path = "contracts/reference-contract/out" }]


### PR DESCRIPTION
For some reason the `out` field of the `profile.reference-contract` in the `foundry.toml` does not get used. This PR forces its usage with the env var `FOUNDRY_OUT`
It also fixes a crate version mismatch, `risc0-groth16` by pinning and forcing to use a specific version. This can be removed once upgrading the zkvm to v2.0