### PR TITLE
make CI faster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -383,11 +383,15 @@ jobs:
     runs-on: [ self-hosted, Linux, X64, prod, cuda, g6.4xlarge ]
     strategy:
       matrix:
-        workspace:
-          - examples/counter
-          - examples/smart-contract-requestor
-          - examples/counter-with-callback
-          - examples/composition
+        include:
+          - workspace: examples/counter
+            dev-mode: true
+          - workspace: examples/smart-contract-requestor
+            dev-mode: true
+          - workspace: examples/counter-with-callback
+            dev-mode: true
+          - workspace: examples/composition
+            dev-mode: false
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -459,6 +463,7 @@ jobs:
         env:
           RUST_LOG: "info"
           RISC0_INFO: 1
+          RISC0_DEV_MODE: ${{ matrix.dev-mode }}
 
       - name: sccache stats
         run: sccache --show-stats


### PR DESCRIPTION
It improves the examples that do not require real proofs by about 4x: https://github.com/boundless-xyz/boundless/actions/runs/14242015863