### PR TITLE
BM-891: multiply anvil gas estimates in testing contexts

### DIFF
--- a/examples/composition/apps/src/main.rs
+++ b/examples/composition/apps/src/main.rs
@@ -316,7 +316,7 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 1800; // 30 minutes

--- a/examples/composition/apps/src/main.rs
+++ b/examples/composition/apps/src/main.rs
@@ -316,7 +316,8 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) =
+            BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 1800; // 30 minutes

--- a/examples/counter-with-callback/apps/src/main.rs
+++ b/examples/counter-with-callback/apps/src/main.rs
@@ -229,7 +229,8 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) =
+            BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 600; // 10 minutes

--- a/examples/counter-with-callback/apps/src/main.rs
+++ b/examples/counter-with-callback/apps/src/main.rs
@@ -229,7 +229,7 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 600; // 10 minutes

--- a/examples/counter/apps/src/main.rs
+++ b/examples/counter/apps/src/main.rs
@@ -275,7 +275,8 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) =
+            BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 600; // 10 minutes

--- a/examples/counter/apps/src/main.rs
+++ b/examples/counter/apps/src/main.rs
@@ -275,7 +275,7 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker.
-        let (broker, _) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 600; // 10 minutes

--- a/examples/smart-contract-requestor/apps/src/main.rs
+++ b/examples/smart-contract-requestor/apps/src/main.rs
@@ -303,7 +303,8 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker
-        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) =
+            BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 300; // 5 minutes

--- a/examples/smart-contract-requestor/apps/src/main.rs
+++ b/examples/smart-contract-requestor/apps/src/main.rs
@@ -303,7 +303,7 @@ mod tests {
         let mut tasks = JoinSet::new();
 
         // Start a broker
-        let (broker, _) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
+        let (broker, _config) = BrokerBuilder::new_test(&ctx, anvil.endpoint_url()).await.build().await?;
         tasks.spawn(async move { broker.start_service().await });
 
         const TIMEOUT_SECS: u64 = 300; // 5 minutes


### PR DESCRIPTION
Not quite ideal to have different gas estimation logic for testing, but currently unclear if based around anvil or if there is some edge case that can be hit that changes the gas usage. This is a stop-gap to avoid random failures in tests, as this has not been seen outside of tests yet. 👀 

Also changes the invocations of `BrokerBuilder::new_test` to keep around the config file handle so it isn't dropped and causes error logs within the tests.