### PR TITLE
BM-873: Fix typos in contracts/scripts and examples README files

### DIFF
--- a/contracts/scripts/README.md
+++ b/contracts/scripts/README.md
@@ -26,7 +26,7 @@ Configurations and deployment state information is stored in `deployment.toml`.
 It contains information about each chain (e.g. name, ID, Etherscan URL), and addresses for the RISC Zero verifier and Boundless market contracts on each chain.
 
 Accompanying the `deployment.toml` file is a `deployment_secrets.toml` file with the following schema.
-It is used to store somewhat sensative API keys for RPC services and Etherscan.
+It is used to store somewhat sensitive API keys for RPC services and Etherscan.
 Note that it does not contain private keys or API keys for Fireblocks.
 It should never be committed to `git`, and the API keys should be rotated if this occurs.
 

--- a/examples/smart-contract-requestor/README.md
+++ b/examples/smart-contract-requestor/README.md
@@ -16,7 +16,7 @@ See `contracts/src/SmartContractClient.sol` for the client logic that validates 
 ### Entities
 
 - Request Builder
-  - Responsible for building the proof request and submitting it to the market. This is a fully permissionless role. Request builders are expected to be incentivized to fufill this role outside of the Boundless protocol.
+  - Responsible for building the proof request and submitting it to the market. This is a fully permissionless role. Request builders are expected to be incentivized to fulfill this role outside of the Boundless protocol.
 - Smart Contract Requestor
   - An ERC-1271 contract that contains the logic for authorizing a proof request, and has deposited funds to Boundless Market for fulfilling requests.
 - Provers


### PR DESCRIPTION
This PR fixes minor typos in the following README files:

- contracts/scripts/README.md

- examples/smart-contract-requestor/README.md

Includes replacement of the typo "sensative" with "sensitive", "fufill" with "fulfill".
