### PR TITLE
BM-828: Log error on image fetch fail

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -48,10 +48,10 @@ const ERC1271_MAX_GAS_FOR_CHECK: u64 = 100000;
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum PriceOrderErr {
-    #[error("failed to fetch / push input")]
+    #[error("failed to fetch / push input: {0}")]
     FetchInputErr(#[source] anyhow::Error),
 
-    #[error("failed to fetch / push image")]
+    #[error("failed to fetch / push image: {0}")]
     FetchImageErr(#[source] anyhow::Error),
 
     #[error("guest panicked: {0}")]


### PR DESCRIPTION
We've seen a few of these errors recently, but we're not logging the underlying error, so unclear if they are 500s or rate limiting. This should help debug