### PR TITLE
BM-772: Resume slashing RISC Zero provers using the RISC Zero slasher

### DIFF
--- a/infra/slasher/Pulumi.prod.yaml
+++ b/infra/slasher/Pulumi.prod.yaml
@@ -12,5 +12,5 @@ config:
   slasher:INTERVAL: "60"
   slasher:LOG_LEVEL: info
   slasher:RETRIES: "5"
-  slasher:SKIP_ADDRESSES: 0x52792d081461e5c874e78f90360e3320b2960cc5,0xf8087e8f3ba5fc4865eda2fcd3c05846982da136
+  slasher:SKIP_ADDRESSES: ""
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic

--- a/infra/slasher/Pulumi.staging.yaml
+++ b/infra/slasher/Pulumi.staging.yaml
@@ -12,5 +12,5 @@ config:
   slasher:INTERVAL: "60"
   slasher:LOG_LEVEL: info
   slasher:RETRIES: "5"
-  slasher:SKIP_ADDRESSES: 0x52792d081461e5c874e78f90360e3320b2960cc5,0xf8087e8f3ba5fc4865eda2fcd3c05846982da136
+  slasher:SKIP_ADDRESSES: ""
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic


### PR DESCRIPTION
We operate a slashing bot on the Boundless testnet, and due to difficulties with the freezing system that ultimately would cause requestors to have a bad experience, we temporarily removed RISC Zero provers from the list of slashing targets. We have not removed freezing, and so now will slash our own provers again.
