### PR TITLE
BM-776: Bump rust toolchain version in agent.dockerfile

### DIFF
--- a/dockerfiles/agent.dockerfile
+++ b/dockerfiles/agent.dockerfile
@@ -19,7 +19,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 # Install rust and a target rust version (should match rust-toolchain.toml for best speed)
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN chmod -R a+w $RUSTUP_HOME $CARGO_HOME
-RUN rustup install 1.81
+RUN rustup install 1.85
 
 FROM rust-builder AS builder
 


### PR DESCRIPTION
Building the docker image results in the following error:

```console
 => ERROR [exec_agent builder 8/8] RUN     --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials     --mount=type=cache,target=/root/.cache/scc  0.4s
------
 > [exec_agent builder 8/8] RUN     --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials     --mount=type=cache,target=/root/.cache/sccache/,id=bndlss_agent_sc     source ./sccache-config.sh shared/boundless/rust-cache-docker-Linux-X64/sccache &&     cargo build --release -p workflow -F cuda --bin agent &&     cp /src/bento/target/release/agent /src/agent &&     sccache --show-stats:
0.169 Using local sccache
0.178 error: toolchain '1.85-x86_64-unknown-linux-gnu' is not installed
0.178 help: run `rustup toolchain install 1.85-x86_64-unknown-linux-gnu` to install it
```

This fix should be back-ported also to the `release-0.7.0` branch