### PR TITLE
BM-874: Modify invalid links

### DIFF
--- a/documentation/site/pages/developers/steel/how-it-works.mdx
+++ b/documentation/site/pages/developers/steel/how-it-works.mdx
@@ -140,7 +140,7 @@ Aggregation is a key feature of [Boundless][boundless-website]
 
 [boundless-website]: https://beboundless.xyz/
 
-[sol-macro]: https://alloy.rs/examples/sol-macro/index.html
+[sol-macro]: https://alloy.rs/examples/sol-macro/README/
 [here]: https://github.com/risc0/risc0-ethereum/blob/main/examples/erc20-counter
 [guest program]: https://dev.risczero.com/terminology#guest-program
 [revm]: https://docs.rs/revm/latest/revm/

--- a/documentation/site/pages/developers/tutorials/request.mdx
+++ b/documentation/site/pages/developers/tutorials/request.mdx
@@ -232,7 +232,7 @@ let (request_id, expires_at) = boundless_client.submit_request_with_signer(&requ
 
 Similarly, using `boundless_client.submit_request_offchain_with_signer`, will send your request offchain through the order-stream service.
 
-> Relevant links: [Signers supported by alloy](https://alloy.rs/examples/wallets/index.html)
+> Relevant links: [Signers supported by alloy](https://alloy.rs/examples/wallets/README)
 
 ### 7. Wait for the Request to Be Fulfilled
 

--- a/documentation/site/pages/developers/tutorials/use.mdx
+++ b/documentation/site/pages/developers/tutorials/use.mdx
@@ -51,7 +51,7 @@ let (journal, seal) = boundless_client
 ```
 </StripRustCodeComments>
 
-Using Alloys [sol! Macro](https://alloy.rs/examples/sol-macro/index.html), the rust types/bindings are generated for the [`EvenNumber.sol`](https://github.com/boundless-xyz/boundless-foundry-template/blob/main/contracts/src/EvenNumber.sol) contract.
+Using Alloys [sol! Macro](https://alloy.rs/examples/sol-macro/README), the rust types/bindings are generated for the [`EvenNumber.sol`](https://github.com/boundless-xyz/boundless-foundry-template/blob/main/contracts/src/EvenNumber.sol) contract.
 To create an `EvenNumber` contract instance:
 
 <StripRustCodeComments>


### PR DESCRIPTION
This PR Fix the bronken links from "use.mdx", "how-it-works.mdx", and "request.mdx" file.

- sol-macro: "https://alloy.rs/examples/sol-macro/index.html" is invalid. "https://alloy.rs/examples/sol-macro/README/" is right. which is the 'index' page.

- Signers supported by alloy: "https://alloy.rs/examples/wallets/index.html" is invalid. "https://alloy.rs/examples/wallets/README" is right. It is 'index' page too.
