### PR TITLE
BM-870: Remove order picker trace logging from deployed prover

### DIFF
--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -349,7 +349,7 @@ export = () => {
         ],
         environment: [
           { name: 'NO_COLOR', value: '1' },
-          { name: 'RUST_LOG', value: 'broker=debug,boundless_market=debug,broker::order_picker=trace' },
+          { name: 'RUST_LOG', value: 'broker=debug,boundless_market=debug' },
           { name: 'RUST_BACKTRACE', value: '1' },
           { name: 'BONSAI_API_URL', value: bonsaiApiUrl },
           { name: 'BUCKET', value: brokerS3BucketName }


### PR DESCRIPTION
`order_picker=trace` was added to debug an issue, and is no longer needed.