### PR TITLE
BM-924: Cap block range size on the indexer

### DIFF
--- a/crates/indexer/migrations/1_transactions.sql
+++ b/crates/indexer/migrations/1_transactions.sql
@@ -3,11 +3,6 @@ CREATE TABLE IF NOT EXISTS last_block (
     block TEXT
 );
 
-CREATE TABLE IF NOT EXISTS blocks (
-  block_number    BIGINT    PRIMARY KEY,
-  block_timestamp BIGINT    NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS transactions (
   tx_hash         TEXT      PRIMARY KEY,
   block_number    BIGINT    NOT NULL,

--- a/crates/indexer/migrations/6_blocks.sql
+++ b/crates/indexer/migrations/6_blocks.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS blocks (
+    block_number    BIGINT    PRIMARY KEY,
+    block_timestamp BIGINT    NOT NULL
+);


### PR DESCRIPTION
should fix:

```
2025-05-15T16:16:16.323327Z  WARN boundless_indexer: Failed to process blocks from 8038641 to 8333060: EventQueryError(TransportError(ErrorResp(ErrorPayload { code: -32602, message: "Log response size exceeded. You can make eth_getLogs requests with up to a 500 block range and no limit on the response size, or you can request any block range with a cap of 10K logs in the response. Based on your parameters and the response size limit, this block range should work: [0x7aa8f1, 0x7d5efc]", data: None }))), attempt number 11, retrying in 120s
```