### PR TITLE
BM-899: Chain monitor RPC errors as known. Order monitor txn confirmation errors as known.

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -82,17 +82,9 @@ pub enum MarketError {
     #[error("Request not found in event logs 0x{0:x}")]
     RequestNotFound(U256),
 
-    /// Request lock has expired.
-    #[error("Request lock expired at {1}: 0x{0:x}")]
-    RequestLockHasExpired(U256, u64),
-
     /// Request already locked.
     #[error("Request already locked: 0x{0:x}")]
     RequestAlreadyLocked(U256),
-
-    /// Request already locked.
-    #[error("Request already fulfilled: 0x{0:x}")]
-    RequestAlreadyFulfilled(U256),
 
     /// Lock request reverted, possibly outbid.
     #[error("Lock request reverted, possibly outbid: txn_hash: {0}")]

--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -27,6 +27,7 @@ use alloy::{
     rpc::types::{Log, TransactionReceipt},
     signers::Signer,
 };
+
 use alloy_sol_types::{SolCall, SolEvent};
 use anyhow::{anyhow, Context, Result};
 use risc0_ethereum_contracts::event_query::EventQueryConfig;
@@ -53,6 +54,10 @@ pub enum MarketError {
     #[error("Transaction error: {0}")]
     TxnError(#[from] TxnErr),
 
+    /// Transaction confirmation error.
+    #[error("Transaction confirmation error: {0:?}")]
+    TxnConfirmationError(anyhow::Error),
+
     /// Request not fulfilled.
     #[error("Request is not fulfilled 0x{0:x}")]
     RequestNotFulfilled(U256),
@@ -77,9 +82,17 @@ pub enum MarketError {
     #[error("Request not found in event logs 0x{0:x}")]
     RequestNotFound(U256),
 
+    /// Request lock has expired.
+    #[error("Request lock expired at {1}: 0x{0:x}")]
+    RequestLockHasExpired(U256, u64),
+
     /// Request already locked.
     #[error("Request already locked: 0x{0:x}")]
     RequestAlreadyLocked(U256),
+
+    /// Request already locked.
+    #[error("Request already fulfilled: 0x{0:x}")]
+    RequestAlreadyFulfilled(U256),
 
     /// Lock request reverted, possibly outbid.
     #[error("Lock request reverted, possibly outbid: txn_hash: {0}")]
@@ -469,10 +482,7 @@ impl<P: Provider> BoundlessMarketService<P> {
         let receipt = self.get_receipt_with_retry(pending_tx).await?;
         if !receipt.status() {
             // TODO: Get + print revertReason
-            return Err(MarketError::Error(anyhow!(
-                "lockRequestWithSignature failed [{}], possibly outbid",
-                receipt.transaction_hash
-            )));
+            return Err(MarketError::LockRevert(receipt.transaction_hash));
         }
 
         tracing::info!(
@@ -513,13 +523,12 @@ impl<P: Provider> BoundlessMarketService<P> {
                 )
                 .into())
             }
-            Err(e) => Err(anyhow!(
+            Err(e) => Err(MarketError::TxnConfirmationError(anyhow!(
                 "failed to confirm tx {:?} within timeout {:?}: {}",
                 tx_hash,
                 self.timeout,
                 e
-            )
-            .into()),
+            ))),
         }
     }
 

--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -496,6 +496,13 @@ export = () => {
   //
   // Chain Monitor
   //
+  
+  // RPC errors can occur transiently. 
+  // If we see 5 rpc errors within 1 hour in the chain monitor trigger a SEV2 alarm to investigate.
+  createErrorCodeAlarm('"[B-CHM-400]"', 'chain-monitor-rpc-error', Severity.SEV2, {
+    threshold: 5,
+  }, { period: 3600 });
+
   // Any 1 unexpected error in the on-chain market monitor triggers a SEV2 alarm.
   createErrorCodeAlarm('"[B-CHM-500]"', 'chain-monitor-unexpected-error', Severity.SEV2);
 
@@ -558,6 +565,12 @@ export = () => {
 
   // If we fail to lock an order because we don't have enough stake balance, SEV2.
   createErrorCodeAlarm('"[B-OM-010]"', 'order-monitor-insufficient-balance', Severity.SEV2);
+
+  // 3 lock tx not confirmed errors within 1 hour in the order monitor triggers a SEV2 alarm.
+  // This may indicate a misconfiguration of the tx timeout config.
+  createErrorCodeAlarm('"[B-OM-006]"', 'order-monitor-lock-tx-not-confirmed', Severity.SEV2, { 
+    threshold: 3,
+  }, { period: 3600 });
 
   //
   // Prover


### PR DESCRIPTION
Moves RPC errors in the chain monitor to known, and tx confirmation errors to known.

Both these errors will happen occasionally transiently. We only need to be alerted if they are happening frequently