### PR TITLE
BM-804: Fix simple gas estimation in order generator

### DIFF
--- a/crates/order-generator/src/bin/zeth.rs
+++ b/crates/order-generator/src/bin/zeth.rs
@@ -318,7 +318,7 @@ where
     // Add to the max price an estimated upper bound on the gas costs.
     // Add a 10% buffer to the gas costs to account for flucuations after submission.
     let gas_price: u128 = boundless_client.provider().get_gas_price().await?;
-    let gas_cost_estimate = gas_price + (gas_price / 10) * LOCK_FULFILL_GAS_UPPER_BOUND;
+    let gas_cost_estimate = (gas_price + (gas_price / 10)) * LOCK_FULFILL_GAS_UPPER_BOUND;
     let max_price = mcycle_max_price + U256::from(gas_cost_estimate);
     tracing::info!(
         "Setting a max price of {} ether: {} mcycle_price + {} gas_cost_estimate",

--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -221,7 +221,7 @@ async fn run(args: &MainArgs) -> Result<()> {
         // Note that the auction will allow us to pay the lowest price a prover will accept.
         // Add a 10% buffer to the gas costs to account for flucuations after submission.
         let gas_price: u128 = boundless_client.provider().get_gas_price().await?;
-        let gas_cost_estimate = gas_price + (gas_price / 10) * LOCK_FULFILL_GAS_UPPER_BOUND;
+        let gas_cost_estimate = (gas_price + (gas_price / 10)) * LOCK_FULFILL_GAS_UPPER_BOUND;
         let max_price = mcycle_max_price + U256::from(gas_cost_estimate);
         tracing::info!(
             "Setting a max price of {} ether: {} mcycle_price + {} gas_cost_estimate",


### PR DESCRIPTION
Missing parenthesis included in a last minute change that intended to add a 10% margin on gas price estimation resulted in reduction instead.
