### PR TITLE
BM-931: Redeploy ECS tasks when secrets updated

### DIFF
--- a/infra/builder/configure_builder.sh
+++ b/infra/builder/configure_builder.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+ssh-add ~/.ssh/id_ed25519_dev_docker_builder
+
 INSTANCE_ID=$(aws ec2 describe-instances \
   --filters "Name=tag:Name,Values=builder-local" \
   --query "Reservations[*].Instances[*].InstanceId" \

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -9,6 +9,7 @@ export = () => {
   const config = new pulumi.Config();
   const stackName = pulumi.getStack();
   const isDev = stackName === "dev";
+  const dockerRemoteBuilder = isDev ? process.env.DOCKER_REMOTE_BUILDER : undefined;
 
   const ethRpcUrl = isDev ? pulumi.output(getEnvVar("ETH_RPC_URL")) : config.requireSecret('ETH_RPC_URL');
   const rdsPassword = isDev ? pulumi.output(getEnvVar("RDS_PASSWORD")) : config.requireSecret('RDS_PASSWORD');
@@ -43,6 +44,7 @@ export = () => {
     ethRpcUrl,
     boundlessAlertsTopicArn,
     startBlock,
+    dockerRemoteBuilder,
   });
 
   new MonitorLambda('monitor', {


### PR DESCRIPTION
When we change secrets a new ECS deployment is not triggered. This is because changing the secret updates the value stored in Secret Manager, but ECS only sees the Secret Arn, not the secret itself, so it doesn't know it needs to redeploy.

To fix we pass a hash of the secrets as an env variable. Changes in env variables _do_ trigger a redeployment.