### PR TITLE
BM-882: Catch locked already error from sdk, fix error codes in submitter

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -77,6 +77,10 @@ pub enum MarketError {
     #[error("Request not found in event logs 0x{0:x}")]
     RequestNotFound(U256),
 
+    /// Request already locked.
+    #[error("Request already locked: 0x{0:x}")]
+    RequestAlreadyLocked(U256),
+
     /// Lock request reverted, possibly outbid.
     #[error("Lock request reverted, possibly outbid: txn_hash: {0}")]
     LockRevert(B256),
@@ -378,7 +382,7 @@ impl<P: Provider> BoundlessMarketService<P> {
         let is_locked_in: bool =
             self.instance.requestIsLocked(request.id).call().await.context("call failed")?._0;
         if is_locked_in {
-            return Err(MarketError::Error(anyhow!("request is already locked")));
+            return Err(MarketError::RequestAlreadyLocked(request.id));
         }
 
         tracing::trace!("Calling lockRequest({:x?}, {:x?})", request, client_sig);
@@ -443,7 +447,7 @@ impl<P: Provider> BoundlessMarketService<P> {
         let is_locked_in: bool =
             self.instance.requestIsLocked(request.id).call().await.context("call failed")?._0;
         if is_locked_in {
-            return Err(MarketError::Error(anyhow!("request is already locked-in")));
+            return Err(MarketError::RequestAlreadyLocked(request.id));
         }
 
         tracing::trace!(

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -222,6 +222,7 @@ where
             .await
             .map_err(|e| -> OrderMonitorErr {
                 match e {
+                    MarketError::RequestAlreadyLocked(_e) => OrderMonitorErr::AlreadyLocked,
                     MarketError::LockRevert(e) => {
                         OrderMonitorErr::LockTxFailed(format!("Tx hash 0x{:x}", e))
                     }


### PR DESCRIPTION
* The SDK also does a check if the request is locked which was not caught in the prover, meaning it triggers alarms. Now we map this error to a known error.
* The error codes in the submitter were not being rendered correctly. Also changed some logs to warning since we retry submission. Now we only error log after the retries all fail so they don't trigger alarms