### PR TITLE
BM-949: Fix log group

### DIFF
--- a/infra/prover/components/bonsaiBroker.ts
+++ b/infra/prover/components/bonsaiBroker.ts
@@ -290,13 +290,11 @@ export class BonsaiECSBroker extends pulumi.ComponentResource {
         return new aws.cloudwatch.LogGroup(`${serviceName}-log-group`, {
           name: existing.name,
           retentionInDays: existing.retentionInDays,
-          skipDestroy: true,
         }, { parent: this, import: existing.id });
       }
       return new aws.cloudwatch.LogGroup(`${serviceName}-log-group`, {
         name: serviceName,
         retentionInDays: 0,
-        skipDestroy: true,
       }, { parent: this });
     });
 


### PR DESCRIPTION
Staging error:
```
Diagnostics:
  aws:cloudwatch:LogGroup (staging-bonsai-prover-11155111-log-group):
    error: inputs to import do not match the existing resource: [skipDestroy]
```