### PR TITLE
BM-950: Tx timeouts in submitter as known errors

### DIFF
--- a/broker.toml
+++ b/broker.toml
@@ -155,4 +155,4 @@ single_txn_fulfill = true
 # max batch fees (in ETH) before publishing
 #batch_max_fees = "0.1"
 # Number of attempts to make to submit a batch before abandoning
-#max_submission_attempts = 3
+#max_submission_attempts = 2

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -47,7 +47,7 @@ mod defaults {
     }
 
     pub const fn max_submission_attempts() -> u32 {
-        3
+        2
     }
 }
 /// All configuration related to markets mechanics

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -38,6 +38,12 @@ use crate::errors::CodedError;
 
 #[derive(Error, Debug)]
 pub enum SubmitterErr {
+    #[error("{code} Batch submission failed: {0}", code = self.code())]
+    BatchSubmissionFailed(String),
+
+    #[error("{code} Failed to confirm transaction: {0}", code = self.code())]
+    TxnConfirmationError(MarketError),
+
     #[error("{code} Request expired before submission: {0}", code = self.code())]
     RequestExpiredBeforeSubmission(MarketError),
 
@@ -54,6 +60,8 @@ impl CodedError for SubmitterErr {
             SubmitterErr::UnexpectedErr(_) => "[B-SUB-500]",
             SubmitterErr::RequestExpiredBeforeSubmission(_) => "[B-SUB-001]",
             SubmitterErr::MarketError(_) => "[B-SUB-002]",
+            SubmitterErr::BatchSubmissionFailed(_) => "[B-SUB-003]",
+            SubmitterErr::TxnConfirmationError(_) => "[B-SUB-004]",
         }
     }
 }
@@ -371,10 +379,34 @@ where
             };
             if !contains_root {
                 tracing::info!("Submitting app merkle root: {root}");
-                self.set_verifier
-                    .submit_merkle_root(root, batch_seal.into())
-                    .await
-                    .context("Failed to submit app merkle_root")?;
+                if let Err(err) =
+                    self.set_verifier.submit_merkle_root(root, batch_seal.into()).await
+                {
+                    let order_ids: Vec<&str> = fulfillments
+                        .iter()
+                        .map(|f| *fulfillment_to_order_id.get(&f.id).unwrap())
+                        .collect();
+                    tracing::warn!("Failed to submit app merkle root for orders: {order_ids:?}");
+
+                    // Map the error from the R0 Contracts crate crate to an error type from BoundlessMarket
+                    if err.to_string().contains("failed to confirm tx") {
+                        self.handle_fulfillment_error(
+                            MarketError::TxnConfirmationError(err),
+                            batch_id,
+                            &fulfillments,
+                            &order_ids,
+                        )
+                        .await?;
+                    } else {
+                        self.handle_fulfillment_error(
+                            MarketError::Error(err),
+                            batch_id,
+                            &fulfillments,
+                            &order_ids,
+                        )
+                        .await?;
+                    }
+                }
             } else {
                 tracing::info!("Contract already contains root, skipping to fulfillment");
             }
@@ -463,15 +495,20 @@ where
         if err.to_string().contains("RequestIsExpiredOrNotPriced") {
             return Err(SubmitterErr::RequestExpiredBeforeSubmission(err));
         }
+
+        if let MarketError::TxnConfirmationError(_) = &err {
+            return Err(SubmitterErr::TxnConfirmationError(err));
+        }
+
         Err(SubmitterErr::MarketError(err))
     }
 
-    pub async fn process_next_batch(&self) -> Result<bool, SubmitterErr> {
+    pub async fn process_next_batch(&self) -> Result<(), SubmitterErr> {
         let batch_res =
             self.db.get_complete_batch().await.context("Failed to get complete batch")?;
 
         let Some((batch_id, batch)) = batch_res else {
-            return Ok(false);
+            return Ok(());
         };
 
         let max_batch_submission_attempts = self
@@ -493,7 +530,7 @@ where
                         "Completed batch: {batch_id} total_fees: {}",
                         format_ether(batch.fees)
                     );
-                    return Ok(true);
+                    return Ok(());
                 }
                 Err(err) => {
                     tracing::warn!(
@@ -505,14 +542,13 @@ where
                 }
             }
         }
-        tracing::error!("Batch {batch_id} has reached max submission attempts. Errors: {errors:?}");
+        tracing::warn!("Batch {batch_id} has reached max submission attempts. Errors: {errors:?}");
         if let Err(err) = self.db.set_batch_failure(batch_id, format!("{errors:?}")).await {
-            tracing::error!("Failed to set batch failure in db: {batch_id} - {err:?}");
             return Err(SubmitterErr::UnexpectedErr(anyhow!(
                 "Failed to set batch failure in db: {batch_id} - {err:?}"
             )));
         }
-        Ok(false)
+        Err(SubmitterErr::BatchSubmissionFailed(format!("{errors:?}")))
     }
 }
 
@@ -527,7 +563,19 @@ where
         Box::pin(async move {
             tracing::info!("Starting Submitter service");
             loop {
-                obj_clone.process_next_batch().await.map_err(SupervisorErr::Recover)?;
+                let result = obj_clone.process_next_batch().await;
+                if let Err(err) = result {
+                    // Only restart the service on unexpected errors.
+                    match err {
+                        SubmitterErr::BatchSubmissionFailed(_) => {
+                            tracing::error!("Batch submission failed: {err:?}");
+                        }
+                        _ => {
+                            tracing::error!("Submitter service failed: {err:?}");
+                            return Err(SupervisorErr::Recover(err));
+                        }
+                    }
+                }
 
                 // TODO: configuration
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
@@ -797,7 +845,7 @@ mod tests {
     where
         P: Provider<Ethereum> + WalletProvider + 'static + Clone,
     {
-        assert!(submitter.process_next_batch().await.unwrap());
+        submitter.process_next_batch().await.unwrap();
         let batch = db.get_batch(batch_id).await.unwrap();
         assert_eq!(batch.status, BatchStatus::Submitted);
     }
@@ -827,13 +875,9 @@ mod tests {
 
         drop(anvil); // drop anvil to simluate an RPC fault
 
-        assert!(!submitter.process_next_batch().await.unwrap()); // returned Ok(false)
-        assert!(logs_contain("Batch submission attempt 1/3 failed"));
-
-        assert!(!submitter.process_next_batch().await.unwrap()); // returned Ok(false)
-        assert!(logs_contain("Batch submission attempt 2/3 failed"));
-
-        assert!(!submitter.process_next_batch().await.unwrap()); // returned Ok(false)
+        let res = submitter.process_next_batch().await;
+        assert!(logs_contain("Batch submission attempt 1/2 failed"));
         assert!(logs_contain("reached max submission attempts"));
+        assert!(matches!(res, Err(SubmitterErr::BatchSubmissionFailed(_))));
     }
 }

--- a/infra/prover/broker-dev.toml
+++ b/infra/prover/broker-dev.toml
@@ -33,5 +33,5 @@ min_batch_size = 1
 block_deadline_buffer_secs = 120
 txn_timeout = 75
 single_txn_fulfill = true
-# max_submission_attempts = 3
+max_submission_attempts = 2
 # batch_poll_time_ms = 500

--- a/infra/prover/broker-prod.toml
+++ b/infra/prover/broker-prod.toml
@@ -33,5 +33,5 @@ min_batch_size = 1
 block_deadline_buffer_secs = 120
 txn_timeout = 75
 single_txn_fulfill = true
-# max_submission_attempts = 3
+max_submission_attempts = 2
 # batch_poll_time_ms = 500

--- a/infra/prover/broker-staging.toml
+++ b/infra/prover/broker-staging.toml
@@ -33,5 +33,5 @@ min_batch_size = 1
 block_deadline_buffer_secs = 120
 txn_timeout = 75
 single_txn_fulfill = true
-# max_submission_attempts = 3
+max_submission_attempts = 2
 # batch_poll_time_ms = 500

--- a/infra/prover/components/brokerAlarms.ts
+++ b/infra/prover/components/brokerAlarms.ts
@@ -241,6 +241,8 @@ export const createProverAlarms = (
     threshold: 3,
   }, { period: 3600 });
 
+
+
   //
   // Prover
   //
@@ -270,6 +272,17 @@ export const createProverAlarms = (
 
   // Any 1 request expired before submission triggers a SEV2 alarm.
   createErrorCodeAlarm('"[B-SUB-002]"', 'submitter-market-error-submission', Severity.SEV2);
+
+  // 2 failures to submit a batch within 1 hour in the submitter triggers a SEV2 alarm.
+  createErrorCodeAlarm('"[B-SUB-003]"', 'submitter-batch-submission-failure', Severity.SEV2, {
+    threshold: 2,
+  }, { period: 3600 });
+
+  // 3 txn confirmation errors within 1 hour in the submitter triggers a SEV2 alarm. 
+  // This may indicate a misconfiguration of the tx timeout config.
+  createErrorCodeAlarm('"[B-SUB-004]"', 'submitter-txn-confirmation-error', Severity.SEV2, {
+    threshold: 3,
+  }, { period: 3600 });
 
   // Any 1 unexpected error in the submitter triggers a SEV2 alarm.
   createErrorCodeAlarm('"[B-SUB-500]"', 'submitter-unexpected-error', Severity.SEV2);


### PR DESCRIPTION
The transactions in the submitter can occasionally fail due to not being confirmed in time. Given those transactions the same treatment as we have for sending lock transactions, which is currently only alert us on 3 errors in an hour.

Also changing the default retries for batch submission down to 2. Generally if a single retry here doesn't work a 3rd won't work either, and retrying too much wastes time + gas