### PR TITLE
Backport "BM-880: Handle double event delivery in RequestSubmitted and RequestLocked (#612)" to release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "alloy-primitives 0.8.25",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-indexer"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "alloy-primitives 0.8.25",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "alloy-primitives 0.8.25",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-order-generator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-slasher"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "alloy-chains",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "broker-stress"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "doc-test"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "alloy-primitives 0.8.25",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6781,7 +6781,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "order-stream"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy 0.12.6",
  "anyhow",

--- a/crates/guest/assessor/assessor-guest/Cargo.lock
+++ b/crates/guest/assessor/assessor-guest/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/examples/composition/Cargo.lock
+++ b/examples/composition/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/counter-with-callback/Cargo.lock
+++ b/examples/counter-with-callback/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/smart-contract-requestor/Cargo.lock
+++ b/examples/smart-contract-requestor/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "hex",
  "risc0-build",


### PR DESCRIPTION
Event delivery has at least once semantics. This was handled for
RequestSubmitted event, but not for RequestLocked or RequestFulfilled.


