### PR TITLE
Support multiple requests fulfillment via CLI

### DIFF
--- a/crates/boundless-cli/src/bin/boundless-cli.rs
+++ b/crates/boundless-cli/src/bin/boundless-cli.rs
@@ -270,19 +270,29 @@ enum ProvingCommands {
         order_stream_url: Option<Url>,
     },
 
-    /// Fulfill a proof request using the RISC Zero zkVM default prover
+    /// Fulfill one or more proof requests using the RISC Zero zkVM default prover.
+    ///
+    /// This command can process multiple requests in a single batch, which is more efficient
+    /// than fulfilling requests individually.
+    ///
+    /// Example usage:
+    ///   --request-ids 0x123,0x456,0x789  # Comma-separated list of request IDs
+    ///   --request-digests 0xabc,0xdef,0x012  # Optional, must match request_ids length and order
+    ///   --tx-hashes 0x111,0x222,0x333  # Optional, must match request_ids length and order
     Fulfill {
-        /// The proof request identifier
+        /// The proof requests identifiers (comma-separated list of hex values)
         #[arg(long)]
-        request_id: U256,
+        request_ids: Vec<U256>,
 
-        /// The request digest
+        /// The request digests (comma-separated list of hex values).
+        /// If provided, must have the same length and order as request_ids.
         #[arg(long)]
-        request_digest: Option<B256>,
+        request_digests: Option<Vec<B256>>,
 
-        /// The tx hash of the request submission
+        /// The tx hash of the requests submissions (comma-separated list of hex values).
+        /// If provided, must have the same length and order as request_ids.
         #[arg(long)]
-        tx_hash: Option<B256>,
+        tx_hashes: Option<Vec<B256>>,
 
         /// The order stream service URL.
         ///
@@ -770,8 +780,20 @@ where
             tracing::debug!("Journal: {:?}", journal);
             Ok(())
         }
-        ProvingCommands::Fulfill { request_id, request_digest, tx_hash, order_stream_url } => {
-            tracing::info!("Fulfilling proof request 0x{:x}", request_id);
+        ProvingCommands::Fulfill { request_ids, request_digests, tx_hashes, order_stream_url } => {
+            if request_digests.is_some()
+                && request_ids.len() != request_digests.as_ref().unwrap().len()
+            {
+                bail!("request_ids and request_digests must have the same length");
+            }
+            if tx_hashes.is_some() && request_ids.len() != tx_hashes.as_ref().unwrap().len() {
+                bail!("request_ids and tx_hashes must have the same length");
+            }
+
+            let request_ids_string =
+                request_ids.iter().map(|id| format!("0x{:x}", id)).collect::<Vec<_>>().join(", ");
+            tracing::info!("Fulfilling proof requests {}", request_ids_string);
+
             let (_, market_url) = boundless_market.image_info().await?;
             tracing::debug!("Fetching Assessor ELF from {}", market_url);
             let assessor_elf = fetch_url(&market_url).await?;
@@ -800,35 +822,46 @@ where
                 .build()
                 .await?;
 
-            let order = client.fetch_order(*request_id, *tx_hash, *request_digest).await?;
-            tracing::debug!("Fetched order details: {:?}", order.request);
+            let mut orders = Vec::new();
+            let mut signatures = Vec::new();
+            let mut requests_to_price = Vec::new();
+            for (i, request_id) in request_ids.iter().enumerate() {
+                let order = client
+                    .fetch_order(
+                        *request_id,
+                        tx_hashes.as_ref().map(|tx_hashes| tx_hashes[i]),
+                        request_digests.as_ref().map(|request_digests| request_digests[i]),
+                    )
+                    .await?;
+                tracing::debug!("Fetched order details: {:?}", order.request);
 
-            let sig: Bytes = order.signature.as_bytes().into();
-            order.request.verify_signature(
-                &sig,
-                args.config.boundless_market_address,
-                boundless_market.get_chain_id().await?,
-            )?;
+                // If the request is not locked in, we need to "price" which checks the requirements
+                // and assigns a price. Otherwise, we don't. This vec will be a singleton if not locked
+                // and empty if the request is locked.
+                if !boundless_market.is_locked(*request_id).await? {
+                    requests_to_price.push(order.request.clone());
+                }
 
-            let (fill, root_receipt, assessor_receipt) = prover.fulfill(order.clone()).await?;
-            let order_fulfilled = OrderFulfilled::new(fill, root_receipt, assessor_receipt)?;
+                let sig: Bytes = order.signature.as_bytes().into();
+                order.request.verify_signature(
+                    &sig,
+                    args.config.boundless_market_address,
+                    boundless_market.get_chain_id().await?,
+                )?;
+                orders.push(order);
+                signatures.push(sig);
+            }
+
+            let (fills, root_receipt, assessor_receipt) = prover.fulfill(&orders).await?;
+            let order_fulfilled = OrderFulfilled::new(fills, root_receipt, assessor_receipt)?;
             tracing::debug!("Submitting root {} to SetVerifier", order_fulfilled.root);
             set_verifier.submit_merkle_root(order_fulfilled.root, order_fulfilled.seal).await?;
             tracing::debug!("Successfully submitted root to SetVerifier");
 
-            // If the request is not locked in, we need to "price" which checks the requirements
-            // and assigns a price. Otherwise, we don't. This vec will be a singleton if not locked
-            // and empty if the request is locked.
-            let requests_to_price: Vec<ProofRequest> =
-                (!boundless_market.is_locked(*request_id).await?)
-                    .then_some(order.request)
-                    .into_iter()
-                    .collect();
-
             match boundless_market
                 .price_and_fulfill_batch(
                     requests_to_price,
-                    vec![sig],
+                    signatures,
                     order_fulfilled.fills,
                     order_fulfilled.assessorReceipt,
                     None,
@@ -836,11 +869,11 @@ where
                 .await
             {
                 Ok(_) => {
-                    tracing::info!("Successfully fulfilled request 0x{:x}", request_id);
+                    tracing::info!("Successfully fulfilled requests {}", request_ids_string);
                     Ok(())
                 }
                 Err(e) => {
-                    tracing::error!("Failed to fulfill request 0x{:x}: {}", request_id, e);
+                    tracing::error!("Failed to fulfill requests {}: {}", request_ids_string, e);
                     bail!("Failed to fulfill request: {}", e)
                 }
             }
@@ -1877,16 +1910,16 @@ mod tests {
         run(&MainArgs {
             config: config.clone(),
             command: Command::Proving(Box::new(ProvingCommands::Fulfill {
-                request_id,
-                request_digest: None,
-                tx_hash: None,
+                request_ids: vec![request_id],
+                request_digests: None,
+                tx_hashes: None,
                 order_stream_url: None,
             })),
         })
         .await
         .unwrap();
 
-        assert!(logs_contain(&format!("Successfully fulfilled request 0x{:x}", request.id)));
+        assert!(logs_contain(&format!("Successfully fulfilled requests 0x{:x}", request.id)));
 
         // test the Status command
         run(&MainArgs {
@@ -1926,6 +1959,55 @@ mod tests {
             "Successfully verified proof for request 0x{:x}",
             request.id
         )));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    #[ignore = "Generates a proof. Slow without RISC0_DEV_MODE=1"]
+    async fn test_proving_multiple_requests() {
+        let (ctx, _anvil, config) = setup_test_env(AccountOwner::Customer).await;
+
+        let mut request_ids = Vec::new();
+        for _ in 0..3 {
+            let request = generate_request(
+                ctx.customer_market.index_from_nonce().await.unwrap(),
+                &ctx.customer_signer.address(),
+            );
+
+            ctx.customer_market.submit_request(&request, &ctx.customer_signer).await.unwrap();
+            request_ids.push(request.id);
+        }
+
+        // test the Fulfill command
+        run(&MainArgs {
+            config: config.clone(),
+            command: Command::Proving(Box::new(ProvingCommands::Fulfill {
+                request_ids: request_ids.clone(),
+                request_digests: None,
+                tx_hashes: None,
+                order_stream_url: None,
+            })),
+        })
+        .await
+        .unwrap();
+
+        let request_ids_str =
+            request_ids.iter().map(|id| format!("0x{:x}", id)).collect::<Vec<_>>().join(", ");
+        assert!(logs_contain(&format!("Successfully fulfilled requests {request_ids_str}")));
+
+        for request_id in request_ids {
+            // test the Status command
+            run(&MainArgs {
+                config: config.clone(),
+                command: Command::Request(Box::new(RequestCommands::Status {
+                    request_id,
+                    expires_at: None,
+                })),
+            })
+            .await
+            .unwrap();
+            assert!(logs_contain(&format!("Request 0x{:x} status: Fulfilled", request_id)));
+        }
     }
 
     #[tokio::test]
@@ -1978,9 +2060,9 @@ mod tests {
         run(&MainArgs {
             config,
             command: Command::Proving(Box::new(ProvingCommands::Fulfill {
-                request_id: request.id,
-                request_digest: None,
-                tx_hash: None,
+                request_ids: vec![request.id],
+                request_digests: None,
+                tx_hashes: None,
                 order_stream_url: None,
             })),
         })
@@ -2032,9 +2114,9 @@ mod tests {
         run(&MainArgs {
             config,
             command: Command::Proving(Box::new(ProvingCommands::Fulfill {
-                request_id: request.id,
-                request_digest: None,
-                tx_hash: None,
+                request_ids: vec![request.id],
+                request_digests: None,
+                tx_hashes: None,
                 order_stream_url: None,
             })),
         })
@@ -2133,16 +2215,16 @@ mod tests {
         run(&MainArgs {
             config,
             command: Command::Proving(Box::new(ProvingCommands::Fulfill {
-                request_id,
-                request_digest: None,
-                tx_hash: None,
+                request_ids: vec![request_id],
+                request_digests: None,
+                tx_hashes: None,
                 order_stream_url: Some(order_stream_url),
             })),
         })
         .await
         .unwrap();
 
-        assert!(logs_contain(&format!("Successfully fulfilled request 0x{:x}", request.id)));
+        assert!(logs_contain(&format!("Successfully fulfilled requests 0x{:x}", request.id)));
 
         // Clean up
         order_stream_handle.abort();

--- a/crates/boundless-cli/src/bin/boundless-ffi.rs
+++ b/crates/boundless-cli/src/bin/boundless-ffi.rs
@@ -85,8 +85,8 @@ async fn main() -> Result<()> {
             Bytes::from_hex(args.signature.trim_start_matches("0x"))?.as_ref(),
         )?,
     };
-    let (fill, root_receipt, assessor_receipt) = prover.fulfill(order.clone()).await?;
-    let order_fulfilled = OrderFulfilled::new(fill, root_receipt, assessor_receipt)?;
+    let (fills, root_receipt, assessor_receipt) = prover.fulfill(&[order.clone()]).await?;
+    let order_fulfilled = OrderFulfilled::new(fills, root_receipt, assessor_receipt)?;
 
     // Forge test FFI calls expect hex encoded bytes sent to stdout
     write!(&mut stdout, "{}", hex::encode(order_fulfilled.abi_encode()))

--- a/crates/boundless-cli/src/lib.rs
+++ b/crates/boundless-cli/src/lib.rs
@@ -63,7 +63,7 @@ alloy::sol!(
 impl OrderFulfilled {
     /// Creates a new [OrderFulfilled],
     pub fn new(
-        fill: BoundlessFulfillment,
+        fills: Vec<BoundlessFulfillment>,
         root_receipt: Receipt,
         assessor_receipt: AssessorReceipt,
     ) -> Result<Self> {
@@ -75,7 +75,7 @@ impl OrderFulfilled {
         Ok(OrderFulfilled {
             root: <[u8; 32]>::from(root).into(),
             seal: root_seal.into(),
-            fills: vec![fill],
+            fills,
             assessorReceipt: assessor_receipt,
         })
     }
@@ -233,98 +233,109 @@ impl DefaultProver {
         self.prove(self.assessor_elf.clone(), stdin, receipts, ProverOpts::succinct()).await
     }
 
-    /// Fulfills an order as a singleton, returning the relevant data:
-    /// * The [Fulfillment] of the order.
+    /// Fulfills a list of orders, returning the relevant data:
+    /// * A list of [Fulfillment] of the orders.
     /// * The [Receipt] of the root set.
-    /// * The [SetInclusionReceipt] of the order.
     /// * The [SetInclusionReceipt] of the assessor.
     pub async fn fulfill(
         &self,
-        order: Order,
-    ) -> Result<(BoundlessFulfillment, Receipt, AssessorReceipt)> {
-        let request = order.request.clone();
-        let order_elf = fetch_url(&request.imageUrl).await?;
-        let order_input: Vec<u8> = match request.input.inputType {
-            InputType::Inline => GuestEnv::decode(&request.input.data)?.stdin,
-            InputType::Url => {
-                GuestEnv::decode(
-                    &fetch_url(
-                        std::str::from_utf8(&request.input.data)
-                            .context("input url is not utf8")?,
-                    )
-                    .await?,
-                )?
-                .stdin
-            }
-            _ => bail!("Unsupported input type"),
-        };
+        orders: &[Order],
+    ) -> Result<(Vec<BoundlessFulfillment>, Receipt, AssessorReceipt)> {
+        let mut fills = Vec::new();
+        let mut receipts = Vec::new();
+        let mut claims = Vec::new();
+        let mut claim_digests = Vec::new();
+        for order in orders.iter() {
+            let request = order.request.clone();
+            let order_elf = fetch_url(&request.imageUrl).await?;
+            let order_input: Vec<u8> = match request.input.inputType {
+                InputType::Inline => GuestEnv::decode(&request.input.data)?.stdin,
+                InputType::Url => {
+                    GuestEnv::decode(
+                        &fetch_url(
+                            std::str::from_utf8(&request.input.data)
+                                .context("input url is not utf8")?,
+                        )
+                        .await?,
+                    )?
+                    .stdin
+                }
+                _ => bail!("Unsupported input type"),
+            };
 
-        let selector = request.requirements.selector;
-        if !self.supported_selectors.is_supported(selector) {
-            bail!("Unsupported selector {}", request.requirements.selector);
-        };
+            let selector = request.requirements.selector;
+            if !self.supported_selectors.is_supported(selector) {
+                bail!("Unsupported selector {}", request.requirements.selector);
+            };
 
-        let order_receipt = self
-            .prove(order_elf.clone(), order_input.clone(), vec![], ProverOpts::succinct())
-            .await?;
+            let order_receipt = self
+                .prove(order_elf.clone(), order_input.clone(), vec![], ProverOpts::succinct())
+                .await?;
 
-        let order_journal = order_receipt.journal.bytes.clone();
-        let order_image_id = compute_image_id(&order_elf)?;
+            let order_journal = order_receipt.journal.bytes.clone();
+            let order_image_id = compute_image_id(&order_elf)?;
+            let order_claim = ReceiptClaim::ok(order_image_id, order_journal.clone());
+            let order_claim_digest = order_claim.digest();
 
-        let fill = Fulfillment {
-            request: order.request.clone(),
-            signature: order.signature.into(),
-            journal: order_journal.clone(),
-        };
+            let fill = Fulfillment {
+                request: order.request.clone(),
+                signature: order.signature.into(),
+                journal: order_journal.clone(),
+            };
 
-        let assessor_receipt = self.assessor(vec![fill], vec![order_receipt.clone()]).await?;
+            receipts.push(order_receipt.clone());
+            claims.push(order_claim.clone());
+            claim_digests.push(order_claim_digest);
+            fills.push(fill.clone());
+        }
+
+        let assessor_receipt = self.assessor(fills.clone(), receipts.clone()).await?;
         let assessor_journal = assessor_receipt.journal.bytes.clone();
         let assessor_image_id = compute_image_id(&self.assessor_elf)?;
-
-        let order_claim = ReceiptClaim::ok(order_image_id, order_journal.clone());
-        let order_claim_digest = order_claim.digest();
         let assessor_claim = ReceiptClaim::ok(assessor_image_id, assessor_journal.clone());
-        let assessor_claim_digest = assessor_claim.digest();
         let assessor_receipt_journal: AssessorJournal =
             AssessorJournal::abi_decode(&assessor_journal, true)?;
-        let root_receipt = self
-            .finalize(
-                vec![order_claim.clone(), assessor_claim.clone()],
-                vec![order_receipt.clone(), assessor_receipt],
-            )
-            .await?;
 
-        let order_path = merkle_path(&[order_claim_digest, assessor_claim_digest], 0);
-        let assessor_path = merkle_path(&[order_claim_digest, assessor_claim_digest], 1);
+        receipts.push(assessor_receipt);
+        claims.push(assessor_claim.clone());
+        claim_digests.push(assessor_claim.digest());
+
+        let root_receipt = self.finalize(claims.clone(), receipts.clone()).await?;
 
         let verifier_parameters =
             SetInclusionReceiptVerifierParameters { image_id: self.set_builder_image_id };
 
-        let order_inclusion_receipt = SetInclusionReceipt::from_path_with_verifier_params(
-            order_claim,
-            order_path,
-            verifier_parameters.digest(),
-        );
-        let order_seal = if is_groth16_selector(selector) {
-            let receipt = self.compress(&order_receipt).await?;
-            encode_seal(&receipt)?
-        } else {
-            order_inclusion_receipt.abi_encode_seal()?
-        };
+        let mut boundless_fills = Vec::new();
+
+        for (i, order) in orders.iter().enumerate() {
+            let order_inclusion_receipt = SetInclusionReceipt::from_path_with_verifier_params(
+                claims[i].clone(),
+                merkle_path(&claim_digests, i),
+                verifier_parameters.digest(),
+            );
+            let order_seal = if is_groth16_selector(order.request.requirements.selector) {
+                let receipt = self.compress(&receipts[i]).await?;
+                encode_seal(&receipt)?
+            } else {
+                order_inclusion_receipt.abi_encode_seal()?
+            };
+
+            let fulfillment = BoundlessFulfillment {
+                id: order.request.id,
+                requestDigest: order.request.eip712_signing_hash(&self.domain.alloy_struct()),
+                imageId: order.request.requirements.imageId,
+                journal: fills[i].journal.clone().into(),
+                seal: order_seal.into(),
+            };
+
+            boundless_fills.push(fulfillment);
+        }
 
         let assessor_inclusion_receipt = SetInclusionReceipt::from_path_with_verifier_params(
             assessor_claim,
-            assessor_path,
+            merkle_path(&claim_digests, claim_digests.len() - 1),
             verifier_parameters.digest(),
         );
-
-        let fulfillment = BoundlessFulfillment {
-            id: request.id,
-            requestDigest: order.request.eip712_signing_hash(&self.domain.alloy_struct()),
-            imageId: request.requirements.imageId,
-            journal: order_journal.into(),
-            seal: order_seal.into(),
-        };
 
         let assessor_receipt = AssessorReceipt {
             seal: assessor_inclusion_receipt.abi_encode_seal()?.into(),
@@ -333,7 +344,7 @@ impl DefaultProver {
             callbacks: assessor_receipt_journal.callbacks,
         };
 
-        Ok((fulfillment, root_receipt, assessor_receipt))
+        Ok((boundless_fills, root_receipt, assessor_receipt))
     }
 }
 
@@ -416,7 +427,7 @@ mod tests {
         .expect("failed to create prover");
 
         let order = Order { request, request_digest, signature };
-        prover.fulfill(order.clone()).await.unwrap();
+        prover.fulfill(&[order.clone()]).await.unwrap();
     }
 
     #[tokio::test]
@@ -436,6 +447,6 @@ mod tests {
         .expect("failed to create prover");
 
         let order = Order { request, request_digest, signature };
-        prover.fulfill(order.clone()).await.unwrap();
+        prover.fulfill(&[order.clone()]).await.unwrap();
     }
 }

--- a/documentation/site/pages/developers/tooling/cli.mdx
+++ b/documentation/site/pages/developers/tooling/cli.mdx
@@ -138,7 +138,7 @@ Checks the current in-market ETH balance for a given address (defaults to your a
 account balance [address]
 ```
 
-- `[address]` (optional) — The address to check. If omitted, uses the caller’s address.
+- `[address]` (optional) — The address to check. If omitted, uses the caller's address.
 
 **Example**:
 ```
@@ -198,7 +198,7 @@ The `request` subcommand is used to manage proof requests on the Boundless Marke
 
 #### 1. submit-offer
 
-Constructs and submits a proof request by reading a YAML offer definition, plus specifying guest ELF, input data, and additional requirements on the command line. This is effectively a “shortcut” for quickly submitting a structured request.
+Constructs and submits a proof request by reading a YAML offer definition, plus specifying guest ELF, input data, and additional requirements on the command line. This is effectively a "shortcut" for quickly submitting a structured request.
 
 **Syntax** (excerpt of key options):
 ```
@@ -217,12 +217,12 @@ request submit-offer [OPTIONS] <YAML_OFFER> [ID] [--wait] [--offchain] [--no-pre
 - `--input <STRING>` or `--input-file <PATH>`: data to feed the guest image.
 - `--encode-input`: if used, the input is encoded with `risc0_zkvm::serde`.
 - `--inline-input`: if used, the input is pushed onchain rather than stored offchain.
-- `--journal-digest <HEX>`: require the guest’s journal to match this digest.
-- `--journal-prefix <STRING>`: require the guest’s journal to start with these bytes.
+- `--journal-digest <HEX>`: require the guest's journal to match this digest.
+- `--journal-prefix <STRING>`: require the guest's journal to start with these bytes.
 - `--callback-address <ADDRESS> --callback-gas-limit <NUM>`: optional callback triggered upon proof success.
 - `--wait`: block until the proof request is fulfilled (or expires).
 - `--offchain`: submit the request offchain to an order-stream server (requires `--order-stream-url`).
-- `--no-preflight`: skip local “dry-run” execution of the guest.
+- `--no-preflight`: skip local "dry-run" execution of the guest.
 - `--proof-type <PROOF_TYPE>`: specify the proof type to request. This is a string that indicates the type of proof you want to generate for the request.
   - `any`: Any proof type
   - `groth16`: Groth16 proof type
@@ -233,7 +233,7 @@ request submit-offer [OPTIONS] <YAML_OFFER> [ID] [--wait] [--offchain] [--no-pre
 boundless-cli request submit-offer offer.yaml --elf guest.wasm \
   --input-file data.bin --journal-prefix "ABCDEF" --wait
 ```
-Submits a request reading the YAML from `offer.yaml`, providing `guest.wasm` as the ELF, `data.bin` as input, and requiring the journal to start with “ABCDEF”. It waits for fulfillment.
+Submits a request reading the YAML from `offer.yaml`, providing `guest.wasm` as the ELF, `data.bin` as input, and requiring the journal to start with "ABCDEF". It waits for fulfillment.
 
 
 ### 2. submit
@@ -249,7 +249,7 @@ request submit [OPTIONS] <YAML_REQUEST> [ID] [--wait] [--offchain] [--no-preflig
 - `id`: optional integer ID for the request (otherwise generated or from the YAML itself).
 - `--wait`: wait for fulfillment.
 - `--offchain`: submit to an order-stream server (requires `--order-stream-url`).
-- `--no-preflight`: skip local “dry-run” execution.
+- `--no-preflight`: skip local "dry-run" execution.
 - `--callback-address <ADDRESS> --callback-gas-limit <NUM>`: optional callback triggered upon proof success.
 - `--proof-type <PROOF_TYPE>`: specify the proof type to request. This is a string that indicates the type of proof you want to generate for the request.
   - `any`: Any proof type
@@ -263,14 +263,14 @@ boundless-cli request submit ./request.yaml --wait
 
 #### 3. status
 
-Shows the request status and whether it’s open, locked, fulfilled, or expired.
+Shows the request status and whether it's open, locked, fulfilled, or expired.
 
 **Syntax**:
 ```
 request status <REQUEST_ID> [expires_at]
 ```
 
-- `expires_at`: optional expiration timestamp (UNIX time). If omitted, uses the request’s known end time.
+- `expires_at`: optional expiration timestamp (UNIX time). If omitted, uses the request's known end time.
 
 **Example**:
 ```
@@ -313,7 +313,7 @@ The `proving` subcommand is used to execute guest code locally, lock and generat
 
 #### 1. execute
 
-Locally executes (without proving) the given request’s guest code, either from a YAML file or fetching from chain/offchain. Allows checking correctness prior to submission.
+Locally executes (without proving) the given request's guest code, either from a YAML file or fetching from chain/offchain. Allows checking correctness prior to submission.
 
 **Syntax**:
 ```
@@ -322,7 +322,7 @@ proving execute [--request-path <PATH> | --request-id <U256> [--tx-hash <HASH>] 
 ```
 - `--request-path`: path to a YAML file containing the request.
 - `--request-id`: the proof request identifier.
-- `--request-digest`: request’s EIP712 digest (optional).
+- `--request-digest`: request's EIP712 digest (optional).
 - `--tx-hash`: transaction hash (optional, to find the request).
 - `--order-stream-url`: fetch request data from an offchain server.
 
@@ -341,21 +341,30 @@ proving execute [--request-path <PATH> | --request-id <U256> [--tx-hash <HASH>] 
 
 #### 2. fulfill
 
-Generates a valid proof locally, then publishes the fulfillment onchain. This subcommand uses the RISC Zero default prover.
+Generates valid proofs locally for one or more requests, then publishes the fulfillments onchain. This subcommand uses the RISC Zero default prover and can process multiple requests in a single batch, which is more efficient than fulfilling requests individually.
 
 **Syntax**:
 ```
-proving fulfill --request-id <U256> [--request-digest <B256>] [--tx-hash <B256>]
+proving fulfill --request-ids <U256,...> [--request-digests <B256,...>] [--tx-hashes <B256,...>]
         [--order-stream-url <URL>]
 ```
-- `--request-id`: the proof request identifier.
-- `--request-digest`: request’s EIP712 digest (optional).
-- `--tx-hash`: transaction hash (optional, to find the request).
-- `--order-stream-url`: fetch request data from an offchain server.
+- `--request-ids`: comma-separated list of proof request identifiers (hex values)
+- `--request-digests`: comma-separated list of request EIP712 digests (optional, must match request_ids length and order)
+- `--tx-hashes`: comma-separated list of transaction hashes (optional, must match request_ids length and order)
+- `--order-stream-url`: fetch request data from an offchain server
 
-**Example**:
+**Examples**:
 ```
-boundless-cli proving fulfill --request-id 0x5...
+# Fulfill a single request
+boundless-cli proving fulfill --request-ids 0x5...
+
+# Fulfill multiple requests
+boundless-cli proving fulfill --request-ids 0x123,0x456,0x789
+
+# Fulfill multiple requests with digests and tx hashes
+boundless-cli proving fulfill --request-ids 0x123,0x456,0x789 \
+    --request-digests 0xabc,0xdef,0x012 \
+    --tx-hashes 0x111,0x222,0x333
 ```
 
 #### 3. lock
@@ -367,7 +376,7 @@ proving lock --request-id <U256> [--request-digest <B256>] [--tx-hash <B256>]
         [--order-stream-url <URL>]
 ```
 - `--request-id`: the proof request identifier.
-- `--request-digest`: request’s EIP712 digest (optional).
+- `--request-digest`: request's EIP712 digest (optional).
 - `--tx-hash`: transaction hash (optional, to find the request).
 - `--order-stream-url`: fetch request data from an offchain server.
 
@@ -383,7 +392,7 @@ The `ops` subcommand is used to manage operations on the Boundless Market. Curre
 
 #### 1. slash
 
-Slashes a prover for failing to meet obligations for a given request ID. Only the request’s buyer can slash.
+Slashes a prover for failing to meet obligations for a given request ID. Only the request's buyer can slash.
 
 **Syntax**:
 ```


### PR DESCRIPTION
Generates valid proofs locally for one or more requests, then publishes the fulfillments onchain. This subcommand uses the RISC Zero default prover and can process multiple requests in a single batch, which is more efficient than fulfilling requests individually.

**Syntax**:
```
proving fulfill --request-ids <U256,...> [--request-digests <B256,...>] [--tx-hashes <B256,...>]
        [--order-stream-url <URL>]
```
- `--request-ids`: comma-separated list of proof request identifiers (hex values)
- `--request-digests`: comma-separated list of request EIP712 digests (optional, must match request_ids length and order)
- `--tx-hashes`: comma-separated list of transaction hashes (optional, must match request_ids length and order)
- `--order-stream-url`: fetch request data from an offchain server

**Examples**:
```
# Fulfill a single request
boundless-cli proving fulfill --request-ids 0x5...

# Fulfill multiple requests
boundless-cli proving fulfill --request-ids 0x123,0x456,0x789

# Fulfill multiple requests with digests and tx hashes
boundless-cli proving fulfill --request-ids 0x123,0x456,0x789 \
    --request-digests 0xabc,0xdef,0x012 \
    --tx-hashes 0x111,0x222,0x333
```