### PR TITLE
BM-792: Add lock subcommand

### DIFF
--- a/crates/boundless-cli/src/bin/boundless-cli.rs
+++ b/crates/boundless-cli/src/bin/boundless-cli.rs
@@ -290,6 +290,27 @@ enum ProvingCommands {
         #[arg(long, env = "ORDER_STREAM_URL", conflicts_with_all = ["tx_hash"])]
         order_stream_url: Option<Url>,
     },
+
+    /// Lock a request in the market
+    Lock {
+        /// The proof request identifier
+        #[arg(long)]
+        request_id: U256,
+
+        /// The request digest
+        #[arg(long)]
+        request_digest: Option<B256>,
+
+        /// The tx hash of the request submission
+        #[arg(long)]
+        tx_hash: Option<B256>,
+
+        /// The order stream service URL.
+        ///
+        /// If provided, the request will be fetched offchain via the provided order stream service URL.
+        #[arg(long, env = "ORDER_STREAM_URL", conflicts_with_all = ["tx_hash"])]
+        order_stream_url: Option<Url>,
+    },
 }
 
 #[derive(Args, Clone, Debug)]
@@ -823,6 +844,32 @@ where
                     bail!("Failed to fulfill request: {}", e)
                 }
             }
+        }
+        ProvingCommands::Lock { request_id, request_digest, tx_hash, order_stream_url } => {
+            tracing::info!("Locking proof request 0x{:x}", request_id);
+            let client = ClientBuilder::new()
+                .with_private_key(args.config.private_key.clone())
+                .with_rpc_url(args.config.rpc_url.clone())
+                .with_boundless_market_address(args.config.boundless_market_address)
+                .with_set_verifier_address(args.config.set_verifier_address)
+                .with_order_stream_url(order_stream_url.clone())
+                .with_timeout(args.config.tx_timeout)
+                .build()
+                .await?;
+
+            let order = client.fetch_order(*request_id, *tx_hash, *request_digest).await?;
+            tracing::debug!("Fetched order details: {:?}", order.request);
+
+            let sig: Bytes = order.signature.as_bytes().into();
+            order.request.verify_signature(
+                &sig,
+                args.config.boundless_market_address,
+                boundless_market.get_chain_id().await?,
+            )?;
+
+            boundless_market.lock_request(&order.request, &sig, None).await?;
+            tracing::info!("Successfully locked request 0x{:x}", request_id);
+            Ok(())
         }
     }
 }
@@ -1784,16 +1831,29 @@ mod tests {
 
         assert!(logs_contain(&format!("Successfully executed request 0x{:x}", request.id)));
 
-        let client_sig = request
-            .sign_request(&ctx.customer_signer, ctx.boundless_market_address, anvil.chain_id())
-            .await
-            .unwrap();
+        let prover_config = GlobalConfig {
+            rpc_url: anvil.endpoint_url(),
+            private_key: ctx.prover_signer.clone(),
+            boundless_market_address: ctx.boundless_market_address,
+            verifier_address: ctx.verifier_address,
+            set_verifier_address: ctx.set_verifier_address,
+            tx_timeout: None,
+            log_level: LevelFilter::INFO,
+        };
 
-        // Lock the request
-        ctx.prover_market
-            .lock_request(&request, &Bytes::copy_from_slice(&client_sig.as_bytes()), None)
-            .await
-            .unwrap();
+        // test the Lock command
+        run(&MainArgs {
+            config: prover_config,
+            command: Command::Proving(Box::new(ProvingCommands::Lock {
+                request_id,
+                request_digest: None,
+                tx_hash: None,
+                order_stream_url: None,
+            })),
+        })
+        .await
+        .unwrap();
+        assert!(logs_contain(&format!("Successfully locked request 0x{:x}", request.id)));
 
         // test the Status command
         run(&MainArgs {
@@ -1986,7 +2046,7 @@ mod tests {
     #[traced_test]
     #[ignore = "Generates a proof. Slow without RISC0_DEV_MODE=1"]
     async fn test_proving_offchain(pool: PgPool) {
-        let (ctx, _anvil, config, order_stream_url, order_stream_handle) =
+        let (ctx, anvil, config, order_stream_url, order_stream_handle) =
             setup_test_env_with_order_stream(AccountOwner::Customer, pool).await;
 
         // Deposit funds into the market
@@ -2038,6 +2098,30 @@ mod tests {
         .unwrap();
 
         assert!(logs_contain(&format!("Successfully executed request 0x{:x}", request.id)));
+
+        let prover_config = GlobalConfig {
+            rpc_url: anvil.endpoint_url(),
+            private_key: ctx.prover_signer.clone(),
+            boundless_market_address: ctx.boundless_market_address,
+            verifier_address: ctx.verifier_address,
+            set_verifier_address: ctx.set_verifier_address,
+            tx_timeout: None,
+            log_level: LevelFilter::INFO,
+        };
+
+        // test the Lock command
+        run(&MainArgs {
+            config: prover_config,
+            command: Command::Proving(Box::new(ProvingCommands::Lock {
+                request_id,
+                request_digest: None,
+                tx_hash: None,
+                order_stream_url: Some(order_stream_url.clone()),
+            })),
+        })
+        .await
+        .unwrap();
+        assert!(logs_contain(&format!("Successfully locked request 0x{:x}", request.id)));
 
         // test the Fulfill command
         run(&MainArgs {

--- a/documentation/site/pages/developers/tooling/cli.mdx
+++ b/documentation/site/pages/developers/tooling/cli.mdx
@@ -307,7 +307,7 @@ boundless-cli request verify-proof 0x5... 0x0002f87ec0...
 
 ### 3. Proving subcommands
 
-The `proving` subcommand is used to execute guest code locally and generate proofs for specific requests.
+The `proving` subcommand is used to execute guest code locally, lock and generate proofs for specific requests.
 
 >**Note**: The proving subcommands are not equivalent to running a [bento](../../provers/quick-start.mdx) prover.
 
@@ -357,6 +357,25 @@ proving fulfill --request-id <U256> [--request-digest <B256>] [--tx-hash <B256>]
 ```
 boundless-cli proving fulfill --request-id 0x5...
 ```
+
+#### 3. lock
+Locks the request on the market, preventing other provers to acquire the exclusive right to get paid for its fulfillment, as long as the request gets fulfilled before the lock timeout.
+
+**Syntax**:
+```
+proving lock --request-id <U256> [--request-digest <B256>] [--tx-hash <B256>]
+        [--order-stream-url <URL>]
+```
+- `--request-id`: the proof request identifier.
+- `--request-digest`: request’s EIP712 digest (optional).
+- `--tx-hash`: transaction hash (optional, to find the request).
+- `--order-stream-url`: fetch request data from an offchain server.
+
+**Example**:
+```
+boundless-cli proving lock --request-id 0x5...
+```
+
 
 ### 4. Ops subcommands
 


### PR DESCRIPTION
**Syntax**:
```
proving lock --request-id <U256> [--request-digest <B256>] [--tx-hash <B256>]
        [--order-stream-url <URL>]
```
- `--request-id`: the proof request identifier.
- `--request-digest`: request’s EIP712 digest (optional).
- `--tx-hash`: transaction hash (optional, to find the request).
- `--order-stream-url`: fetch request data from an offchain server.

**Example**:
```
boundless-cli proving lock --request-id 0x5...
```

Should results in something like:

```console
2025-04-17T17:41:00.519190Z  INFO test_proving_offchain: boundless_cli: Locking proof request 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc00000001
2025-04-17T17:41:00.522179Z DEBUG test_proving_offchain: boundless_cli: Fetched order details: ProofRequest { id: 1477785848920527538943426201171954208394474144316077899777, requirements: Requirements { imageId: 0x13ae8844506a103a72cab419e7603987a673140575f7ab1a8ce87b1d5eac5040, callback: Callback { addr: 0x0000000000000000000000000000000000000000, gasLimit: 0 }, predicate: Predicate { predicateType: PrefixMatch, data: 0x }, selector: 0x00000000 }, imageUrl: "file:///Users/angelo/dev/risc-zero/boundless/target/riscv-guest/guest-util/echo/riscv32im-risc0-zkvm-elf/release/echo.bin", input: Input { inputType: Inline, data: 0x0181a5737464696edc001041000000410000004100000041000000 }, offer: Offer { minPrice: 20000000000000, maxPrice: 40000000000000, biddingStart: 1744911660, rampUpPeriod: 1, lockTimeout: 420, timeout: 420, lockStake: 10 } }
2025-04-17T17:41:02.532307Z  INFO test_proving_offchain: boundless_cli: Successfully locked request 0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc00000001
```