### PR TITLE
BM-739: update http cache to always use cached response

### DIFF
--- a/crates/broker/src/storage.rs
+++ b/crates/broker/src/storage.rs
@@ -108,7 +108,7 @@ impl UriHandler {
         let client = if let Some(cache_dir) = cache_dir {
             let manager = CACacheManager { path: cache_dir };
             let cache = Cache(HttpCache {
-                mode: CacheMode::Default,
+                mode: CacheMode::ForceCache,
                 manager,
                 options: HttpCacheOptions::default(),
             });


### PR DESCRIPTION
This cache is only used for requesting assessor and set builder images, and given they are IPFS URLs, probably fine to force the cache usage.

Perhaps not ideal if we switch this to a URL that isn't content addressed, but I don't think we ever plan to do this.