### PR TITLE
BM-757: Use cert in prod

### DIFF
--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -144,7 +144,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       listener = {
         port: 443,
         protocol: 'HTTPS',
-        certificateArn: cert.arn,
+        certificateArn: cert.arn.apply((arn) => arn),
       };
     } else {
       listener = {

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -26,7 +26,6 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       boundlessAddress: string;
       vpcId: pulumi.Output<string>;
       rdsPassword: pulumi.Output<string>;
-      acmCertArn?: pulumi.Output<string>;
       albDomain?: pulumi.Output<string>;
       ethRpcUrl: pulumi.Output<string>;
       bypassAddrs: string;
@@ -43,7 +42,6 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       orderStreamPingTime, 
       privSubNetIds, 
       pubSubNetIds, 
-      acmCertArn, 
       githubTokenSecret, 
       minBalance, 
       boundlessAddress, 
@@ -139,13 +137,14 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       ],
     });
 
-
+    // If we have a cert and a domain, use it, and enable https.
+    // Otherwise we use the default lb endpoint that AWS provides that only supports http.
     let listener: awsx.types.input.lb.ListenerArgs;
-    if (acmCertArn !== undefined) {
+    if (cert && albDomain) {
       listener = {
         port: 443,
         protocol: 'HTTPS',
-        certificateArn: acmCertArn,
+        certificateArn: cert.arn,
       };
     } else {
       listener = {

--- a/infra/order-stream/index.ts
+++ b/infra/order-stream/index.ts
@@ -21,7 +21,6 @@ export = () => {
   const baseStackName = config.require('BASE_STACK');
   const orderStreamPingTime = config.requireNumber('ORDER_STREAM_PING_TIME');
   const albDomain = config.getSecret('ALB_DOMAIN');
-  const acmCertArn = config.getSecret('ACM_CERT_ARN');
 
   const baseStack = new pulumi.StackReference(baseStackName);
   const vpcId = baseStack.getOutput('VPC_ID') as pulumi.Output<string>;
@@ -44,7 +43,6 @@ export = () => {
     rdsPassword,
     ethRpcUrl,
     albDomain,
-    acmCertArn,
   });
 
   return {


### PR DESCRIPTION
Now that the cert has been created and validated, we can enable the order stream is prod to use it.

ACM_CERT_ARN is not necessary as in this design the cert is fully managed by Pulumi, so we can get the ARN from the Pulumi resource.

This should be the last change to set up the DNS, though I'm unable to test locally since this is prod only, so can't be sure.