### PR TITLE
BM-840: fix logic with estimation log and warn if broker behind

### DIFF
--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -546,22 +546,25 @@ where
         // Apply peak khz limit if specified
         if peak_prove_khz.is_some() && !orders_truncated.is_empty() {
             let peak_prove_khz = peak_prove_khz.unwrap();
-            let mut commited_orders = self.db.get_committed_orders().await?;
-            let num_commited_orders = commited_orders.len();
+            let committed_orders = self.db.get_committed_orders().await?;
+            let num_commited_orders = committed_orders.len();
             let total_commited_cycles =
-                commited_orders.iter().map(|order| order.total_cycles.unwrap()).sum::<u64>();
+                committed_orders.iter().map(|order| order.total_cycles.unwrap()).sum::<u64>();
 
             let now = now_timestamp();
             // Estimate the time the prover will be available given our current committed orders.
-            commited_orders.sort_by_key(|order| order.proving_started_at);
-            let started_proving_at = if !commited_orders.is_empty() {
-                commited_orders[0].proving_started_at.unwrap()
-            } else {
-                now
-            };
+            let started_proving_at = committed_orders
+                .iter()
+                .map(|order| order.proving_started_at.unwrap())
+                .min()
+                .unwrap_or(now);
 
             let proof_time_seconds = total_commited_cycles.div_ceil(1_000).div_ceil(peak_prove_khz);
             let mut prover_available_at = started_proving_at + proof_time_seconds;
+            if prover_available_at < now {
+                tracing::warn!("Proofs are behind what is estimated from peak_prove_khz config. Consider lowering this value to avoid overlocking orders.");
+                prover_available_at = now;
+            }
             tracing::debug!("Already committed to {} orders, with a total cycle count of {}, a peak khz limit of {}, started working on them at {}, we estimate the prover will be available in {} seconds", 
                 num_commited_orders,
                 total_commited_cycles,

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -447,7 +447,7 @@ where
                     .set_order_status(&order.id(), OrderStatus::Skipped)
                     .await
                     .context("Failed to set order status to skipped")?;
-            } else if order.request.expires_at() - now < min_deadline {
+            } else if order.request.expires_at().saturating_sub(now) < min_deadline {
                 tracing::debug!("Request {:x} deadline at {} is less than the minimum deadline {} seconds required to prove an order. Skipping.", order.request.id, order.request.expires_at(), min_deadline);
                 self.db
                     .set_order_status(&order.id(), OrderStatus::Skipped)
@@ -570,7 +570,7 @@ where
                 total_commited_cycles,
                 peak_prove_khz,
                 started_proving_at,
-                prover_available_at - now
+                prover_available_at.saturating_sub(now),
             );
 
             // For each order in consideration, check if it can be completed before its expiration.

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -228,7 +228,7 @@ where
         };
 
         // Does the order expire within the min deadline
-        let seconds_left = expiration - now;
+        let seconds_left = expiration.saturating_sub(now);
         if seconds_left <= min_deadline {
             tracing::info!("Removing order with request id {request_id:x} because it expires within min_deadline: {seconds_left}, min_deadline: {min_deadline}");
             return Ok(Skip);
@@ -737,7 +737,7 @@ where
     async fn available_stake_balance(&self) -> Result<U256> {
         let balance = self.market.balance_of_stake(self.provider.default_signer_address()).await?;
         let pending_balance = self.pending_locked_stake().await?;
-        Ok(balance - pending_balance)
+        Ok(balance.saturating_sub(pending_balance))
     }
 
     async fn spawn_pricing_tasks(&self, tasks: &mut JoinSet<bool>, capacity: u32) -> Result<()> {


### PR DESCRIPTION
There was an underflow in the log if the estimation is before the current time. This seems like a reasonable place to warn, as it indicates that the broker may overlock orders. Possibly could be noisy if tuned tightly, but airing on the side of caution. Happy to only warn if above a margin of error also