### PR TITLE
BM-874: Remove lock failed alarms, lower hyper_util log level

### DIFF
--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -556,14 +556,6 @@ export = () => {
     threshold: 3,
   }, { period: 300 });
 
-  // If we fail to lock an order because the tx fails for some reason, SEV2.
-  createErrorCodeAlarm('"[B-OM-007]"', 'order-monitor-lock-tx-failed', Severity.SEV2);
-
-  // If we fail to lock an order 3 times because another prover locked before us, SEV2.
-  createErrorCodeAlarm('"[B-OM-009]"', 'order-monitor-already-locked', Severity.SEV2, {
-    threshold: 3,
-  }, { period: 3600 });
-
   // If we fail to lock an order because we don't have enough stake balance, SEV2.
   createErrorCodeAlarm('"[B-OM-010]"', 'order-monitor-insufficient-balance', Severity.SEV2);
 

--- a/infra/slasher/Pulumi.prod.yaml
+++ b/infra/slasher/Pulumi.prod.yaml
@@ -10,7 +10,7 @@ config:
   slasher:DOCKER_DIR: ../../
   slasher:DOCKER_TAG: latest
   slasher:INTERVAL: "60"
-  slasher:LOG_LEVEL: debug
+  slasher:LOG_LEVEL: "debug,hyper_util=info"
   slasher:RETRIES: "5"
   slasher:SKIP_ADDRESSES: ""
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic

--- a/infra/slasher/Pulumi.staging.yaml
+++ b/infra/slasher/Pulumi.staging.yaml
@@ -10,7 +10,7 @@ config:
   slasher:DOCKER_DIR: ../../
   slasher:DOCKER_TAG: latest
   slasher:INTERVAL: "60"
-  slasher:LOG_LEVEL: debug
+  slasher:LOG_LEVEL: "debug,hyper_util=info"
   slasher:RETRIES: "5"
   slasher:SKIP_ADDRESSES: ""
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic


### PR DESCRIPTION
Lock Failed Alarms: Both these are expected when someone else beats us to locking the request. No need to alert on them.

re: hyper_util, I moved the slasher logging to debug to debug the SQL issue. On debug mode hyper_util logs "error" when a connection is closed, which triggers our alarms, so moving it back to info.