### PR TITLE
BM-777: Raise max price for order gens

### DIFF
--- a/infra/order-generator/Pulumi.prod.yaml
+++ b/infra/order-generator/Pulumi.prod.yaml
@@ -19,7 +19,7 @@ config:
     secure: v1:9iJ6gE5+gp4aipMW:lZlt7k89kafxnLvr8Qe0sStef/3gNEOcr67breAfH/sSrlgL4m6k081WHMUpaU2doI683Sd0TQ+kSnbLKINXfxvqiw/EFfhz4SxOks6d9UI=
   order-generator-simple:INTERVAL: "300"
   order-generator-simple:LOCK_STAKE: "0.1"
-  order-generator-simple:MAX_PRICE_PER_MCYCLE: "0.01"
+  order-generator-simple:MAX_PRICE_PER_MCYCLE: "0.1"
   order-generator-simple:MIN_PRICE_PER_MCYCLE: "0.00005"
   order-generator-simple:RAMP_UP: "600"
   order-generator-simple:LOCK_TIMEOUT: "900"

--- a/infra/order-generator/Pulumi.prod.yaml
+++ b/infra/order-generator/Pulumi.prod.yaml
@@ -22,6 +22,8 @@ config:
   order-generator-simple:MAX_PRICE_PER_MCYCLE: "0.01"
   order-generator-simple:MIN_PRICE_PER_MCYCLE: "0.00005"
   order-generator-simple:RAMP_UP: "600"
+  order-generator-simple:LOCK_TIMEOUT: "900"
+  order-generator-simple:TIMEOUT: "1800"
   order-generator-zeth:SCHEDULE_MINUTES: "10"
   order-generator-zeth:RETRIES: "2"
   order-generator-zeth:INTERVAL: "1800"

--- a/infra/order-generator/Pulumi.staging.yaml
+++ b/infra/order-generator/Pulumi.staging.yaml
@@ -21,9 +21,11 @@ config:
     secure: v1:/PAo8IW1iSC4PfVa:j+e1NmKVKprC8cRWBPmmQ5GT9O4ppUeU2VYFdpPiZDZHHCW6GCrTbHO+1BWu1rinjCT1lppKhzXhxBXlVabTVdwPOfjYZO7lF4g+dQjqq5U=
   order-generator-simple:INTERVAL: "300"
   order-generator-simple:LOCK_STAKE: "0.1"
-  order-generator-simple:MAX_PRICE_PER_MCYCLE: "0.01"
+  order-generator-simple:MAX_PRICE_PER_MCYCLE: "0.1"
   order-generator-simple:MIN_PRICE_PER_MCYCLE: "0.00005"
   order-generator-simple:RAMP_UP: "600"
+  order-generator-simple:LOCK_TIMEOUT: "900"
+  order-generator-simple:TIMEOUT: "1800"
   order-generator-zeth:SCHEDULE_MINUTES: "10"
   order-generator-zeth:RETRIES: "2"
   order-generator-zeth:INTERVAL: "3600"


### PR DESCRIPTION
We saw a large spike in gas prices that made our order generator orders not profitable. These orders are used to assess the health of the system, so its important they are always fulfilled. Bumping the max price should help keep these order fulfillable during gas spikes.