### PR TITLE
BM-942: Indexer alerts on event time rather than bidding start. Additional logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ bun run docs
 
 Then open your browser and navigate to `http://localhost:5173`.
 
-
 ## Audits
 
 See https://github.com/boundless-xyz/boundless-security

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ bun run docs
 
 Then open your browser and navigate to `http://localhost:5173`.
 
+
+## Audits
+
+See https://github.com/boundless-xyz/boundless-security
+
 ## License
 
 See [LICENSE](./LICENSE).

--- a/crates/indexer/migrations/3_proof_requests.sql
+++ b/crates/indexer/migrations/3_proof_requests.sql
@@ -22,7 +22,13 @@ CREATE TABLE IF NOT EXISTS proof_requests (
     bidding_start       BIGINT    NOT NULL, -- Unix timestamp when bidding starts
     expires_at          BIGINT    NOT NULL, -- Unix timestamp when request expires
     lock_end            BIGINT    NOT NULL, -- Unix timestamp when lock ends
-    ramp_up_period      BIGINT    NOT NULL  -- Ramp up period in seconds  
+    ramp_up_period      BIGINT    NOT NULL,  -- Ramp up period in seconds  
+
+    -- Tx metadata which led to us adding this proof request to the table. 
+    -- Could be a request submitted or request locked (if submitted offchain)
+    tx_hash             TEXT      NOT NULL,
+    block_number        BIGINT    NOT NULL, -- Block number
+    block_timestamp     BIGINT    NOT NULL  -- Block timestamp
 );
 
 -- Add an index on client_address for faster lookups

--- a/crates/indexer/migrations/7_proof_request_metadata.sql
+++ b/crates/indexer/migrations/7_proof_request_metadata.sql
@@ -1,5 +1,0 @@
- -- Tx metadata which led to us adding this proof request to the table. 
- -- Could be a request submitted or request locked (if submitted offchain)
-ALTER TABLE proof_requests ADD COLUMN tx_hash TEXT NOT NULL;
-ALTER TABLE proof_requests ADD COLUMN block_number BIGINT NOT NULL;
-ALTER TABLE proof_requests ADD COLUMN block_timestamp BIGINT NOT NULL;

--- a/crates/indexer/migrations/7_proof_request_metadata.sql
+++ b/crates/indexer/migrations/7_proof_request_metadata.sql
@@ -1,0 +1,5 @@
+ -- Tx metadata which led to us adding this proof request to the table. 
+ -- Could be a request submitted or request locked (if submitted offchain)
+ALTER TABLE proof_requests ADD COLUMN tx_hash TEXT NOT NULL;
+ALTER TABLE proof_requests ADD COLUMN block_number BIGINT NOT NULL;
+ALTER TABLE proof_requests ADD COLUMN block_timestamp BIGINT NOT NULL;

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -289,14 +289,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, input) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing request locked event for request: 0x{:x} [block: {}, timestamp: {}]",
                 log.requestId,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, input) = self.fetch_tx(log_data).await?;
-
             let request = IBoundlessMarket::lockRequestCall::abi_decode(&input)
                 .context(anyhow!(
                     "abi decode failure for request locked event of tx: {}",
@@ -348,13 +347,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, input) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing proof delivered event for request: 0x{:x} [block: {}, timestamp: {}]",
                 log.requestId,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, input) = self.fetch_tx(log_data).await?;
             let (fills, assessor_receipt) = decode_calldata(&input).context(anyhow!(
                 "abi decode failure for proof delivered event of tx: {}",
                 hex::encode(metadata.tx_hash)
@@ -392,13 +391,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, input) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing fulfilled event for request: 0x{:x} [block: {}, timestamp: {}]",
                 log.requestId,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, input) = self.fetch_tx(log_data).await?;
 
             let (fills, _) = decode_calldata(&input).context(anyhow!(
                 "abi decode failure for fulfilled event of tx: {}",
@@ -434,13 +433,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing slashed event for request: 0x{:x} [block: {}, timestamp: {}]",
                 log.requestId,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _) = self.fetch_tx(log_data).await?;
             self.db
                 .add_prover_slashed_event(
                     log.requestId,
@@ -477,13 +476,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing deposit event for account: 0x{:x} [block: {}, timestamp: {}]",
                 log.account,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _) = self.fetch_tx(log_data).await?;
             self.db.add_deposit_event(log.account, log.value, &metadata).await?;
         }
 
@@ -512,13 +511,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing withdrawal event for account: 0x{:x} [block: {}, timestamp: {}]",
                 log.account,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _) = self.fetch_tx(log_data).await?;
             self.db.add_withdrawal_event(log.account, log.value, &metadata).await?;
         }
 
@@ -547,13 +546,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing stake deposit event for account: 0x{:x} [block: {}, timestamp: {}]",
                 log.account,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _) = self.fetch_tx(log_data).await?;
             self.db.add_stake_deposit_event(log.account, log.value, &metadata).await?;
         }
 
@@ -582,13 +581,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing stake withdrawal event for account: 0x{:x} [block: {}, timestamp: {}]",
                 log.account,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _) = self.fetch_tx(log_data).await?;
             self.db.add_stake_withdrawal_event(log.account, log.value, &metadata).await?;
         }
 
@@ -617,13 +616,13 @@ where
         );
 
         for (log, log_data) in logs {
+            let (metadata, _) = self.fetch_tx(log_data).await?;
             tracing::debug!(
                 "Processing callback failed event for request: 0x{:x} [block: {}, timestamp: {}]",
                 log.requestId,
-                log.blockNumber,
-                log.blockTimestamp
+                metadata.block_number,
+                metadata.block_timestamp
             );
-            let (metadata, _tx_input) = self.fetch_tx(log_data).await?;
 
             self.db
                 .add_callback_failed_event(

--- a/crates/indexer/tests/basic.rs
+++ b/crates/indexer/tests/basic.rs
@@ -364,8 +364,8 @@ async fn test_monitoring() {
     let total_requests = monitor.total_requests().await.unwrap();
     assert_eq!(total_requests, 2);
 
-    let requests_count = monitor.fetch_requests_number(0, now as i64).await.unwrap();
-    assert_eq!(requests_count, 2);
+    let requests = monitor.fetch_requests(0, now as i64).await.unwrap();
+    assert_eq!(requests.len(), 2);
 
     let total_requests =
         monitor.total_requests_from_client(ctx.customer_signer.address()).await.unwrap();

--- a/crates/ops-lambdas/indexer-monitor/src/handler.rs
+++ b/crates/ops-lambdas/indexer-monitor/src/handler.rs
@@ -84,31 +84,34 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
         .map_err(|e| Error::from(e.to_string()))?;
 
     let expired_count = expired.len();
-    debug!(count = expired_count, "Found expired requests");
+    debug!(count = expired_count, expired = ?expired, "Found expired requests");
     metrics.push(new_metric("expired_requests_number", expired_count as f64, now));
 
-    let requests_count = monitor
-        .fetch_requests_number(start_time, now)
+    let requests = monitor
+        .fetch_requests(start_time, now)
         .await
         .context("Failed to fetch requests number")
         .map_err(|e| Error::from(e.to_string()))?;
-    debug!(count = requests_count, "Fetched requests number");
+    let requests_count = requests.len();
+    debug!(count = requests_count, requests = ?requests, "Fetched requests");
     metrics.push(new_metric("requests_number", requests_count as f64, now));
 
-    let fulfillment_count = monitor
-        .fetch_fulfillments_number(start_time, now)
+    let fulfillments = monitor
+        .fetch_fulfillments(start_time, now)
         .await
         .context("Failed to fetch fulfilled requests number")
         .map_err(|e| Error::from(e.to_string()))?;
-    debug!(count = fulfillment_count, "Fetched fulfilled requests number");
+    let fulfillment_count = fulfillments.len();
+    debug!(count = fulfillment_count, fulfillments = ?fulfillments, "Fetched fulfilled requests");
     metrics.push(new_metric("fulfilled_requests_number", fulfillment_count as f64, now));
 
-    let slashed_count = monitor
-        .fetch_slashed_number(start_time, now)
+    let slashed = monitor
+        .fetch_slashed(start_time, now)
         .await
         .context("Failed to fetch slashed requests number")
         .map_err(|e| Error::from(e.to_string()))?;
-    debug!(count = slashed_count, "Fetched slashed requests number");
+    let slashed_count = slashed.len();
+    debug!(count = slashed_count, slashed = ?slashed, "Fetched slashed requests");
     metrics.push(new_metric("slashed_requests_number", slashed_count as f64, now));
 
     for client in event.clients {
@@ -123,28 +126,33 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch expired requests for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
         let expired_count = expired_requests.len();
+        debug!(count = expired_count, expired = ?expired_requests, "Fetched expired requests for client {client}");
         metrics.push(new_metric(
             &format!("expired_requests_number_from_{client}"),
             expired_count as f64,
             now,
         ));
 
-        let requests_count = monitor
-            .fetch_requests_number_from_client(start_time, now, address)
+        let requests = monitor
+            .fetch_requests_from_client(start_time, now, address)
             .await
             .context("Failed to fetch requests number for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
+        let requests_count = requests.len();
+        debug!(count = requests_count, requests = ?requests, "Fetched requests for client {client}");
         metrics.push(new_metric(
             &format!("requests_number_from_{client}"),
             requests_count as f64,
             now,
         ));
 
-        let fulfilled_count = monitor
-            .fetch_fulfillments_number_from_client(start_time, now, address)
+        let fulfilled = monitor
+            .fetch_fulfillments_from_client(start_time, now, address)
             .await
             .context("Failed to fetch fulfilled requests number for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
+        let fulfilled_count = fulfilled.len();
+        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Fetched fulfilled requests for client {client}");
         metrics.push(new_metric(
             &format!("fulfilled_requests_number_from_{client}"),
             fulfilled_count as f64,
@@ -159,36 +167,42 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to parse prover address")
             .map_err(|e| Error::from(e.to_string()))?;
 
-        let fulfilled_number = monitor
-            .fetch_fulfillments_number_by_prover(start_time, now, address)
+        let fulfilled = monitor
+            .fetch_fulfillments_by_prover(start_time, now, address)
             .await
             .context("Failed to fetch fulfilled requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
+        let fulfilled_count = fulfilled.len();
+        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Fetched fulfilled requests for prover {prover}");
         metrics.push(new_metric(
             &format!("fulfilled_requests_number_by_{prover}"),
-            fulfilled_number as f64,
+            fulfilled_count as f64,
             now,
         ));
 
-        let locked_number = monitor
-            .fetch_locked_number_by_prover(start_time, now, address)
+        let locked = monitor
+            .fetch_locked_by_prover(start_time, now, address)
             .await
             .context("Failed to fetch locked requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
+        let locked_count = locked.len();
+        debug!(count = locked_count, locked = ?locked, "Fetched locked requests for prover {prover}");
         metrics.push(new_metric(
             &format!("locked_requests_number_by_{prover}"),
-            locked_number as f64,
+            locked_count as f64,
             now,
         ));
 
-        let slashed_number = monitor
-            .fetch_slashed_number_by_prover(start_time, now, address)
+        let slashed = monitor
+            .fetch_slashed_by_prover(start_time, now, address)
             .await
             .context("Failed to fetch slashed requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
+        let slashed_count = slashed.len();
+        debug!(count = slashed_count, slashed = ?slashed, "Fetched slashed requests for prover {prover}");
         metrics.push(new_metric(
             &format!("slashed_requests_number_by_{prover}"),
-            slashed_number as f64,
+            slashed_count as f64,
             now,
         ));
     }

--- a/crates/ops-lambdas/indexer-monitor/src/handler.rs
+++ b/crates/ops-lambdas/indexer-monitor/src/handler.rs
@@ -75,7 +75,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
 
     let mut metrics = vec![];
 
-    debug!(start_time, now, "Fetching metrics");
+    debug!(start_time, now, "Fetching metrics from {start_time} to {now}");
 
     let expired = monitor
         .fetch_requests_expired(start_time, now)
@@ -93,7 +93,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
         .context("Failed to fetch requests number")
         .map_err(|e| Error::from(e.to_string()))?;
     let requests_count = requests.len();
-    debug!(count = requests_count, requests = ?requests, "Fetched requests");
+    debug!(count = requests_count, requests = ?requests, "Found requests");
     metrics.push(new_metric("requests_number", requests_count as f64, now));
 
     let fulfillments = monitor
@@ -102,7 +102,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
         .context("Failed to fetch fulfilled requests number")
         .map_err(|e| Error::from(e.to_string()))?;
     let fulfillment_count = fulfillments.len();
-    debug!(count = fulfillment_count, fulfillments = ?fulfillments, "Fetched fulfilled requests");
+    debug!(count = fulfillment_count, fulfillments = ?fulfillments, "Found fulfilled requests");
     metrics.push(new_metric("fulfilled_requests_number", fulfillment_count as f64, now));
 
     let slashed = monitor
@@ -111,7 +111,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
         .context("Failed to fetch slashed requests number")
         .map_err(|e| Error::from(e.to_string()))?;
     let slashed_count = slashed.len();
-    debug!(count = slashed_count, slashed = ?slashed, "Fetched slashed requests");
+    debug!(count = slashed_count, slashed = ?slashed, "Found slashed requests");
     metrics.push(new_metric("slashed_requests_number", slashed_count as f64, now));
 
     for client in event.clients {
@@ -126,7 +126,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch expired requests for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
         let expired_count = expired_requests.len();
-        debug!(count = expired_count, expired = ?expired_requests, "Fetched expired requests for client {client}");
+        debug!(count = expired_count, expired = ?expired_requests, "Found expired requests for client {client}");
         metrics.push(new_metric(
             &format!("expired_requests_number_from_{client}"),
             expired_count as f64,
@@ -139,7 +139,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch requests number for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
         let requests_count = requests.len();
-        debug!(count = requests_count, requests = ?requests, "Fetched requests for client {client}");
+        debug!(count = requests_count, requests = ?requests, "Found requests for client {client}");
         metrics.push(new_metric(
             &format!("requests_number_from_{client}"),
             requests_count as f64,
@@ -152,7 +152,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch fulfilled requests number for client {client}")
             .map_err(|e| Error::from(e.to_string()))?;
         let fulfilled_count = fulfilled.len();
-        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Fetched fulfilled requests for client {client}");
+        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Found fulfilled requests for client {client}");
         metrics.push(new_metric(
             &format!("fulfilled_requests_number_from_{client}"),
             fulfilled_count as f64,
@@ -173,7 +173,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch fulfilled requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
         let fulfilled_count = fulfilled.len();
-        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Fetched fulfilled requests for prover {prover}");
+        debug!(count = fulfilled_count, fulfillments = ?fulfilled, "Found fulfilled requests for prover {prover}");
         metrics.push(new_metric(
             &format!("fulfilled_requests_number_by_{prover}"),
             fulfilled_count as f64,
@@ -186,7 +186,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch locked requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
         let locked_count = locked.len();
-        debug!(count = locked_count, locked = ?locked, "Fetched locked requests for prover {prover}");
+        debug!(count = locked_count, locked = ?locked, "Found locked requests for prover {prover}");
         metrics.push(new_metric(
             &format!("locked_requests_number_by_{prover}"),
             locked_count as f64,
@@ -199,7 +199,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
             .context("Failed to fetch slashed requests number by prover {prover}")
             .map_err(|e| Error::from(e.to_string()))?;
         let slashed_count = slashed.len();
-        debug!(count = slashed_count, slashed = ?slashed, "Fetched slashed requests for prover {prover}");
+        debug!(count = slashed_count, slashed = ?slashed, "Found slashed requests for prover {prover}");
         metrics.push(new_metric(
             &format!("slashed_requests_number_by_{prover}"),
             slashed_count as f64,

--- a/infra/indexer/Pulumi.prod-11155111.yaml
+++ b/infra/indexer/Pulumi.prod-11155111.yaml
@@ -6,9 +6,9 @@ config:
   indexer:BOUNDLESS_ADDRESS: 0x006b92674E2A8d397884e293969f8eCD9f615f4C
   indexer:DOCKER_DIR: ../../
   indexer:DOCKER_TAG: latest
-  indexer:START_BLOCK: "8137095"
+  indexer:START_BLOCK: "8361293"
   indexer:ETH_RPC_URL:
-    secure: v1:I5G1si5T9viPY+ag:ENBXAsoaKSNMEbod6/TssBys7PC5WpLCAwP3TvLAOy1QsFODZrUnLBXAtzy+cPqKqzELezj1v/8G5v124XrbM66n+rmapydJ9YrDu0VaiPotkdrdhg==
+    secure: v1:mt9m+x0hh0APYSHY:syfdwFQ+hkMssi5DMPnpmNzyJHagUpY+VNmHOkoXo1dg18edU2zjdiriENXqQNNWNaS5/ZJweownQIR9+/PfjfGGBMB6SvLDGjXdVvE2sXGm85H86A==
   indexer:RDS_PASSWORD:
     secure: v1:6OldikDHGPtFsshU:3tg0ETBuoOsjoCnrxja5zQnWyaGOSvtIsNEIjH2uu7tvuA==
   indexer:CHAIN_ID: "11155111"

--- a/infra/indexer/Pulumi.staging.yaml
+++ b/infra/indexer/Pulumi.staging.yaml
@@ -6,9 +6,9 @@ config:
   indexer:BOUNDLESS_ADDRESS: 0x2d124b86179F0De2d5B7A75E4dcD7e35a3363B16
   indexer:DOCKER_DIR: ../../
   indexer:DOCKER_TAG: latest
-  indexer:START_BLOCK: "8038641"
+  indexer:START_BLOCK: "8361293"
   indexer:ETH_RPC_URL:
-    secure: v1:k1yy++VLVeDHpj1p:SKUw1hSwX7mMDOhQjf+C4Bs5ZpgXL8cnkg0ZG3qLRIwQ4fS9UWh6ETnVxOUEZalQgDTHHhdB/ndPQd3BOrmAROeWZNrwFRDsVdceUZNHwkPuOKPbjw==
+    secure: v1:fBDwXXhk0gJUPNU7:dacNN3JBrStdOucG6EON3IlpV6akbq1Nm+TdR6NSIx9NnbYktivufUpp3FScXBONcMSWvuWMCNt56SujJ8E4zKbEN1pf3iOEF/m0QpRQ3GUwZSq2bA==
   indexer:RDS_PASSWORD:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
   indexer:CHAIN_ID: "11155111"
@@ -16,4 +16,3 @@ config:
   indexer:GH_TOKEN_SECRET:
     secure: v1:D7aNTgIv8gY4epbh:mKyCvgukF7lPd76Gt36t/dIFggRDOHdTr7jfa3BSyc7+2mdXNdhT/TtymB9otk0NdcoqaesOx4tY972Hl5+b5NOKXBjRgDt2/m/cDKWDIrgllf+mFAZyBiFH8e2K+QQH7e00oOrKAkEH1Ne5+Q==
   indexer:RUST_LOG: debug
-  

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -51,10 +51,10 @@ export const alarmConfig: ChainStageAlarms = {
           address: "0xe9669e8fe06aa27d3ed5d85a33453987c80bbdc3",
           submissionRate: [
             {
-              description: "no submitted orders in 15 minutes from og_offchain",
+              description: "no submitted orders in 30 minutes from og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
-                period: 900
+                period: 1800
               },
               alarmConfig: {
                 evaluationPeriods: 1,
@@ -68,7 +68,7 @@ export const alarmConfig: ChainStageAlarms = {
           successRate: [
             {
               // Since current submit every 5 mins, this is >= 2 failures an hour
-              description: "less than 90% success rate in 60 minutes",
+              description: "less than 90% success rate in 60 minutes for og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 3600

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -51,21 +51,7 @@ export const alarmConfig: ChainStageAlarms = {
           address: "0xe9669e8fe06aa27d3ed5d85a33453987c80bbdc3",
           submissionRate: [
             {
-              description: "no submitted orders in 30 minutes",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 1800
-              },
-              alarmConfig: {
-                evaluationPeriods: 1,
-                datapointsToAlarm: 1,
-                threshold: 1,
-                comparisonOperator: "LessThanThreshold",
-                treatMissingData: "breaching"
-              }
-            },
-            {
-              description: "no submitted orders in 15 minutes",
+              description: "no submitted orders in 15 minutes from og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 900
@@ -89,20 +75,6 @@ export const alarmConfig: ChainStageAlarms = {
               },
               alarmConfig: {
                 threshold: 0.90,
-                evaluationPeriods: 1,
-                datapointsToAlarm: 1,
-                comparisonOperator: "LessThanThreshold"
-              }
-            },
-            {
-              // Since current submit every 5 mins, this is >= 3 failures an hour
-              description: "less than 80% success rate in 60 minutes",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 3600
-              },
-              alarmConfig: {
-                threshold: 0.80,
                 evaluationPeriods: 1,
                 datapointsToAlarm: 1,
                 comparisonOperator: "LessThanThreshold"
@@ -115,21 +87,7 @@ export const alarmConfig: ChainStageAlarms = {
           address: "0x8934790e351cbcadd11fc6f9729257cd64f860bf",
           submissionRate: [
             {
-              description: "no submitted orders in 30 minutes",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 1800
-              },
-              alarmConfig: {
-                evaluationPeriods: 1,
-                datapointsToAlarm: 1,
-                threshold: 1,
-                comparisonOperator: "LessThanThreshold",
-                treatMissingData: "breaching"
-              }
-            },
-            {
-              description: "no submitted orders in 15 minutes",
+              description: "no submitted orders in 15 minutes from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 900
@@ -146,27 +104,13 @@ export const alarmConfig: ChainStageAlarms = {
           successRate: [
             {
               // Since current submit every 5 mins, this is >= 2 failures an hour
-              description: "less than 90% success rate in 60 minutes",
+              description: "less than 90% success rate in 60 minutes from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 3600
               },
               alarmConfig: {
                 threshold: 0.90,
-                evaluationPeriods: 1,
-                datapointsToAlarm: 1,
-                comparisonOperator: "LessThanThreshold"
-              }
-            },
-            {
-              // Since current submit every 5 mins, this is >= 3 failures an hour
-              description: "less than 80% success rate in 60 minutes",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 3600
-              },
-              alarmConfig: {
-                threshold: 0.80,
                 evaluationPeriods: 1,
                 datapointsToAlarm: 1,
                 comparisonOperator: "LessThanThreshold"
@@ -199,20 +143,6 @@ export const alarmConfig: ChainStageAlarms = {
             comparisonOperator: "LessThanThreshold",
             treatMissingData: "breaching"
           }
-        },
-        {
-          description: "less than 1 fulfilled orders in 15 minutes",
-          severity: Severity.SEV1,
-          metricConfig: {
-            period: 900
-          },
-          alarmConfig: {
-            threshold: 1,
-            evaluationPeriods: 1,
-            datapointsToAlarm: 1,
-            comparisonOperator: "LessThanThreshold",
-            treatMissingData: "breaching"
-          }
         }],
         submittedRequests: [{
           description: "less than 2 submitted orders in 30 minutes",
@@ -222,20 +152,6 @@ export const alarmConfig: ChainStageAlarms = {
           },
           alarmConfig: {
             threshold: 2,
-            evaluationPeriods: 1,
-            datapointsToAlarm: 1,
-            comparisonOperator: "LessThanThreshold",
-            treatMissingData: "breaching"
-          }
-        },
-        {
-          description: "less than 1 submitted orders in 15 minutes",
-          severity: Severity.SEV1,
-          metricConfig: {
-            period: 900,
-          },
-          alarmConfig: {
-            threshold: 1,
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             comparisonOperator: "LessThanThreshold",
@@ -279,7 +195,7 @@ export const alarmConfig: ChainStageAlarms = {
           address: "0x2546c553d857d20658ece248f7c7d0861a240681",
           submissionRate: [
             {
-              description: "no submitted orders in 30 minutes",
+              description: "no submitted orders in 30 minutes from og_offchain",
               severity: Severity.SEV1,
               metricConfig: {
                 period: 1800
@@ -293,7 +209,7 @@ export const alarmConfig: ChainStageAlarms = {
               }
             },
             {
-              description: "no submitted orders in 15 minutes",
+              description: "no submitted orders in 15 minutes from og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 900
@@ -324,7 +240,7 @@ export const alarmConfig: ChainStageAlarms = {
             },
             {
               // Since current submit every 5 mins, this is >= 3 failures an hour
-              description: "less than 80% success rate in 60 minutes",
+              description: "less than 80% success rate in 60 minutes from og_offchain",
               severity: Severity.SEV1,
               metricConfig: {
                 period: 3600
@@ -343,7 +259,7 @@ export const alarmConfig: ChainStageAlarms = {
           address: "0xc2db89b2bd434ceac6c74fbc0b2ad3a280e66db0",
           submissionRate: [
             {
-              description: "no submitted orders in 30 minutes",
+              description: "no submitted orders in 30 minutes from og_onchain",
               severity: Severity.SEV1,
               metricConfig: {
                 period: 1800
@@ -357,7 +273,7 @@ export const alarmConfig: ChainStageAlarms = {
               }
             },
             {
-              description: "no submitted orders in 15 minutes",
+              description: "no submitted orders in 15 minutes from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 900
@@ -374,7 +290,7 @@ export const alarmConfig: ChainStageAlarms = {
           successRate: [
             {
               // Since current submit every 5 mins, this is >= 2 failures an hour
-              description: "less than 90% success rate in 60 minutes",
+              description: "less than 90% success rate in 60 minutes from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
                 period: 3600
@@ -388,7 +304,7 @@ export const alarmConfig: ChainStageAlarms = {
             },
             {
               // Since current submit every 5 mins, this is >= 3 failures an hour
-              description: "less than 80% success rate in 60 minutes",
+              description: "less than 80% success rate in 60 minutes from og_onchain",
               severity: Severity.SEV1,
               metricConfig: {
                 period: 3600

--- a/infra/indexer/components/indexer.ts
+++ b/infra/indexer/components/indexer.ts
@@ -143,7 +143,7 @@ export class IndexerInstance extends pulumi.ComponentResource {
 
     const rdsUser = 'indexer';
     const rdsPort = 5432;
-    const rdsDbName = 'indexer';
+    const rdsDbName = 'indexerV1';
 
     const dbSubnets = new aws.rds.SubnetGroup(`${serviceName}-dbsubnets`, {
       subnetIds: privSubNetIds,
@@ -170,10 +170,10 @@ export class IndexerInstance extends pulumi.ComponentResource {
       ],
     });
 
-    const auroraCluster = new aws.rds.Cluster(`${serviceName}-aurora`, {
+    const auroraCluster = new aws.rds.Cluster(`${serviceName}-aurora-v1`, {
       engine: "aurora-postgresql",
       engineVersion: "17.4",
-      clusterIdentifier: `${serviceName}-aurora`,
+      clusterIdentifier: `${serviceName}-aurora-v1`,
       databaseName: rdsDbName,
       masterUsername: rdsUser,
       masterPassword: rdsPassword,
@@ -185,13 +185,12 @@ export class IndexerInstance extends pulumi.ComponentResource {
       storageEncrypted: true,
     }, { /** protect: true **/ }); // TODO: Re-enable protection once deployed and stable.
 
-    const auroraWriter = new aws.rds.ClusterInstance(
-      `${serviceName}-aurora-writer`, {
+    const auroraWriter = new aws.rds.ClusterInstance(`${serviceName}-aurora-writer-1`, {
       clusterIdentifier: auroraCluster.id,
       engine: "aurora-postgresql",
       engineVersion: "17.4",
       instanceClass: "db.t4g.medium",
-      identifier: `${serviceName}-aurora-writer`,
+      identifier: `${serviceName}-aurora-writer-v1`,
       publiclyAccessible: false,
       dbSubnetGroupName: dbSubnets.name,
     },

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -23,7 +23,7 @@ export = () => {
   const baseStackName = config.require('BASE_STACK');
   const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
   const startBlock = config.require('START_BLOCK');
-  const rustLogLevel = config.get('RUST_LOG_LEVEL') || 'info';
+  const rustLogLevel = config.get('RUST_LOG') || 'info';
 
   const baseStack = new pulumi.StackReference(baseStackName);
   const vpcId = baseStack.getOutput('VPC_ID') as pulumi.Output<string>;


### PR DESCRIPTION
* We're seeing alerts going off like "no requests submitted in 15 mins" when our order generators submit every 5 minutes. Adding additional logging of ids to help debug.
* Also making the alerts more lenient just to reduce noise for now until the issue is resolved.
* Changing fulfilled monitoring to use event emission time over `biddingStart`. Since fulfillment can happen a long time after `biddingStart`, I believe the previous implementation can cause us to miss capturing fulfillment events.
* Removing SEV1s from staging. SEV1 will page us and we only want to do that for prod.