### PR TITLE
BM-746: Shorten naming of order-stream resources

### DIFF
--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -55,7 +55,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
     } = args;
     
     const stackName = pulumi.getStack();
-    const serviceName = getServiceNameV1(stackName, SERVICE_NAME_BASE, chainId);
+    const serviceName = getServiceNameV1(stackName, SERVICE_NAME_BASE);
 
     // If we're in prod and have a domain, create a cert
     let cert: aws.acm.Certificate | undefined;
@@ -87,7 +87,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
     // Optionally add in the gh token secret and sccache s3 creds to the build ctx
     let buildSecrets = {};
     if (ciCacheSecret !== undefined) {
-      const cacheFileData = ciCacheSecret.apply((filePath) => fs.readFileSync(filePath, 'utf8'));
+      const cacheFileData = ciCacheSecret.apply((filePath: any) => fs.readFileSync(filePath, 'utf8'));
       buildSecrets = {
         ci_cache_creds: cacheFileData,
       };

--- a/infra/util/index.ts
+++ b/infra/util/index.ts
@@ -15,10 +15,11 @@ export const getEnvVar = (name: string) => {
 //       and recreated. This is because the service name is used as part of each resource name.
 //       
 //       To use a new naming scheme for new services, we should create a new "V2" function.
-export const getServiceNameV1 = (stackName: string, name: string, chainId: ChainId | string) => {
+export const getServiceNameV1 = (stackName: string, name: string, chainId?: ChainId | string) => {
   const isDev = stackName === "dev";
   const prefix = isDev ? `${getEnvVar("DEV_NAME")}` : `${stackName}`;
-  const serviceName = `${prefix}-${name}-${chainId}`;
+  const suffix = chainId ? `-${chainId}` : "";
+  const serviceName = `${prefix}-${name}${suffix}`;
   // When creating S3 buckets using prefixName the max length is 37 characters.
   if (serviceName.length > 37) {
     throw new Error(`Service name ${serviceName} is too long`);


### PR DESCRIPTION
Now that Chain ID is in the stack name, it ends up repeated in the service name. This causes prod to fail, since now the names of various resources exceed the character limits.