### PR TITLE
BM-794: Fix order stream deployment healthcheck

### DIFF
--- a/crates/order-stream/src/api.rs
+++ b/crates/order-stream/src/api.rs
@@ -6,7 +6,8 @@ use alloy::primitives::Address;
 use anyhow::Context;
 use axum::extract::{Json, Path, Query, State};
 use boundless_market::order_stream_client::{
-    ErrMsg, Nonce, OrderData, SubmitOrderRes, HEALTH_CHECK, ORDER_LIST_PATH, ORDER_SUBMISSION_PATH,
+    ErrMsg, Nonce, OrderData, SubmitOrderRes, AUTH_GET_NONCE, HEALTH_CHECK, ORDER_LIST_PATH,
+    ORDER_SUBMISSION_PATH,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -78,7 +79,7 @@ pub(crate) async fn list_orders(
 
 #[utoipa::path(
     get,
-    path = "api/orders/<request_id>",
+    path = format!("{}/<request_id>", ORDER_LIST_PATH),
     params(
         ("id" = String, Path, description = "Request ID")
     ),
@@ -99,7 +100,7 @@ pub(crate) async fn find_orders_by_request_id(
 
 #[utoipa::path(
     get,
-    path = "/api/nonce/<addr>",
+    path = format!("{}/<addr>", AUTH_GET_NONCE),
     params(
         Pagination,
     ),

--- a/infra/order-stream/Pulumi.prod-11155111.yaml
+++ b/infra/order-stream/Pulumi.prod-11155111.yaml
@@ -15,3 +15,4 @@ config:
     secure: v1:6OldikDHGPtFsshU:3tg0ETBuoOsjoCnrxja5zQnWyaGOSvtIsNEIjH2uu7tvuA==
   order-stream:ALB_DOMAIN: eth-sepolia.beboundless.xyz
   order-stream:CHAIN_ID: "11155111"
+  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic

--- a/infra/order-stream/Pulumi.staging.yaml
+++ b/infra/order-stream/Pulumi.staging.yaml
@@ -14,3 +14,4 @@ config:
   order-stream:RDS_PASSWORD:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
   order-stream:CHAIN_ID: "11155111"
+  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -6,6 +6,7 @@ import * as pulumi from '@pulumi/pulumi';
 import { getServiceNameV1 } from '../../util';
 
 const SERVICE_NAME_BASE = 'order-stream';
+const HEALTH_CHECK_PATH = '/api/v1/health';
 
 export class OrderStreamInstance extends pulumi.ComponentResource {
   public lbUrl: pulumi.Output<string>;
@@ -29,6 +30,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       albDomain?: pulumi.Output<string>;
       ethRpcUrl: pulumi.Output<string>;
       bypassAddrs: string;
+      boundlessAlertsTopicArn?: string;
     },
     opts?: pulumi.ComponentResourceOptions
   ) {
@@ -61,7 +63,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       cert = new aws.acm.Certificate(`${serviceName}-cert`, {
         domainName: pulumi.interpolate`${albDomain}`,
         validationMethod: "DNS",
-      });
+      }, { protect: true });
     }
 
     const ecrRepository = new awsx.ecr.Repository(`${serviceName}-repo`, {
@@ -153,6 +155,8 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       };
     }
   
+    // Protect the load balancer so it doesn't get deleted if the stack is accidently modified/deleted
+    // Important as the A record of this resource is tied to DNS.
     const loadbalancer = new awsx.lb.ApplicationLoadBalancer(`${serviceName}-lb`, {
       name: `${serviceName}-lb`,
       subnetIds: pubSubNetIds,
@@ -168,12 +172,12 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
           healthyThreshold: 2,
           port: '8585',
           protocol: 'HTTP',
-          path: '/api/v1/health',
+          path: HEALTH_CHECK_PATH,
         },
       },
       // This should be slightly greater than the order-steam configured ping/pong time
       idleTimeout: orderStreamPingTime + orderStreamPingTime * 0.2,
-    });
+    }, { protect: true });
   
     const orderStreamSecGroup = new aws.ec2.SecurityGroup(`${serviceName}-sg`, {
       name: `${serviceName}-sg`,
@@ -250,7 +254,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       dbSubnetGroupName: dbSubnets.name,
       vpcSecurityGroupIds: [rdsSecurityGroup.id],
       storageType: 'gp3',
-    });
+    }, { protect: true });
   
     const webAcl = new aws.wafv2.WebAcl(`${serviceName}-acl`, {
       defaultAction: {
@@ -461,7 +465,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
             },
           ],
           healthCheck: {
-            command: ['CMD-SHELL', 'curl -f http://localhost:8585/api/health || exit 1'],
+            command: ['CMD-SHELL', `curl -f http://localhost:8585${HEALTH_CHECK_PATH} || exit 1`],
             interval: 60,
             timeout: 5,
             retries: 1,
@@ -476,7 +480,9 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
         },
       },
     });
-  
+
+    const alarmActions = args.boundlessAlertsTopicArn ? [args.boundlessAlertsTopicArn] : [];
+
     new aws.cloudwatch.LogMetricFilter(`${serviceName}-log-err-filter`, {
       name: `${serviceName}-log-err-filter`,
       logGroupName: serviceLogGroup,
@@ -489,6 +495,58 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       // Whitespace prevents us from alerting on SQL injection probes.
       pattern: `"ERROR "`,
     }, { dependsOn: [service] });
+
+    // Two errors within an hour triggers alarm.
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-error-alarm`, {
+      name: `${serviceName}-log-err`,
+      metricQueries: [
+        {
+          id: 'm1',
+          metric: {
+            namespace: `Boundless/Services/${serviceName}`,
+            metricName: `${serviceName}-log-err`,
+            period: 60,
+            stat: 'Sum',
+          },
+          returnData: true,
+        },
+      ],
+      threshold: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      // Two errors within an hour triggers alarm.
+      evaluationPeriods: 60,
+      datapointsToAlarm: 2,
+      treatMissingData: 'notBreaching',
+      alarmDescription: 'Order stream log ERROR level',
+      actionsEnabled: true,
+      alarmActions,
+    });
+
+    // Convert the arns to the format expected by the Cloudwatch metric alarm.
+    // The format is of form: 
+    //  app/order-stream-11155111-lb/a1fb2124f59f54fb
+    // and 
+    //  targetgroup/order-stream-11155111-tg/6f6f9bce2553bf09
+    const loadBalancerId = pulumi.interpolate`${loadbalancer.loadBalancer.arn.apply((arn) => arn.split('/').pop())}`;
+    const targetGroupId = pulumi.interpolate`targetgroup/${loadbalancer.defaultTargetGroup.arn.apply((arn) => arn.split('/').pop())}`;
+    
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-health-check-alarm`, {
+      name: `${serviceName}-health-check-alarm`,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      evaluationPeriods: 1,
+      metricName: `UnHealthyHostCount`,
+      dimensions: {
+        TargetGroup: targetGroupId,
+        LoadBalancer: loadBalancerId,
+      },
+      namespace: 'AWS/ApplicationELB',
+      period: 60,
+      statistic: 'Sum',
+      threshold: 1,
+      alarmDescription: 'Order stream health check alarm',
+      actionsEnabled: true,
+      alarmActions,
+    });
   
     this.lbUrl = albEndPoint;
     this.swaggerUrl = domain.apply((domain) => {

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -168,7 +168,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
           healthyThreshold: 2,
           port: '8585',
           protocol: 'HTTP',
-          path: '/api/health',
+          path: '/api/v1/health',
         },
       },
       // This should be slightly greater than the order-steam configured ping/pong time

--- a/infra/order-stream/index.ts
+++ b/infra/order-stream/index.ts
@@ -21,6 +21,7 @@ export = () => {
   const baseStackName = config.require('BASE_STACK');
   const orderStreamPingTime = config.requireNumber('ORDER_STREAM_PING_TIME');
   const albDomain = config.getSecret('ALB_DOMAIN');
+  const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
 
   const baseStack = new pulumi.StackReference(baseStackName);
   const vpcId = baseStack.getOutput('VPC_ID') as pulumi.Output<string>;
@@ -43,6 +44,7 @@ export = () => {
     rdsPassword,
     ethRpcUrl,
     albDomain,
+    boundlessAlertsTopicArn,
   });
 
   return {


### PR DESCRIPTION
We noticed the order stream deployments had rolled back and were marked as unhealthy. Root cause was that the health check endpoints in Pulumi were not updated to include the new /v1/ versioning of the API. Deployments still succeed in this case, as Pulumi does not have insight into whether a container's healthchecks succeed or not.

Also adds an alarm so we can be notified of this in the future, and sets up slack alerts for the order stream which was missed.