### PR TITLE
BM-930: Indexer namespace cleanup, various fixes

### DIFF
--- a/crates/indexer/src/db.rs
+++ b/crates/indexer/src/db.rs
@@ -33,10 +33,10 @@ impl TxMetadata {
 
 #[derive(Error, Debug)]
 pub enum DbError {
-    #[error("SQL error")]
+    #[error("SQL error {0:?}")]
     SqlErr(#[from] sqlx::Error),
 
-    #[error("SQL Migration error")]
+    #[error("SQL Migration error {0:?}")]
     MigrateErr(#[from] sqlx::migrate::MigrateError),
 
     #[error("Invalid block number: {0}")]

--- a/infra/indexer/Pulumi.staging.yaml
+++ b/infra/indexer/Pulumi.staging.yaml
@@ -16,3 +16,4 @@ config:
   indexer:GH_TOKEN_SECRET:
     secure: v1:D7aNTgIv8gY4epbh:mKyCvgukF7lPd76Gt36t/dIFggRDOHdTr7jfa3BSyc7+2mdXNdhT/TtymB9otk0NdcoqaesOx4tY972Hl5+b5NOKXBjRgDt2/m/cDKWDIrgllf+mFAZyBiFH8e2K+QQH7e00oOrKAkEH1Ne5+Q==
   indexer:RUST_LOG: debug
+  

--- a/infra/indexer/components/alarms.ts
+++ b/infra/indexer/components/alarms.ts
@@ -1,103 +1,100 @@
-import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import { getServiceNameV1, Severity } from "../../util";
+import { Severity } from "../../util";
 import { Target } from "./targets";
 
-const SERVICE_NAME_BASE = 'indexer';
-const stackName = pulumi.getStack();
-const serviceName = getServiceNameV1(stackName, SERVICE_NAME_BASE);
-const config = new pulumi.Config();
-const namespace = config.get("cloudwatchNamespace") || "indexer-monitor";
-const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
-const alarmActions = boundlessAlertsTopicArn
-    ? [boundlessAlertsTopicArn]
-    : [];
-
-export const createMetricAlarm = (
-    metricName: string,
-    severity: Severity,
-    target?: Target,
-    description?: string,
-    metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
-    alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
-): void => {
-    metricName = target ? `${metricName}_${target.address}` : metricName;
-    const metricFullName = target ? `${metricName}_${target.name}` : metricName;
-    new aws.cloudwatch.MetricAlarm(`${serviceName}-${metricFullName}-${severity}-alarm`, {
-        name: `${serviceName}-${metricName}-${severity}`,
-        metricQueries: [
-            {
-                id: "a",
-                metric: {
-                    namespace: namespace,
-                    metricName: metricName,
-                    period: 60,
-                    stat: "Sum",
-                    ...metricConfig
+export const buildCreateMetricFns = (serviceName: string, namespace: string, alarmActions: string[]) => {
+    const createMetricAlarm = (
+        metricName: string,
+        severity: Severity,
+        target?: Target,
+        description?: string,
+        metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
+        alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
+    ): void => {
+        metricName = target ? `${metricName}_${target.address}` : metricName;
+        const metricFullName = target ? `${metricName}_${target.name}` : metricName;
+        new aws.cloudwatch.MetricAlarm(`${serviceName}-${metricFullName}-${severity}-alarm`, {
+            name: `${serviceName}-${metricName}-${severity}`,
+            metricQueries: [
+                {
+                    id: "a",
+                    metric: {
+                        namespace: namespace,
+                        metricName: metricName,
+                        period: 60,
+                        stat: "Sum",
+                        ...metricConfig
+                    },
+                    returnData: true,
                 },
-                returnData: true,
-            },
-        ],
-        threshold: 1,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold',
-        evaluationPeriods: 1,
-        datapointsToAlarm: 1,
-        treatMissingData: 'notBreaching',
-        alarmDescription: `${severity} ${metricFullName} ${description}`,
-        actionsEnabled: true,
-        alarmActions,
-        ...alarmConfig
-    });
+            ],
+            threshold: 1,
+            comparisonOperator: 'GreaterThanOrEqualToThreshold',
+            evaluationPeriods: 1,
+            datapointsToAlarm: 1,
+            treatMissingData: 'notBreaching',
+            alarmDescription: `${severity} ${metricFullName} ${description}`,
+            actionsEnabled: true,
+            alarmActions,
+            ...alarmConfig
+        });
+    }
+
+    const createSuccessRateAlarm = (
+        target: Target,
+        severity: Severity,
+        description?: string,
+        metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
+        alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
+    ): void => {
+        const metricName = `success_rate_for_${target.address}_${target.name}`;
+        new aws.cloudwatch.MetricAlarm(`${serviceName}-${metricName}-${severity}-alarm`, {
+            name: `${serviceName}-${metricName}-${severity}`,
+            metricQueries: [
+                {
+                    id: "a",
+                    metric: {
+                        namespace: namespace,
+                        metricName: `fulfilled_requests_number_from_${target.address}`,
+                        period: 3600,
+                        stat: "Sum",
+                        ...metricConfig
+                    },
+                    returnData: false,
+                },
+                {
+                    id: "b",
+                    metric: {
+                        namespace: namespace,
+                        metricName: `expired_requests_number_from_${target.address}`,
+                        period: 3600,
+                        stat: "Sum",
+                        ...metricConfig
+                    },
+                    returnData: false,
+                },
+                {
+                    id: "sr",
+                    expression: "IF(a + b > 0, a / (a + b), 1)",
+                    label: "SuccessRate",
+                    returnData: true,
+                },
+            ],
+            threshold: 1,
+            comparisonOperator: 'LessThanThreshold',
+            evaluationPeriods: 12,
+            datapointsToAlarm: 1,
+            treatMissingData: 'notBreaching',
+            alarmDescription: `${severity} ${metricName} ${description}`,
+            actionsEnabled: true,
+            alarmActions,
+            ...alarmConfig
+        });
+    }
+
+    return {
+        createMetricAlarm,
+        createSuccessRateAlarm,
+    }
 }
 
-export const createSuccessRateAlarm = (
-    target: Target,
-    severity: Severity,
-    description?: string,
-    metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
-    alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
-): void => {
-    const metricName = `success_rate_for_${target.address}_${target.name}`;
-    new aws.cloudwatch.MetricAlarm(`${serviceName}-${metricName}-${severity}-alarm`, {
-        name: `${serviceName}-${metricName}-${severity}`,
-        metricQueries: [
-            {
-                id: "a",
-                metric: {
-                    namespace: namespace,
-                    metricName: `fulfilled_requests_number_from_${target.address}`,
-                    period: 3600,
-                    stat: "Sum",
-                    ...metricConfig
-                },
-                returnData: false,
-            },
-            {
-                id: "b",
-                metric: {
-                    namespace: namespace,
-                    metricName: `expired_requests_number_from_${target.address}`,
-                    period: 3600,
-                    stat: "Sum",
-                    ...metricConfig
-                },
-                returnData: false,
-            },
-            {
-                id: "sr",
-                expression: "IF(a + b > 0, a / (a + b), 1)",
-                label: "SuccessRate",
-                returnData: true,
-            },
-        ],
-        threshold: 1,
-        comparisonOperator: 'LessThanThreshold',
-        evaluationPeriods: 12,
-        datapointsToAlarm: 1,
-        treatMissingData: 'notBreaching',
-        alarmDescription: `${severity} ${metricName} ${description}`,
-        actionsEnabled: true,
-        alarmActions,
-        ...alarmConfig
-    });
-}

--- a/infra/indexer/components/indexer.ts
+++ b/infra/indexer/components/indexer.ts
@@ -206,10 +206,11 @@ export class IndexerInstance extends pulumi.ComponentResource {
     });
 
     const secretHash = pulumi
-      .all([dbUrlSecretValue])
-      .apply(([_dbUrlSecretValue]: any[]) => {
+      .all([dbUrlSecretValue, dbUrlSecretVersion.arn])
+      .apply(([_dbUrlSecretValue, _secretVersionArn]: any[]) => {
         const hash = crypto.createHash("sha1");
         hash.update(_dbUrlSecretValue);
+        hash.update(_secretVersionArn);
         return hash.digest("hex");
       });
 
@@ -435,6 +436,7 @@ export class IndexerInstance extends pulumi.ComponentResource {
     this.dbUrlSecret = dbUrlSecret;
     this.dbUrlSecretVersion = dbUrlSecretVersion;
     this.rdsSecurityGroupId = rdsSecurityGroup.id;
+
 
     this.registerOutputs({
       dbUrlSecret: this.dbUrlSecret,

--- a/infra/indexer/components/indexer.ts
+++ b/infra/indexer/components/indexer.ts
@@ -7,6 +7,7 @@ import * as pulumi from '@pulumi/pulumi';
 
 export class IndexerInstance extends pulumi.ComponentResource {
   public readonly dbUrlSecret: aws.secretsmanager.Secret;
+  public readonly dbUrlSecretVersion: aws.secretsmanager.SecretVersion;
   public readonly rdsSecurityGroupId: pulumi.Output<string>;
 
   constructor(
@@ -192,7 +193,7 @@ export class IndexerInstance extends pulumi.ComponentResource {
     );
 
     const dbUrlSecret = new aws.secretsmanager.Secret(`${serviceName}-db-url`);
-    new aws.secretsmanager.SecretVersion(`${serviceName}-db-url-ver`, {
+    const dbUrlSecretVersion = new aws.secretsmanager.SecretVersion(`${serviceName}-db-url-ver`, {
       secretId: dbUrlSecret.id,
       secretString: pulumi.interpolate`postgres://${rdsUser}:${rdsPassword}@${auroraCluster.endpoint}:${rdsPort}/${rdsDbName}?sslmode=require`,
     });
@@ -413,10 +414,12 @@ export class IndexerInstance extends pulumi.ComponentResource {
     });
 
     this.dbUrlSecret = dbUrlSecret;
+    this.dbUrlSecretVersion = dbUrlSecretVersion;
     this.rdsSecurityGroupId = rdsSecurityGroup.id;
 
     this.registerOutputs({
       dbUrlSecret: this.dbUrlSecret,
+      dbUrlSecretVersion: this.dbUrlSecretVersion,
       rdsSecurityGroupId: this.rdsSecurityGroupId
     });
   }

--- a/infra/indexer/components/monitor-lambda.ts
+++ b/infra/indexer/components/monitor-lambda.ts
@@ -130,7 +130,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
 
     const { marketMetricsNamespace, serviceMetricsNamespace } = args;
 
-    this.lambdaFunction = createRustLambda(`${serviceName}-monitor`, {
+    const { lambda, logGroupName } = createRustLambda(`${serviceName}-monitor`, {
       projectPath: path.join(__dirname, '../../../'),
       packageName: 'indexer-monitor',
       release: true,
@@ -148,10 +148,11 @@ export class MonitorLambda extends pulumi.ComponentResource {
       },
     },
     );
+    this.lambdaFunction = lambda;
 
     new aws.cloudwatch.LogMetricFilter(`${serviceName}-monitor-error-filter`, {
       name: `${serviceName}-monitor-log-err-filter`,
-      logGroupName: this.lambdaFunction.loggingConfig.logGroup,
+      logGroupName: logGroupName,
       metricTransformation: {
         namespace: serviceMetricsNamespace,
         name: `${serviceName}-monitor-log-err`,

--- a/infra/indexer/components/monitor-lambda.ts
+++ b/infra/indexer/components/monitor-lambda.ts
@@ -2,9 +2,9 @@ import * as path from 'path';
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import { createRustLambda } from './rust-lambda';
-import { getServiceNameV1, Severity } from '../../util';
+import { Severity } from '../../util';
 import { clients, clientAddresses, proverAddresses } from './targets';
-import { createMetricAlarm, createSuccessRateAlarm } from './alarms';
+import { buildCreateMetricFns } from './alarms';
 
 export interface MonitorLambdaArgs {
   /** VPC where RDS lives */
@@ -23,9 +23,11 @@ export interface MonitorLambdaArgs {
   rustLogLevel: string;
   /** Boundless alerts topic ARN */
   boundlessAlertsTopicArn?: string;
+  /** Namespace for service metrics, e.g. operation health of the monitor/indexer infra */
+  serviceMetricsNamespace: string;
+  /** Namespace for market metrics, e.g. order volume, order count, etc. */
+  marketMetricsNamespace: string;
 }
-
-const SERVICE_NAME_BASE = 'indexer';
 
 export class MonitorLambda extends pulumi.ComponentResource {
   public readonly lambdaFunction: aws.lambda.Function;
@@ -35,10 +37,9 @@ export class MonitorLambda extends pulumi.ComponentResource {
     args: MonitorLambdaArgs,
     opts?: pulumi.ComponentResourceOptions,
   ) {
-    super(`${SERVICE_NAME_BASE}-${args.chainId}`, name, opts);
+    super(name, name, opts);
 
-    const stackName = pulumi.getStack();
-    const serviceName = getServiceNameV1(stackName, SERVICE_NAME_BASE);
+    const serviceName = name;
 
     const role = new aws.iam.Role(
       `${serviceName}-role`,
@@ -127,6 +128,8 @@ export class MonitorLambda extends pulumi.ComponentResource {
       secretId: args.dbUrlSecret.id,
     }).secretString;
 
+    const { marketMetricsNamespace, serviceMetricsNamespace } = args;
+
     this.lambdaFunction = createRustLambda(`${serviceName}-monitor`, {
       projectPath: path.join(__dirname, '../../../'),
       packageName: 'indexer-monitor',
@@ -135,7 +138,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
       environmentVariables: {
         DB_URL: dbUrl,
         RUST_LOG: args.rustLogLevel,
-        CLOUDWATCH_NAMESPACE: `${serviceName}-monitor-${args.chainId}`,
+        CLOUDWATCH_NAMESPACE: marketMetricsNamespace,
       },
       memorySize: 128,
       timeout: 30,
@@ -150,7 +153,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
       name: `${serviceName}-monitor-log-err-filter`,
       logGroupName: this.lambdaFunction.loggingConfig.logGroup,
       metricTransformation: {
-        namespace: `Boundless/Services/${serviceName}`,
+        namespace: serviceMetricsNamespace,
         name: `${serviceName}-monitor-log-err`,
         value: '1',
         defaultValue: '0',
@@ -167,7 +170,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
         {
           id: 'm1',
           metric: {
-            namespace: `Boundless/Services/${serviceName}`,
+            namespace: serviceMetricsNamespace,
             metricName: `${serviceName}-monitor-log-err`,
             period: 60,
             stat: 'Sum',
@@ -217,6 +220,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
 
     // Create top level alarms
     // Total Number of Fulfilled Orders - SEV1: <5 within 10 minutes
+    const { createMetricAlarm, createSuccessRateAlarm } = buildCreateMetricFns(serviceName, marketMetricsNamespace, alarmActions);
 
     createMetricAlarm("fulfilled_requests_number", Severity.SEV1,
       undefined,

--- a/infra/indexer/components/rust-lambda.ts
+++ b/infra/indexer/components/rust-lambda.ts
@@ -52,7 +52,7 @@ function ensureCargoLambdaInstalled(): void {
     }
 }
 
-export function createRustLambda(name: string, options: RustLambdaOptions): aws.lambda.Function {
+export function createRustLambda(name: string, options: RustLambdaOptions): { lambda: aws.lambda.Function, logGroupName: pulumi.Output<string> } {
     ensureCargoLambdaInstalled();
 
     const release = options.release ?? true;
@@ -104,6 +104,9 @@ export function createRustLambda(name: string, options: RustLambdaOptions): aws.
         };
     }
 
+    const lambda = new aws.lambda.Function(`${name}-lambda`, lambdaArgs, {});
+    const logGroupName = lambda.arn.apply(arn => `/aws/lambda/${arn.split(":").pop()}`);
+
     // Create the Lambda function
-    return new aws.lambda.Function(`${name}-lambda`, lambdaArgs, {});
+    return { lambda, logGroupName };
 }

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from '@pulumi/pulumi';
 import { IndexerInstance } from './components/indexer';
 import { MonitorLambda } from './components/monitor-lambda';
-import { getEnvVar } from '../util';
+import { getEnvVar, getServiceNameV1 } from '../util';
 
 require('dotenv').config();
 
@@ -29,7 +29,16 @@ export = () => {
   const privSubNetIds = baseStack.getOutput('PRIVATE_SUBNET_IDS') as pulumi.Output<string[]>;
   const pubSubNetIds = baseStack.getOutput('PUBLIC_SUBNET_IDS') as pulumi.Output<string[]>;
 
-  const indexer = new IndexerInstance(`indexer`, {
+  const indexerServiceName = getServiceNameV1(stackName, "indexer", chainId);
+  const monitorServiceName = getServiceNameV1(stackName, "monitor", chainId);
+
+  // Metric namespace for service metrics, e.g. operation health of the monitor/indexer infra
+  const serviceMetricsNamespace = `Boundless/Services/${indexerServiceName}`;
+  const marketName = getServiceNameV1(stackName, "", chainId);
+  // Metric namespace for market metrics, e.g. fulfillment success rate, order count, etc.
+  const marketMetricsNamespace = `Boundless/Market/${marketName}`;
+
+  const indexer = new IndexerInstance(indexerServiceName, {
     chainId,
     ciCacheSecret,
     dockerDir,
@@ -43,9 +52,10 @@ export = () => {
     ethRpcUrl,
     boundlessAlertsTopicArn,
     startBlock,
+    serviceMetricsNamespace,
   });
 
-  new MonitorLambda('monitor', {
+  new MonitorLambda(monitorServiceName, {
     vpcId: vpcId,
     privSubNetIds: privSubNetIds,
     intervalMinutes: '1',
@@ -54,6 +64,8 @@ export = () => {
     chainId: chainId,
     rustLogLevel: rustLogLevel,
     boundlessAlertsTopicArn: boundlessAlertsTopicArn,
+    serviceMetricsNamespace,
+    marketMetricsNamespace,
   }, { parent: indexer, dependsOn: indexer });
 
 };

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -66,6 +66,6 @@ export = () => {
     boundlessAlertsTopicArn: boundlessAlertsTopicArn,
     serviceMetricsNamespace,
     marketMetricsNamespace,
-  }, { parent: indexer, dependsOn: indexer });
+  }, { parent: indexer, dependsOn: [indexer, indexer.dbUrlSecret, indexer.dbUrlSecretVersion] });
 
 };

--- a/infra/order-generator/components/order-generator.ts
+++ b/infra/order-generator/components/order-generator.ts
@@ -60,7 +60,7 @@ export class OrderGenerator extends pulumi.ComponentResource {
     const orderStreamUrlSecret = new aws.secretsmanager.Secret(`${serviceName}-order-stream-url`);
     new aws.secretsmanager.SecretVersion(`${serviceName}-order-stream-url`, {
       secretId: orderStreamUrlSecret.id,
-      secretString: offchainConfig?.orderStreamUrl,
+      secretString: offchainConfig?.orderStreamUrl ?? '',
     });
 
     const secretHash = pulumi


### PR DESCRIPTION
- Currently metrics are being emitted under 3 different namespaces, simplifying to two, and hooking up the alarms with the metrics
- Changing logs to output sql errors
- Fixes naming of infra to have chain ID for consistency with other services, and to avoid conflicts when we go multichain
- Removing circuit breaker on ECS service that causes it to stop trying to start up after a few failures
- Adding FATAL alarm for when the indexer exits and stops running

Does NOT fix the current bug in staging:
```
2025-05-15T19:21:07.614-04:00
2025-05-15T23:21:07.614174Z ERROR boundless_indexer: Failed to process blocks from 8334235 to 8334735: DatabaseError(SqlErr(RowNotFound))
40
2025-05-15T19:21:07.574-04:00
2025-05-15T23:21:07.574340Z DEBUG boundless_indexer: Processing slashed event for request: 0xe9669e8fe06aa27d3ed5d85a33453987c80bbdc355aa8bed
```