### PR TITLE
Adjust error threshold for supervisor restarts, map contract reverts for lock request

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -18,6 +18,7 @@ use std::{
     time::Duration,
 };
 
+use crate::contracts::IBoundlessMarket::IBoundlessMarketErrors;
 use alloy::{
     consensus::{BlockHeader, Transaction},
     eips::BlockNumberOrTag,
@@ -65,6 +66,18 @@ pub enum MarketError {
     /// Request has expired.
     #[error("Request has expired 0x{0:x}")]
     RequestHasExpired(U256),
+
+    /// Request lock has expired.
+    #[error("Request lock has expired 0x{0:x}")]
+    RequestLockHasExpired(U256),
+
+    /// Request has been fulfilled.
+    #[error("Request has been fulfilled 0x{0:x}")]
+    RequestAlreadyFulfilled(U256),
+
+    /// Insufficient balance.
+    #[error("Insufficient balance 0x{0:x}")]
+    InsufficientBalance(Address),
 
     /// Request malformed.
     #[error("Request error {0}")]
@@ -410,7 +423,29 @@ impl<P: Provider> BoundlessMarketService<P> {
 
         tracing::trace!("Sending tx {}", format!("{:?}", call));
 
-        let pending_tx = call.send().await?;
+        let pending_tx = call.send().await.map_err(|e: alloy::contract::Error| {
+            let txn_err = MarketError::TxnError(TxnErr::from(e));
+            match txn_err {
+                MarketError::TxnError(TxnErr::BoundlessMarketErr(boundless_err)) => {
+                    match boundless_err {
+                        IBoundlessMarketErrors::RequestIsLocked(_) => {
+                            MarketError::RequestAlreadyLocked(request.id)
+                        }
+                        IBoundlessMarketErrors::RequestIsFulfilled(_) => {
+                            MarketError::RequestAlreadyFulfilled(request.id)
+                        }
+                        IBoundlessMarketErrors::RequestLockIsExpired(_) => {
+                            MarketError::RequestLockHasExpired(request.id)
+                        }
+                        IBoundlessMarketErrors::InsufficientBalance(address) => {
+                            MarketError::InsufficientBalance(address.account)
+                        }
+                        _ => MarketError::TxnError(TxnErr::BoundlessMarketErr(boundless_err)),
+                    }
+                }
+                _ => txn_err,
+            }
+        })?;
 
         let tx_hash = *pending_tx.tx_hash();
         tracing::trace!("Broadcasting tx {}", tx_hash);
@@ -467,7 +502,29 @@ impl<P: Provider> BoundlessMarketService<P> {
             .instance
             .lockRequestWithSignature(request.clone(), client_sig.clone(), prover_sig.clone())
             .from(self.caller);
-        let pending_tx = call.send().await.context("Failed to lock")?;
+        let pending_tx = call.send().await.map_err(|e: alloy::contract::Error| {
+            let txn_err = MarketError::TxnError(TxnErr::from(e));
+            match txn_err {
+                MarketError::TxnError(TxnErr::BoundlessMarketErr(boundless_err)) => {
+                    match boundless_err {
+                        IBoundlessMarketErrors::RequestIsLocked(_) => {
+                            MarketError::RequestAlreadyLocked(request.id)
+                        }
+                        IBoundlessMarketErrors::RequestIsFulfilled(_) => {
+                            MarketError::RequestAlreadyFulfilled(request.id)
+                        }
+                        IBoundlessMarketErrors::RequestLockIsExpired(_) => {
+                            MarketError::RequestLockHasExpired(request.id)
+                        }
+                        IBoundlessMarketErrors::InsufficientBalance(address) => {
+                            MarketError::InsufficientBalance(address.account)
+                        }
+                        _ => MarketError::TxnError(TxnErr::BoundlessMarketErr(boundless_err)),
+                    }
+                }
+                _ => txn_err,
+            }
+        })?;
 
         tracing::trace!("Broadcasting tx {}", pending_tx.tx_hash());
 

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -227,6 +227,15 @@ where
             .map_err(|e| -> OrderMonitorErr {
                 match e {
                     MarketError::RequestAlreadyLocked(_e) => OrderMonitorErr::AlreadyLocked,
+                    MarketError::RequestLockHasExpired(_e) => {
+                        OrderMonitorErr::LockTxFailed(e.to_string())
+                    }
+                    MarketError::RequestAlreadyFulfilled(_e) => {
+                        OrderMonitorErr::LockTxFailed(e.to_string())
+                    }
+                    MarketError::InsufficientBalance(_e) => {
+                        OrderMonitorErr::LockTxFailed(e.to_string())
+                    }
                     MarketError::TxnConfirmationError(e) => {
                         OrderMonitorErr::LockTxNotConfirmed(e.to_string())
                     }

--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -434,9 +434,9 @@ export = () => {
   
   // Alarms at the supervisor level
   //
-  // 2 supervisor restarts within 15 mins triggers a SEV2 alarm
+  // 5 supervisor restarts within 15 mins triggers a SEV2 alarm
   createErrorCodeAlarm('"[B-SUP-RECOVER]"', 'supervisor-recover-errors', Severity.SEV2, {
-    threshold: 2,
+    threshold: 5,
   }, { period: 900 });
 
   // 1 supervisor fault triggers a SEV2 alarm


### PR DESCRIPTION
Currently 2 supervisor restarts triggers a sev2. It seems a single RPC blip causes minimum 2 supervisors to restart, so raising the threshold so we are only alerted if we see multiple RPC issues.

Also a fix to map contract transaction errors to known errors in the order monitor