### PR TITLE
Split RPC keys, add alarm to monitor lambda, move insufficient requestor balance to known error

### DIFF
--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -125,6 +125,7 @@ pub struct OrderMonitor<P> {
     config: ConfigLock,
     market: BoundlessMarketService<Arc<P>>,
     provider: Arc<P>,
+    prover_addr: Address,
     capacity_debug_log: String,
 }
 
@@ -138,6 +139,7 @@ where
         chain_monitor: Arc<ChainMonitorService<P>>,
         config: ConfigLock,
         block_time: u64,
+        prover_addr: Address,
         market_addr: Address,
     ) -> Result<Self> {
         let txn_timeout_opt = {
@@ -178,6 +180,7 @@ where
             config,
             market,
             provider,
+            prover_addr,
             capacity_debug_log: "".to_string(),
         })
     }
@@ -247,8 +250,20 @@ where
                         OrderMonitorErr::LockTxFailed(format!("Tx hash 0x{:x}", e))
                     }
                     MarketError::Error(e) => {
+                        // Insufficient balance error is thrown both when the requestor has insufficient balance,
+                        // Requestor having insufficient balance can happen and is out of our control. The prover
+                        // having insufficient balance is unexpected as we should have checked for that before committing to locking the order.
+                        let prover_addr_str =
+                            self.prover_addr.to_string().to_lowercase().replace("0x", "");
                         if e.to_string().contains("InsufficientBalance") {
-                            OrderMonitorErr::InsufficientBalance
+                            if e.to_string().contains(prover_addr_str) {
+                                OrderMonitorErr::InsufficientBalance
+                            } else {
+                                OrderMonitorErr::LockTxFailed(format!(
+                                    "Requestor has insufficient balance: {}",
+                                    e
+                                ))
+                            }
                         } else {
                             OrderMonitorErr::UnexpectedError(e)
                         }

--- a/infra/indexer/Pulumi.prod-11155111.yaml
+++ b/infra/indexer/Pulumi.prod-11155111.yaml
@@ -6,12 +6,13 @@ config:
   indexer:BOUNDLESS_ADDRESS: 0x006b92674E2A8d397884e293969f8eCD9f615f4C
   indexer:DOCKER_DIR: ../../
   indexer:DOCKER_TAG: latest
-  indexer:START_BLOCK: 8137095
+  indexer:START_BLOCK: "8137095"
   indexer:ETH_RPC_URL:
-    secure: v1:0j7+fwrATMUU0iT8:73Z27jloXVVuJTghk7ZHOpdO1MfONU/Mm2V6jPfnMRzw5mgWtuuMLeRs1QL9K5gm7dwFvacajUyEFB56r/W49iiD7m5wkH4KOeYFt9ZoDCLgeaEQlQ==
+    secure: v1:I5G1si5T9viPY+ag:ENBXAsoaKSNMEbod6/TssBys7PC5WpLCAwP3TvLAOy1QsFODZrUnLBXAtzy+cPqKqzELezj1v/8G5v124XrbM66n+rmapydJ9YrDu0VaiPotkdrdhg==
   indexer:RDS_PASSWORD:
     secure: v1:6OldikDHGPtFsshU:3tg0ETBuoOsjoCnrxja5zQnWyaGOSvtIsNEIjH2uu7tvuA==
   indexer:CHAIN_ID: "11155111"
   indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:LfbDb8lBoozxHg+u:MSyFlUK/ayFKEXiZ2fvJuuTehwJeQBWsq4FruaZCOkxtxMpVwZnZ0frKzsLXN5UD8NRPNWC/NSfTu9oq4onmDcnn/XULgsiJerGtpuJNvjqjAwuG6GEZM61S1zoEgvI0My09F57JH7jV3OfLAQ==
+  indexer:RUST_LOG: debug

--- a/infra/indexer/Pulumi.staging.yaml
+++ b/infra/indexer/Pulumi.staging.yaml
@@ -6,12 +6,13 @@ config:
   indexer:BOUNDLESS_ADDRESS: 0x2d124b86179F0De2d5B7A75E4dcD7e35a3363B16
   indexer:DOCKER_DIR: ../../
   indexer:DOCKER_TAG: latest
-  indexer:START_BLOCK: 8038641
+  indexer:START_BLOCK: "8038641"
   indexer:ETH_RPC_URL:
-    secure: v1:D0LPseptkWMnYnOv:wW8eWtEA5HHwiJ7xc4RJIHWHCpEmcSAq8OHMeMk0HSYnZpLQXMuax6MqgFQBIzlNWkJKTCTaBw98Oj6TfUvnA8hC0Ub9NJejUHnJdzgKrEL3tscP7g==
+    secure: v1:k1yy++VLVeDHpj1p:SKUw1hSwX7mMDOhQjf+C4Bs5ZpgXL8cnkg0ZG3qLRIwQ4fS9UWh6ETnVxOUEZalQgDTHHhdB/ndPQd3BOrmAROeWZNrwFRDsVdceUZNHwkPuOKPbjw==
   indexer:RDS_PASSWORD:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
   indexer:CHAIN_ID: "11155111"
   indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:D7aNTgIv8gY4epbh:mKyCvgukF7lPd76Gt36t/dIFggRDOHdTr7jfa3BSyc7+2mdXNdhT/TtymB9otk0NdcoqaesOx4tY972Hl5+b5NOKXBjRgDt2/m/cDKWDIrgllf+mFAZyBiFH8e2K+QQH7e00oOrKAkEH1Ne5+Q==
+  indexer:RUST_LOG: debug

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -53,6 +53,7 @@ export = () => {
     rdsSgId: indexer.rdsSecurityGroupId,
     chainId: chainId,
     rustLogLevel: rustLogLevel,
+    boundlessAlertsTopicArn: boundlessAlertsTopicArn,
   }, { parent: indexer, dependsOn: indexer });
 
 };

--- a/infra/order-generator/Pulumi.prod.yaml
+++ b/infra/order-generator/Pulumi.prod.yaml
@@ -30,4 +30,5 @@ config:
     secure: v1:9iJ6gE5+gp4aipMW:lZlt7k89kafxnLvr8Qe0sStef/3gNEOcr67breAfH/sSrlgL4m6k081WHMUpaU2doI683Sd0TQ+kSnbLKINXfxvqiw/EFfhz4SxOks6d9UI=
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:X0x504eGSlReaNWU:HHKOYSpWFvByYG23SRcGA2/uvj0i5S09Jfof+tNB/S1ooLrm8vmZ+QXhS3+8loVt8dIKS3H9U4svS5CrV5FHZNQXlAa74cQ3McoDQsIIQ84=
-  
+  order-generator:ETH_RPC_URL:
+    secure: v1:OL1dK9lvanA4+cxN:k/qrgdflqF78VPuRdMICh7VWbkydVI/FMNG4tjcWS/jkmTXPnmoaY49uG43/uSfyQNoiAZU9L0XhMSJSwimdf3cAwG9TD3hsGmPRAXsaqoJnHw3hqw==

--- a/infra/order-generator/Pulumi.staging.yaml
+++ b/infra/order-generator/Pulumi.staging.yaml
@@ -31,4 +31,5 @@ config:
     secure: v1:/PAo8IW1iSC4PfVa:j+e1NmKVKprC8cRWBPmmQ5GT9O4ppUeU2VYFdpPiZDZHHCW6GCrTbHO+1BWu1rinjCT1lppKhzXhxBXlVabTVdwPOfjYZO7lF4g+dQjqq5U=
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:mCtZDPI169gCEzCS:fs7WOQUknWQ3SgRy1tJWLzSqrm0DFlDyBlOy0FvCr+qPgOPpdedminnQHR4Em1kBoJteJ0H1iUKfNsaE0NUZOk3RAmCdGtsnu/QiYkHQAiQ=
-  
+  order-generator:ETH_RPC_URL:
+    secure: v1:q+IJN29qCq/a5XiD:vV4sMv0SwWDbrk9oH3NMbvX6YuYKhYfjuYk9DeXLIzlg1ukWGGmBfDwfOnNkD8lZCX2lxdF8yehcT04fsoAwkLas+pxxklu5PY5LP5oMwDVoVABdTQ==

--- a/infra/prover/Pulumi.prod.yaml
+++ b/infra/prover/Pulumi.prod.yaml
@@ -11,7 +11,7 @@ config:
   prover:BROKER_TOML_PATH: broker-prod.toml
   prover:BASE_STACK: organization/bootstrap/services-prod
   prover:ETH_RPC_URL:
-    secure: v1:CHmozgrsQ1DIiZ6/:EpHWBQDlO7U3oL1Jp5nAYxL4SQghhuTiGOLCpaGuM21O5RW6eiMfLE145bHvK9+VJaY2F0wZS82IzdHAzateo/3YdHCtgFjjqZoT7VZnbTSmGaIkNw==
+    secure: v1:WGKgRuE6NRsSPeBi:sown/RZXGq3tcM1qUHp41HZo6Z2sll8GLSBcRbNsyxLQql6yDBBpNbkNEbhN9lB2TbFQxP399T9epYGWU2oBMj+348385QAcnX59w+wUtPj9/SyjhQ==
   prover:BONSAI_API_KEY:
     secure: v1:DBLnIT+fWqeYZsZd:FEOPSijO1WHd24xhepKtRB37SnovAt7A+7QmgJJ84yUvoKAmntUYalyrTN3TvSspnpgR23dQlfM=
   prover:PRIVATE_KEY:

--- a/infra/prover/Pulumi.staging.yaml
+++ b/infra/prover/Pulumi.staging.yaml
@@ -12,7 +12,7 @@ config:
   prover:BROKER_TOML_PATH: broker-staging.toml
   prover:BASE_STACK: organization/bootstrap/services-staging
   prover:ETH_RPC_URL:
-    secure: v1:ZGilzSIhSnEnqene:E/RXZFjEwx3dC2+c7SLHOdkts59K/GYPXcy32z9tmion2hWHCnFGoRWgjfL0Yjk8iZGi3D9CvuHb7mj/oE0I6V0cD8CQIPfSpSi1cEQn3SSJKgJiJg==
+    secure: v1:0yWfcUV8jGG1Rmlw:OX5wVMiPsfIegSZvhxAesD9uWTGpyJGNe0PgFErERyr2YJqIi4BAutVKFtvMHzXOEGE9HPs1WiXoyaCwqs3o+R/Vgblx2fPywgVE0aXq4YnABmN1SQ==
   prover:PRIVATE_KEY:
     secure: v1:XeT00OsvvQdg9y4K:jjqy1PfadM1Zo6XwgwI4Z0NmwDYA4akd3HvpD1BKQFt6YqB2QS8l03uccezLX3uFRy67UecCwDYVlP4bG+Np1ClK2O/Wm0h5n2En5XlaslU=
   prover:BONSAI_API_KEY:

--- a/infra/slasher/Pulumi.prod.yaml
+++ b/infra/slasher/Pulumi.prod.yaml
@@ -2,7 +2,7 @@ secretsprovider: awskms:///arn:aws:kms:us-west-2:968153779208:alias/pulumi-secre
 encryptedkey: AQICAHhnm/1/W7/xeF2uxmXOGjFzOf6jjMX+KgbMb0K+LSCbsAEr0ZJEO4dhQ1TcmzPl5RdoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMv7kVvHyDIG5k3eROAgEQgDsjYA0oc2IvwF8i9snHCzZLqIS7m5MXWhDp++g8vXjT5YgqWtPuterOHYDss1R6C3cgaVv2+ow/d63q3A==
 config:
   slasher:ETH_RPC_URL:
-    secure: v1:92vPAHoXvEXusN0k:1iHDNvjg+G2O60ZRU7WBLuUF//k7BamDzngbk4AvLxvOGbpxRN7rhhTuVlWPcqmo43g3YrXwgLDWpRiP6DCbik2lAFCpDStNeLM6bFuPp/t6gFchDg==
+    secure: v1:6nsR5L/6EU+pGf50:hN4tERoAxnyEh7npR3gfrndekS+vgm21atx1xRFTXz/1reaFURro1esQdmvbS39OIPzv7PIlBP2fJEjCdDjOHpDL0lJzprtxZV8Ekt5J1Xu3+UaHPg==
   slasher:PRIVATE_KEY:
     secure: v1:PS8c2ejmKEwjLkJb:yi3puIt9/XPmDuTKjc4m8GyGhpehesDTrwSVdnkrVCkLFvcOq+Lt5vXICRbawHR4VjPaegvQjGJOeP67XLBWiP1rKViAEz0AJp6eOo96GwE=
   slasher:BASE_STACK: organization/bootstrap/services-prod

--- a/infra/slasher/Pulumi.staging.yaml
+++ b/infra/slasher/Pulumi.staging.yaml
@@ -4,7 +4,7 @@ config:
   slasher:PRIVATE_KEY:
     secure: v1:3efkipLM4idAlwaJ:zL3IFTwgobXL0/UB8myW8kA9QZlXJTkRLUQ6O40/jbF6VDQ1gTEFP2oOpzCuCjsR+3ZiaYHzJSe3AB0Ej6bIahODR0llzAF+RpzcB/tmz2U=
   slasher:ETH_RPC_URL:
-    secure: v1:fWKzry8IB3uy/9jH:wj1rNfnq/Gvm4CcQ6mjqd5FZV10y3XwNNMttFaG+64lP416h+7tt59Sxm2W0kV91xDfQz69nTOP+Li/aGcA+nYCooyWShz6OC1HZNHtHpMktup/3Yg==
+    secure: v1:U9t0UwOizTLA1Hmf:i7YUWMkRaJOMUzXGq01qoVFCeMU+e2/N5bQaGSvkhzGb9pmqSL6PF6Oss9pRS5ucR2NOVeOErJxUFHaIN0F823Ro5oqlwSH6BTZr6b01jPhQ++QBgQ==
   slasher:BASE_STACK: organization/bootstrap/services-staging
   slasher:BOUNDLESS_MARKET_ADDR: 0x2d124b86179F0De2d5B7A75E4dcD7e35a3363B16
   slasher:DOCKER_DIR: ../../


### PR DESCRIPTION
1/ Splitting the RPC keys for each service as much as possible given our Alchemy plan
2/ Moving the monitor lambda logs to debug + adding an alarm (currently not seeing any metrics published so will help debug)
3/ Moving InsufficientBalance reverts for when the requestor is out of funds to known error