### PR TITLE
Refactor order-stream for multi-chain

### DIFF
--- a/infra/order-stream/Pulumi.prod-11155111.yaml
+++ b/infra/order-stream/Pulumi.prod-11155111.yaml
@@ -13,3 +13,4 @@ config:
     secure: v1:jMxoiAdaFoB9WAJT:g1NrUTgO6qv3wZqomw4mgtuW43E3Vpu093zhFav17uyr1971GQo6Ngsy9AywFLQBSuwNEViIugZ/I5KOIJW1qgM7ieQTpkhsaeXjL4Sz9tQJ01g2bg==
   order-stream:RDS_PASSWORD:
     secure: v1:dJD9V4HJRNUodRNi:P3NeEgkC+taYmae8PsFSwSs+/RETOtRA/qO/ibHFizvYBw==
+  order-stream:CHAIN_ID: "11155111"

--- a/infra/order-stream/Pulumi.staging.yaml
+++ b/infra/order-stream/Pulumi.staging.yaml
@@ -13,3 +13,4 @@ config:
     secure: v1:D0LPseptkWMnYnOv:wW8eWtEA5HHwiJ7xc4RJIHWHCpEmcSAq8OHMeMk0HSYnZpLQXMuax6MqgFQBIzlNWkJKTCTaBw98Oj6TfUvnA8hC0Ub9NJejUHnJdzgKrEL3tscP7g==
   order-stream:RDS_PASSWORD:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
+  order-stream:CHAIN_ID: "11155111"

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -3,17 +3,9 @@ import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import * as docker_build from '@pulumi/docker-build';
 import * as pulumi from '@pulumi/pulumi';
-import { ChainId, getServiceNameV1 } from '../../util';
+import { getServiceNameV1 } from '../../util';
 
 const SERVICE_NAME_BASE = 'order-stream';
-
-const getEnvVar = (name: string) => {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Environment variable ${name} is not set`);
-  }
-  return value;
-};
 
 export class OrderStreamInstance extends pulumi.ComponentResource {
   public lbUrl: pulumi.Output<string>;
@@ -22,7 +14,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
   constructor(
     name: string,
     args: {
-      chainId: ChainId;
+      chainId: string;
       ciCacheSecret?: pulumi.Output<string>;
       dockerDir: string;
       dockerTag: string;
@@ -266,7 +258,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
         allow: {},
       },
       name: `${serviceName}-acl`,
-      description: 'WebACL for order stream service',
+      description: `WebACL for order stream service ${chainId}`,
       rules: [
         // IP Reputation - AWS managed
         {

--- a/infra/order-stream/index.ts
+++ b/infra/order-stream/index.ts
@@ -1,6 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import { OrderStreamInstance } from './components/order-stream';
-import { ChainId, getEnvVar } from '../util';
+import { getEnvVar } from '../util';
 
 export = () => {
   const config = new pulumi.Config();
@@ -9,6 +9,7 @@ export = () => {
   
   const ethRpcUrl = isDev ? pulumi.output(getEnvVar("ETH_RPC_URL")) : config.requireSecret('ETH_RPC_URL');
   const rdsPassword = isDev ? pulumi.output(getEnvVar("RDS_PASSWORD")) : config.requireSecret('RDS_PASSWORD');
+  const chainId = isDev ? getEnvVar("CHAIN_ID") : config.require('CHAIN_ID');
   
   const githubTokenSecret = config.getSecret('GH_TOKEN_SECRET');
   const dockerDir = config.require('DOCKER_DIR');
@@ -27,8 +28,8 @@ export = () => {
   const privSubNetIds = baseStack.getOutput('PRIVATE_SUBNET_IDS') as pulumi.Output<string[]>;
   const pubSubNetIds = baseStack.getOutput('PUBLIC_SUBNET_IDS') as pulumi.Output<string[]>;
 
-  const orderStreamSepolia = new OrderStreamInstance('order-stream-sepolia', {
-    chainId: ChainId.SEPOLIA,
+  const orderStream = new OrderStreamInstance(`order-stream`, {
+    chainId,
     ciCacheSecret,
     dockerDir,
     dockerTag,
@@ -47,7 +48,7 @@ export = () => {
   });
 
   return {
-    SEPOLIA_ORDER_STREAM_LB_URL: orderStreamSepolia.lbUrl,
-    SEPOLIA_ORDER_STREAM_SWAGGER: orderStreamSepolia.swaggerUrl,
+    ORDER_STREAM_LB_URL: orderStream.lbUrl,
+    ORDER_STREAM_SWAGGER: orderStream.swaggerUrl,
   };
 };

--- a/infra/pipelines/pipelines/order-stream.ts
+++ b/infra/pipelines/pipelines/order-stream.ts
@@ -84,8 +84,8 @@ export class OrderStreamPipeline extends pulumi.ComponentResource {
     );
 
     const prodDeployment = new aws.codebuild.Project(
-      `${APP_NAME}-prod-build`,
-      this.codeBuildProjectArgs(APP_NAME, "prod", role, BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, dockerUsername, dockerTokenSecret, githubTokenSecret),
+      `${APP_NAME}-prod-11155111-build`,
+      this.codeBuildProjectArgs(APP_NAME, "prod-11155111", role, BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, dockerUsername, dockerTokenSecret, githubTokenSecret),
       { dependsOn: [role] }
     );
 

--- a/infra/util/index.ts
+++ b/infra/util/index.ts
@@ -15,7 +15,7 @@ export const getEnvVar = (name: string) => {
 //       and recreated. This is because the service name is used as part of each resource name.
 //       
 //       To use a new naming scheme for new services, we should create a new "V2" function.
-export const getServiceNameV1 = (stackName: string, name: string, chainId: ChainId) => {
+export const getServiceNameV1 = (stackName: string, name: string, chainId: ChainId | string) => {
   const isDev = stackName === "dev";
   const prefix = isDev ? `${getEnvVar("DEV_NAME")}` : `${stackName}`;
   const serviceName = `${prefix}-${name}-${chainId}`;
@@ -25,4 +25,3 @@ export const getServiceNameV1 = (stackName: string, name: string, chainId: Chain
   }
   return serviceName;
 };
-


### PR DESCRIPTION
Initially I was planning to have a single prod stack that deploys all our production instances of the order stream.

On second thought, it seems cleaner and more idiomatic Pulumi to have separate prod stacks, one for each chain.

This PR sets us up for that by moving the chain id into the stacks config file.