### PR TITLE
BM-824: Create revision 2 EFS for prover

### DIFF
--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -78,7 +78,7 @@ export = () => {
   });
 
   // EFS
-  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs`, {
+  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev2`, {
     encrypted: true,
     tags: {
       Name: serviceName,


### PR DESCRIPTION
Rename EFS file system with `-rev2` tag to cause the Pulumi to recreate it in the code pipeline.