### PR TITLE
BM-926: Add fatal log on process exit, and alarms. Fix order generator topup

### DIFF
--- a/crates/indexer/src/main.rs
+++ b/crates/indexer/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     .await?;
 
     if let Err(err) = indexer_service.run(args.start_block).await {
-        bail!("Error running the indexer: {err}");
+        bail!("FATAL: Error running the indexer: {err}");
     }
 
     Ok(())

--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -134,7 +134,10 @@ async fn main() -> Result<()> {
     let args = MainArgs::parse();
 
     // NOTE: Using a separate `run` function to facilitate testing below.
-    run(&args).await?;
+    let result = run(&args).await;
+    if let Err(e) = result {
+        tracing::error!("FATAL: {:?}", e);
+    }
 
     Ok(())
 }

--- a/crates/order-stream/src/bin/order_stream.rs
+++ b/crates/order-stream/src/bin/order_stream.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
     order_stream::run(&args).await.context("Running order-stream REST API failed")?;
-    tracing::info!("order-stream REST API shutdown");
+    tracing::error!("FATAL: order-stream REST API shutdown");
 
     Ok(())
 }

--- a/crates/order-stream/src/bin/order_stream.rs
+++ b/crates/order-stream/src/bin/order_stream.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 RISC Zero, Inc.
+// Copyright (c) 2025 RISC Zero, Inc.
 //
 // All rights reserved.
 

--- a/crates/slasher/src/main.rs
+++ b/crates/slasher/src/main.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
     .await?;
 
     if let Err(err) = slash_service.run(args.start_block).await {
-        bail!("Error running the slasher: {err}");
+        bail!("FATAL: Error running the slasher: {err}");
     }
 
     Ok(())

--- a/infra/order-generator/Pulumi.prod.yaml
+++ b/infra/order-generator/Pulumi.prod.yaml
@@ -28,5 +28,6 @@ config:
     secure: v1:i+l18LS63TZDaTEk:DwR3R7w8tTJCqDQMZpOPF7Ih1xm+xszYALdKhiM+xvSJcPzPhY15QAtamb6RaHjj0g/eOWkHeueQmJY0lmTUNJ9TEte8N4YLfWomNAXJxKKCiXZc7P+S7yy1Gw+f+ljyOXEFDIpQGTO19ZVJ0g==
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:9iJ6gE5+gp4aipMW:lZlt7k89kafxnLvr8Qe0sStef/3gNEOcr67breAfH/sSrlgL4m6k081WHMUpaU2doI683Sd0TQ+kSnbLKINXfxvqiw/EFfhz4SxOks6d9UI=
+  order-generator-offchain:AUTO_DEPOSIT: "20"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:X0x504eGSlReaNWU:HHKOYSpWFvByYG23SRcGA2/uvj0i5S09Jfof+tNB/S1ooLrm8vmZ+QXhS3+8loVt8dIKS3H9U4svS5CrV5FHZNQXlAa74cQ3McoDQsIIQ84=

--- a/infra/order-generator/Pulumi.staging.yaml
+++ b/infra/order-generator/Pulumi.staging.yaml
@@ -29,5 +29,6 @@ config:
     secure: v1:JwMshDYyGPxsESiX:SY8Ye0Yf4BUg2vHfUa0kzK+KV1hUXFBLBdMgDGsIfNosmLjwXkm1+vombjLfhzJQg+/7AFLsKUgHdteI7grj+abG6ty2365BG+claz92m1pKXc+2lJ8ot3B/bghgM5na2s/K1De2p7BEXiIHHQ==
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:/PAo8IW1iSC4PfVa:j+e1NmKVKprC8cRWBPmmQ5GT9O4ppUeU2VYFdpPiZDZHHCW6GCrTbHO+1BWu1rinjCT1lppKhzXhxBXlVabTVdwPOfjYZO7lF4g+dQjqq5U=
+  order-generator-offchain:AUTO_DEPOSIT: "20"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:mCtZDPI169gCEzCS:fs7WOQUknWQ3SgRy1tJWLzSqrm0DFlDyBlOy0FvCr+qPgOPpdedminnQHR4Em1kBoJteJ0H1iUKfNsaE0NUZOk3RAmCdGtsnu/QiYkHQAiQ=

--- a/infra/order-generator/index.ts
+++ b/infra/order-generator/index.ts
@@ -107,6 +107,7 @@ export = () => {
   });
 
   const offchainConfig = new pulumi.Config("order-generator-offchain");
+  const autoDeposit = offchainConfig.require('AUTO_DEPOSIT');
   const offchainPrivateKey = isDev ? pulumi.output(getEnvVar("OFFCHAIN_PRIVATE_KEY")) : offchainConfig.requireSecret('PRIVATE_KEY');
   new OrderGenerator('offchain', {
     chainId,
@@ -114,7 +115,10 @@ export = () => {
     privateKey: offchainPrivateKey,
     pinataJWT,
     ethRpcUrl,
-    orderStreamUrl,
+    offchainConfig: {
+      autoDeposit,
+      orderStreamUrl,
+    },
     image,
     logLevel,
     setVerifierAddr,
@@ -139,7 +143,6 @@ export = () => {
     privateKey: onchainPrivateKey,
     pinataJWT,
     ethRpcUrl,
-    orderStreamUrl,
     image,
     logLevel,
     setVerifierAddr,

--- a/infra/slasher/index.ts
+++ b/infra/slasher/index.ts
@@ -242,4 +242,40 @@ export = () => {
     actionsEnabled: true,
     alarmActions,
   });
+
+  new aws.cloudwatch.LogMetricFilter(`${serviceName}-fatal-filter`, {
+    name: `${serviceName}-log-fatal-filter`,
+    logGroupName: serviceName,
+    metricTransformation: {
+      namespace: `Boundless/Services/${serviceName}`,
+      name: `${serviceName}-log-fatal`,
+      value: '1',
+      defaultValue: '0',
+    },
+    pattern: 'FATAL',
+  }, { dependsOn: [service] });
+
+  new aws.cloudwatch.MetricAlarm(`${serviceName}-fatal-alarm`, {
+    name: `${serviceName}-log-fatal`,
+    metricQueries: [
+      {
+        id: 'm1',
+        metric: {
+          namespace: `Boundless/Services/${serviceName}`,
+          metricName: `${serviceName}-log-fatal`,
+          period: 60,
+          stat: 'Sum',
+        },
+        returnData: true,
+      },
+    ],
+    threshold: 1,
+    comparisonOperator: 'GreaterThanOrEqualToThreshold',
+    evaluationPeriods: 1,
+    datapointsToAlarm: 1,
+    treatMissingData: 'notBreaching',
+    alarmDescription: `Order slasher FATAL (task exited)`,
+    actionsEnabled: true,
+    alarmActions,
+  });
 };


### PR DESCRIPTION
Noticed that the off-chain order generator has been crashing but not alarming us. The error alarm there was misconfigured, so fixed that. But also noticed we don't have alarms for when ecs tasks error out and exit. Added those to all services.

Reason for off-chain order generator crashing is that it creates orders with a high max price (e.g. > 10 ETH) and didn't have enough balance on the market to submit the request. The auto deposit feature was set too low to cover this, so increased it to 20 ETH.

I haven't tested this as this would require redeploying every service, but fairly sure it should be ok ..