### PR TITLE
BM-836: Update example `request.yaml` to 0.1 HP

### DIFF
--- a/request.yaml
+++ b/request.yaml
@@ -33,4 +33,4 @@ offer:
     rampUpPeriod: 300
     timeout: 3600 # 1 hor
     lockTimeout: 2700 # 45 minutes
-    lockStake: 5000000000000000000 # 5 HP tokens (set between 1 and 100)
+    lockStake: 100000000000000000 # 0.1 HP tokens (set between 0 and 100)


### PR DESCRIPTION
Current example uses 5 HP, which is higher than most or all of the provers on Sepolia use in their configs.
