### PR TITLE
chore: added TypeScript Typing for `match` variable

### DIFF
--- a/documentation/scripts/check-links.ts
+++ b/documentation/scripts/check-links.ts
@@ -25,7 +25,7 @@ async function findAnchorsInFile(filePath: string): Promise<Set<string>> {
 
   // Match ATX-style headers (# Header)
   const headerRegex = /^#{1,6}\s+(.+)$/gm;
-  let match: any;
+  let match: RegExpExecArray | null;
 
   // biome-ignore lint/suspicious/noAssignInExpressions: ignore
   while ((match = headerRegex.exec(content)) !== null) {
@@ -99,7 +99,7 @@ async function checkLinks() {
 
     // Check reference-style links
     const refLinkRegex = /^\[([^\]]+)\]:\s*(\S+)/gm;
-    let match: any;
+    let match: RegExpExecArray | null;
 
     // biome-ignore lint/suspicious/noAssignInExpressions: ignore
     while ((match = refLinkRegex.exec(markdown)) !== null) {


### PR DESCRIPTION
updated the code to properly type the `match` variable in two places:  
- In the `findAnchorsInFile` function (for matching headers in the file).  
- In the `checkLinks` function (for matching links in the Markdown file).

this ensures TypeScript correctly handles the `match` variable as either a `RegExpExecArray` (when there are matches) or `null` (when no matches are found).