### PR TITLE
BM-921: Improve indexer

### DIFF
--- a/crates/indexer/migrations/1_transactions.sql
+++ b/crates/indexer/migrations/1_transactions.sql
@@ -3,6 +3,11 @@ CREATE TABLE IF NOT EXISTS last_block (
     block TEXT
 );
 
+CREATE TABLE IF NOT EXISTS blocks (
+  block_number    BIGINT    PRIMARY KEY,
+  block_timestamp BIGINT    NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS transactions (
   tx_hash         TEXT      PRIMARY KEY,
   block_number    BIGINT    NOT NULL,

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -286,7 +286,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} locked events from block {} to block {}",
             logs.len(),
             from_block,
@@ -334,7 +334,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} proof delivered events from block {} to block {}",
             logs.len(),
             from_block,
@@ -373,7 +373,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} fulfilled events from block {} to block {}",
             logs.len(),
             from_block,
@@ -410,7 +410,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} slashed events from block {} to block {}",
             logs.len(),
             from_block,
@@ -448,7 +448,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} deposit events from block {} to block {}",
             logs.len(),
             from_block,
@@ -478,7 +478,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} withdrawal events from block {} to block {}",
             logs.len(),
             from_block,
@@ -508,7 +508,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} stake deposit events from block {} to block {}",
             logs.len(),
             from_block,
@@ -538,7 +538,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} stake withdrawal events from block {} to block {}",
             logs.len(),
             from_block,
@@ -568,7 +568,7 @@ where
 
         // Query the logs for the event
         let logs = event_filter.query().await?;
-        tracing::info!(
+        tracing::debug!(
             "Found {} callback failed events from block {} to block {}",
             logs.len(),
             from_block,


### PR DESCRIPTION
The indexer was calling too many times get_block_by_number, to get its timestamp.
This PR adds a blocks table to store the block timestamp, whenever there is a cache miss and attempt to retrieve it from the db whenever the timestamp for a block is required.
Moreover refactor the starting block logic so that if the starting block is set, use the maximum of the starting block and the last processed block; otherwise, use the last processed block if it is greater than 0, or the current block if the last processed block is 0. This is to ensure that we don't process blocks that have already been processed and to avoid processing blocks that are in the future.


It also tune down the log level