### PR TITLE
BM-706: avoid edge case in broker capacity test

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -1304,7 +1304,8 @@ mod tests {
         );
 
         assert!(logs_contain("cannot be completed in time"));
-        assert!(logs_contain("Proof estimated to take 4s to complete, would be 2s past deadline"));
+        assert!(logs_contain("Proof estimated to take 4s to complete"));
+        assert!(logs_contain("s past deadline"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
If the test is very slow, this can report a different timing than tested. Didn't think it would be feasible for this test, but https://github.com/boundless-xyz/boundless/actions/runs/14178716715/job/39719682612?pr=458