### PR TITLE
BM-911: Add RUSTFLAGS=-Dwarnings in justfile to mirror CI

### DIFF
--- a/justfile
+++ b/justfile
@@ -102,15 +102,25 @@ check-format:
 
 # Run Cargo clippy
 check-clippy:
-    RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
+    RUSTFLAGS=-Dwarnings RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
     cargo clippy --workspace --all-targets -F boundless-order-generator/zeth
-    cd examples/counter && forge build && RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
+
+    cd examples/counter && forge build && \
+    RUSTFLAGS=-Dwarnings RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
     cargo clippy --workspace --all-targets
-    cd examples/composition && forge build && RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
+
+    cd examples/composition && forge build && \
+    RUSTFLAGS=-Dwarnings RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
     cargo clippy --workspace --all-targets
-    cd examples/counter-with-callback && forge build && RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
+
+    cd examples/counter-with-callback && \
+    forge build && \
+    RUSTFLAGS=-Dwarnings RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
     cargo clippy --workspace --all-targets
-    cd examples/smart-contract-requestor && forge build && RISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
+
+    cd examples/smart-contract-requestor && \
+    forge build && \
+    RUSTFLAGS=-Dwarnings ISC0_SKIP_BUILD=1 RISC0_SKIP_BUILD_KERNEL=1 \
     cargo clippy --workspace --all-targets
 
 # Format all code


### PR DESCRIPTION
I realized that `just check` does not always error on issues that will fail on the `clippy` job in CI. This PR adds the `RUSTFLAGS=-Dwarnings` flag to the `justfile` to mirror CI.