### PR TITLE
BM-933: Fix missing locked event on the Indexer

### DIFF
--- a/crates/indexer/src/db.rs
+++ b/crates/indexer/src/db.rs
@@ -518,10 +518,14 @@ impl IndexerDb for AnyDb {
         // TODO: Improve this
         // If for some reason due to a gap in the db that is missing the associated locked request event,
         // we set the prover address to zero.
-        let prover_address = result
-            .map(|row| row.try_get("prover_address"))
-            .transpose()?
-            .unwrap_or_else(|| format!("{:x}", Address::ZERO));
+        let prover_address =
+            result.map(|row| row.try_get("prover_address")).transpose()?.unwrap_or_else(|| {
+                tracing::warn!(
+                    "Missing request locked event for slashed event for request id: {:x}",
+                    request_id
+                );
+                format!("{:x}", Address::ZERO)
+            });
         sqlx::query(
             "INSERT INTO prover_slashed_events (
                 request_id, 

--- a/crates/indexer/src/db.rs
+++ b/crates/indexer/src/db.rs
@@ -513,9 +513,15 @@ impl IndexerDb for AnyDb {
         let result =
             sqlx::query("SELECT prover_address FROM request_locked_events WHERE request_id = $1")
                 .bind(format!("{:x}", request_id))
-                .fetch_one(&self.pool)
+                .fetch_optional(&self.pool)
                 .await?;
-        let prover_address: String = result.try_get("prover_address")?;
+        // TODO: Improve this
+        // If for some reason due to a gap in the db that is missing the associated locked request event,
+        // we set the prover address to zero.
+        let prover_address = result
+            .map(|row| row.try_get("prover_address"))
+            .transpose()?
+            .unwrap_or_else(|| format!("{:x}", Address::ZERO));
         sqlx::query(
             "INSERT INTO prover_slashed_events (
                 request_id, 


### PR DESCRIPTION
This PR is a sort of hack for fixing the Indexer crashing after failing to process a slashed event.
In case the DB has gaps, it might happen that when processing a slash event the corresponding locked event is missing.
In that case we just return the Address::ZERO as prover address