### PR TITLE
Revert "BM-744: Disable CD on order-stream (#494)"

### DIFF
--- a/infra/pipelines/pipelines/order-stream.ts
+++ b/infra/pipelines/pipelines/order-stream.ts
@@ -116,21 +116,13 @@ export class OrderStreamPipeline extends pulumi.ComponentResource {
         {
           name: "DeployStaging",
           actions: [
-            { name: "ApproveDeployToStaging", 
-              category: "Approval", 
-              owner: "AWS", 
-              provider: "Manual", 
-              version: "1", 
-              runOrder: 1,
-              configuration: {}
-            },
             {
               name: "DeployStaging",
               category: "Build",
               owner: "AWS",
               provider: "CodeBuild",
               version: "1",
-              runOrder: 2,
+              runOrder: 1,
               configuration: {
                 ProjectName: stagingDeployment.name
               },


### PR DESCRIPTION
Now that we handle order-stream outages in the prover, we should be safe to move back to CD.

This reverts commit fa277510fc08949472cb92f977a05fe8ed980a11.


