### PR TITLE
BM-821: Bump prover builder pipeline memory

### DIFF
--- a/infra/pipelines/pipelines/prover.ts
+++ b/infra/pipelines/pipelines/prover.ts
@@ -207,7 +207,7 @@ export class ProverPipeline extends pulumi.ComponentResource {
       description: `Deployment for ${APP_NAME}`,
       serviceRole: role.arn,
       environment: {
-        computeType: "BUILD_GENERAL1_MEDIUM",
+        computeType: "BUILD_GENERAL1_LARGE",
         image: "aws/codebuild/standard:7.0",
         type: "LINUX_CONTAINER",
         privilegedMode: true,


### PR DESCRIPTION
Seeing `signal: 9, SIGKILL: kill` during compilation of the broker in the pipeline. This implies out of memory. Bumping the instance size.