### PR TITLE
BM-835: Update Pulumi EFS volume name to `rev3` to recreate DB

### DIFF
--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -78,7 +78,7 @@ export = () => {
   });
 
   // EFS
-  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev2`, {
+  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev3`, {
     encrypted: true,
     tags: {
       Name: serviceName,


### PR DESCRIPTION
https://github.com/boundless-xyz/boundless/pull/542 includes breaking changes to the DB. In order to deploy this, we need to update the EFS volume name to trigger Pulumi to recreate it.
