### PR TITLE
Set up pagerduty integration. Configure SEV1/2 alarms for all services

### DIFF
--- a/infra/indexer/Pulumi.prod-11155111.yaml
+++ b/infra/indexer/Pulumi.prod-11155111.yaml
@@ -13,6 +13,7 @@ config:
     secure: v1:6OldikDHGPtFsshU:3tg0ETBuoOsjoCnrxja5zQnWyaGOSvtIsNEIjH2uu7tvuA==
   indexer:CHAIN_ID: "11155111"
   indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:LfbDb8lBoozxHg+u:MSyFlUK/ayFKEXiZ2fvJuuTehwJeQBWsq4FruaZCOkxtxMpVwZnZ0frKzsLXN5UD8NRPNWC/NSfTu9oq4onmDcnn/XULgsiJerGtpuJNvjqjAwuG6GEZM61S1zoEgvI0My09F57JH7jV3OfLAQ==
   indexer:RUST_LOG: debug

--- a/infra/indexer/Pulumi.staging.yaml
+++ b/infra/indexer/Pulumi.staging.yaml
@@ -13,6 +13,7 @@ config:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
   indexer:CHAIN_ID: "11155111"
   indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:D7aNTgIv8gY4epbh:mKyCvgukF7lPd76Gt36t/dIFggRDOHdTr7jfa3BSyc7+2mdXNdhT/TtymB9otk0NdcoqaesOx4tY972Hl5+b5NOKXBjRgDt2/m/cDKWDIrgllf+mFAZyBiFH8e2K+QQH7e00oOrKAkEH1Ne5+Q==
   indexer:RUST_LOG: debug

--- a/infra/indexer/components/indexer.ts
+++ b/infra/indexer/components/indexer.ts
@@ -26,7 +26,7 @@ export class IndexerInstance extends pulumi.ComponentResource {
       vpcId: pulumi.Output<string>;
       rdsPassword: pulumi.Output<string>;
       ethRpcUrl: pulumi.Output<string>;
-      boundlessAlertsTopicArn?: string;
+      boundlessAlertsTopicArns?: string[];
       startBlock: string;
       serviceMetricsNamespace: string;
       dockerRemoteBuilder?: string;
@@ -361,7 +361,7 @@ export class IndexerInstance extends pulumi.ComponentResource {
       },
     }, { dependsOn: [taskRole, taskRolePolicy] });
 
-    const alarmActions = args.boundlessAlertsTopicArn ? [args.boundlessAlertsTopicArn] : [];
+    const alarmActions = args.boundlessAlertsTopicArns ?? [];
 
     new aws.cloudwatch.LogMetricFilter(`${serviceName}-log-err-filter`, {
       name: `${serviceName}-log-err-filter`,

--- a/infra/indexer/components/monitor-lambda.ts
+++ b/infra/indexer/components/monitor-lambda.ts
@@ -21,8 +21,8 @@ export interface MonitorLambdaArgs {
   chainId: string;
   /** RUST_LOG level */
   rustLogLevel: string;
-  /** Boundless alerts topic ARN */
-  boundlessAlertsTopicArn?: string;
+  /** Boundless alerts topic ARNs */
+  boundlessAlertsTopicArns?: string[];
   /** Namespace for service metrics, e.g. operation health of the monitor/indexer infra */
   serviceMetricsNamespace: string;
   /** Namespace for market metrics, e.g. order volume, order count, etc. */
@@ -165,7 +165,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
       pattern: '?ERROR ?error ?Error',
     }, { dependsOn: [this.lambdaFunction] });
 
-    const alarmActions = args.boundlessAlertsTopicArn ? [args.boundlessAlertsTopicArn] : [];
+    const alarmActions = args.boundlessAlertsTopicArns ?? [];
 
     // 2 errors within 1 hour in the order generator triggers a SEV2 alarm.
     new aws.cloudwatch.MetricAlarm(`${serviceName}-monitor-error-alarm`, {

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -22,6 +22,8 @@ export = () => {
   const boundlessAddress = config.require('BOUNDLESS_ADDRESS');
   const baseStackName = config.require('BASE_STACK');
   const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
+  const boundlessPagerdutyTopicArn = config.get('PAGERDUTY_ALERTS_TOPIC_ARN');
+  const alertsTopicArns = [boundlessAlertsTopicArn, boundlessPagerdutyTopicArn].filter(Boolean) as string[];
   const startBlock = config.require('START_BLOCK');
   const rustLogLevel = config.get('RUST_LOG') || 'info';
 
@@ -51,7 +53,7 @@ export = () => {
     vpcId,
     rdsPassword,
     ethRpcUrl,
-    boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
     startBlock,
     serviceMetricsNamespace,
     dockerRemoteBuilder,
@@ -65,7 +67,7 @@ export = () => {
     rdsSgId: indexer.rdsSecurityGroupId,
     chainId: chainId,
     rustLogLevel: rustLogLevel,
-    boundlessAlertsTopicArn: boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
     serviceMetricsNamespace,
     marketMetricsNamespace,
   }, { parent: indexer, dependsOn: [indexer, indexer.dbUrlSecret, indexer.dbUrlSecretVersion] });

--- a/infra/order-generator/Pulumi.prod.yaml
+++ b/infra/order-generator/Pulumi.prod.yaml
@@ -7,6 +7,7 @@ config:
   order-generator-base:ETH_RPC_URL:
     secure: v1:OL1dK9lvanA4+cxN:k/qrgdflqF78VPuRdMICh7VWbkydVI/FMNG4tjcWS/jkmTXPnmoaY49uG43/uSfyQNoiAZU9L0XhMSJSwimdf3cAwG9TD3hsGmPRAXsaqoJnHw3hqw==
   order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-generator-base:BASE_STACK: organization/bootstrap/services-prod
   order-generator-base:BOUNDLESS_MARKET_ADDR: 0x006b92674E2A8d397884e293969f8eCD9f615f4C
   order-generator-base:SET_VERIFIER_ADDR: 0xEf0A93B2310d52358F1eCA0C946aD7D25596e7dd

--- a/infra/order-generator/Pulumi.staging.yaml
+++ b/infra/order-generator/Pulumi.staging.yaml
@@ -9,6 +9,7 @@ config:
   order-generator-base:ORDER_STREAM_URL:
     secure: v1:+5dxEU6iX85SMPrl:leEoJCPf57OO9LNagQuBXDEJVvLw+nTIRu5LixJ9Efhhi917Z+F9Qgz0I7ps7uGDiyobcMv2gYj56C4nYAkSMC2gsHI5cMQ5xEf58oe0dcRzYD+U
   order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-generator-base:BASE_STACK: organization/bootstrap/services-staging
   order-generator-base:BOUNDLESS_MARKET_ADDR: 0x2d124b86179F0De2d5B7A75E4dcD7e35a3363B16
   order-generator-base:SET_VERIFIER_ADDR: 0xEf0A93B2310d52358F1eCA0C946aD7D25596e7dd

--- a/infra/order-generator/index.ts
+++ b/infra/order-generator/index.ts
@@ -31,6 +31,8 @@ export = () => {
   const vpcId = baseStack.getOutput('VPC_ID') as pulumi.Output<string>;
   const privateSubnetIds = baseStack.getOutput('PRIVATE_SUBNET_IDS') as pulumi.Output<string[]>;
   const boundlessAlertsTopicArn = baseConfig.get('SLACK_ALERTS_TOPIC_ARN');
+  const boundlessPagerdutyTopicArn = baseConfig.get('PAGERDUTY_ALERTS_TOPIC_ARN');
+  const alertsTopicArns = [boundlessAlertsTopicArn, boundlessPagerdutyTopicArn].filter(Boolean) as string[];
   const interval = baseConfig.require('INTERVAL');
   const lockStake = baseConfig.require('LOCK_STAKE');
   const rampUp = baseConfig.require('RAMP_UP');
@@ -133,7 +135,7 @@ export = () => {
     secondsPerMCycle,
     vpcId,
     privateSubnetIds,
-    boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
     txTimeout,
   });
 
@@ -158,7 +160,7 @@ export = () => {
     secondsPerMCycle,
     vpcId,
     privateSubnetIds,
-    boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
     txTimeout,
   });
 };

--- a/infra/order-stream/Pulumi.prod-11155111.yaml
+++ b/infra/order-stream/Pulumi.prod-11155111.yaml
@@ -16,3 +16,4 @@ config:
   order-stream:ALB_DOMAIN: eth-sepolia.beboundless.xyz
   order-stream:CHAIN_ID: "11155111"
   order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic

--- a/infra/order-stream/Pulumi.staging.yaml
+++ b/infra/order-stream/Pulumi.staging.yaml
@@ -15,3 +15,4 @@ config:
     secure: v1:Q8vUXQ59MCkcmyw8:C8BUe4hjIDn+biTuqdDYoluH+rM6eRMO0LKjjmpN9EpQ7A==
   order-stream:CHAIN_ID: "11155111"
   order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -3,7 +3,7 @@ import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import * as docker_build from '@pulumi/docker-build';
 import * as pulumi from '@pulumi/pulumi';
-import { getServiceNameV1 } from '../../util';
+import { getServiceNameV1, Severity } from '../../util';
 import * as crypto from 'crypto';
 
 const SERVICE_NAME_BASE = 'order-stream';
@@ -31,7 +31,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       albDomain?: pulumi.Output<string>;
       ethRpcUrl: pulumi.Output<string>;
       bypassAddrs: string;
-      boundlessAlertsTopicArn?: string;
+      boundlessAlertsTopicArns?: string[];
     },
     opts?: pulumi.ComponentResourceOptions
   ) {
@@ -53,6 +53,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       albDomain,
       ethRpcUrl,
       bypassAddrs,
+      boundlessAlertsTopicArns,
     } = args;
 
     const stackName = pulumi.getStack();
@@ -491,7 +492,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       },
     });
 
-    const alarmActions = args.boundlessAlertsTopicArn ? [args.boundlessAlertsTopicArn] : [];
+    const alarmActions = boundlessAlertsTopicArns ?? [];
 
     new aws.cloudwatch.LogMetricFilter(`${serviceName}-log-err-filter`, {
       name: `${serviceName}-log-err-filter`,
@@ -506,9 +507,9 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       pattern: `"ERROR "`,
     }, { dependsOn: [service] });
 
-    // Two errors within an hour triggers alarm.
-    new aws.cloudwatch.MetricAlarm(`${serviceName}-error-alarm`, {
-      name: `${serviceName}-log-err`,
+    // Two errors within an hour triggers SEV2 alarm.
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-error-${Severity.SEV2}-alarm`, {
+      name: `${serviceName}-${Severity.SEV2}-log-err`,
       metricQueries: [
         {
           id: 'm1',
@@ -527,7 +528,33 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       evaluationPeriods: 60,
       datapointsToAlarm: 2,
       treatMissingData: 'notBreaching',
-      alarmDescription: 'Order stream log ERROR level',
+      alarmDescription: 'Order stream: 2 ERROR logs within an hour',
+      actionsEnabled: true,
+      alarmActions,
+    });
+
+    // Two errors within an hour triggers SEV2 alarm.
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-error-${Severity.SEV1}-alarm`, {
+      name: `${serviceName}-${Severity.SEV1}-log-err`,
+      metricQueries: [
+        {
+          id: 'm1',
+          metric: {
+            namespace: `Boundless/Services/${serviceName}`,
+            metricName: `${serviceName}-log-err`,
+            period: 60,
+            stat: 'Sum',
+          },
+          returnData: true,
+        },
+      ],
+      threshold: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      // Five errors within an hour triggers alarm.
+      evaluationPeriods: 60,
+      datapointsToAlarm: 5,
+      treatMissingData: 'notBreaching',
+      alarmDescription: 'Order stream: 5 ERROR logs within an hour',
       actionsEnabled: true,
       alarmActions,
     });
@@ -540,10 +567,8 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
     const loadBalancerId = pulumi.interpolate`${loadbalancer.loadBalancer.arn.apply((arn) => arn.split('/').pop())}`;
     const targetGroupId = pulumi.interpolate`targetgroup/${loadbalancer.defaultTargetGroup.arn.apply((arn) => arn.split('/').pop())}`;
 
-    new aws.cloudwatch.MetricAlarm(`${serviceName}-health-check-alarm`, {
-      name: `${serviceName}-health-check-alarm`,
-      comparisonOperator: 'GreaterThanOrEqualToThreshold',
-      evaluationPeriods: 1,
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-health-check-alarm-${Severity.SEV2}`, {
+      name: `${serviceName}-health-check-alarm-${Severity.SEV2}`,
       metricName: `UnHealthyHostCount`,
       dimensions: {
         TargetGroup: targetGroupId,
@@ -551,9 +576,31 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       },
       namespace: 'AWS/ApplicationELB',
       period: 60,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      evaluationPeriods: 60,
+      datapointsToAlarm: 2,
       statistic: 'Sum',
       threshold: 1,
-      alarmDescription: 'Order stream health check alarm',
+      alarmDescription: 'Order stream health check alarm failed 2 times within an hour',
+      actionsEnabled: true,
+      alarmActions,
+    });
+
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-health-check-alarm-${Severity.SEV1}`, {
+      name: `${serviceName}-health-check-alarm-${Severity.SEV1}`,
+      metricName: `UnHealthyHostCount`,
+      dimensions: {
+        TargetGroup: targetGroupId,
+        LoadBalancer: loadBalancerId,
+      },
+      namespace: 'AWS/ApplicationELB',
+      period: 60,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      evaluationPeriods: 60,
+      datapointsToAlarm: 5,
+      statistic: 'Sum',
+      threshold: 1,
+      alarmDescription: 'Order stream health check alarm failed 5 times within an hour',
       actionsEnabled: true,
       alarmActions,
     });
@@ -570,8 +617,8 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       pattern: 'FATAL',
     }, { dependsOn: [service] });
 
-    new aws.cloudwatch.MetricAlarm(`${serviceName}-fatal-alarm`, {
-      name: `${serviceName}-log-fatal`,
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-fatal-alarm-${Severity.SEV2}`, {
+      name: `${serviceName}-log-fatal-${Severity.SEV2}`,
       metricQueries: [
         {
           id: 'm1',
@@ -586,10 +633,34 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       ],
       threshold: 1,
       comparisonOperator: 'GreaterThanOrEqualToThreshold',
-      evaluationPeriods: 1,
+      evaluationPeriods: 60,
       datapointsToAlarm: 1,
       treatMissingData: 'notBreaching',
-      alarmDescription: `Order stream FATAL (task exited)`,
+      alarmDescription: `Order stream FATAL (task exited) 1 time within an hour`,
+      actionsEnabled: true,
+      alarmActions,
+    });
+
+    new aws.cloudwatch.MetricAlarm(`${serviceName}-fatal-alarm-${Severity.SEV1}`, {
+      name: `${serviceName}-log-fatal-${Severity.SEV1}`,
+      metricQueries: [
+        {
+          id: 'm1',
+          metric: {
+            namespace: `Boundless/Services/${serviceName}`,
+            metricName: `${serviceName}-log-fatal`,
+            period: 60,
+            stat: 'Sum',
+          },
+          returnData: true,
+        },
+      ],
+      threshold: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      evaluationPeriods: 60,
+      datapointsToAlarm: 3,
+      treatMissingData: 'notBreaching',
+      alarmDescription: `Order stream FATAL (task exited) 3 times within an hour`,
       actionsEnabled: true,
       alarmActions,
     });

--- a/infra/order-stream/index.ts
+++ b/infra/order-stream/index.ts
@@ -24,6 +24,8 @@ export = () => {
   const orderStreamPingTime = config.requireNumber('ORDER_STREAM_PING_TIME');
   const albDomain = config.getSecret('ALB_DOMAIN');
   const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
+  const boundlessPagerdutyTopicArn = config.get('PAGERDUTY_ALERTS_TOPIC_ARN');
+  const alertsTopicArns = [boundlessAlertsTopicArn, boundlessPagerdutyTopicArn].filter(Boolean) as string[];
 
   const baseStack = new pulumi.StackReference(baseStackName);
   const vpcId = baseStack.getOutput('VPC_ID') as pulumi.Output<string>;
@@ -46,7 +48,7 @@ export = () => {
     rdsPassword,
     ethRpcUrl,
     albDomain,
-    boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
   });
 
   return {

--- a/infra/pipelines/Pulumi.prod.yaml
+++ b/infra/pipelines/Pulumi.prod.yaml
@@ -9,5 +9,7 @@ config:
     secure: v1:J2ub3a8jGaglZCGc:S/I5GH1h/1w3UsfHCjjInBOGz3nQG7/W9wYf
   pipelines:WORKSPACE_SLACK_ID:
     secure: v1:vV+qgJdAOlWjWopo:NnPGhM8xj5jRtaKJengh0njuWGTQfw41lmoy
+  pipelines:PAGERDUTY_INTEGRATION_URL:
+    secure: v1:2E/GhMEBxiNIM0ZP:Ru621fMUaloOvdXAeH5c+E1wwz69G0bcwTYfxVpeib6mL+QjkJFfWoaKb4vowKVfvYeEP2+fWovxX98KBUhT1a6VfgW76s/ms2jWH8/Hs4a3V9S3qlxQtf8bPU069WFVMA==
 secretsprovider: awskms:///arn:aws:kms:us-west-2:968153779208:alias/pulumi-secrets-key
 encryptedkey: AQICAHhnm/1/W7/xeF2uxmXOGjFzOf6jjMX+KgbMb0K+LSCbsAFRXbSyr6AYSMcivVuIOKM1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM99POLOpwmSAsUSA6AgEQgDtWlwiW1A4Ljv+YiqVnhqlhSZhL08n2udrkFcXJOak8aa7RyAbspSlyMy/J6r9TffIO8mXOioXADQfokg==

--- a/infra/pipelines/index.ts
+++ b/infra/pipelines/index.ts
@@ -9,11 +9,11 @@ import { OrderStreamPipeline } from "./pipelines/order-stream";
 import { IndexerPipeline } from "./pipelines/indexer";
 import { CodePipelineSharedResources } from "./components/codePipelineResources";
 import * as aws from "@pulumi/aws";
-import { 
-  BOUNDLESS_DEV_ADMIN_ROLE_ARN, 
-  BOUNDLESS_OPS_ACCOUNT_ID, 
-  BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN, 
-  BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, 
+import {
+  BOUNDLESS_DEV_ADMIN_ROLE_ARN,
+  BOUNDLESS_OPS_ACCOUNT_ID,
+  BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN,
+  BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN,
   BOUNDLESS_STAGING_ADMIN_ROLE_ARN,
   BOUNDLESS_PROD_ADMIN_ROLE_ARN,
   BOUNDLESS_STAGING_ACCOUNT_ID,
@@ -72,6 +72,7 @@ const codePipelineSharedResources = new CodePipelineSharedResources("codePipelin
 const config = new pulumi.Config();
 const boundlessAlertsSlackId = config.requireSecret("BOUNDLESS_ALERTS_SLACK_ID");
 const workspaceSlackId = config.requireSecret("WORKSPACE_SLACK_ID");
+const pagerdutyIntegrationUrl = config.requireSecret("PAGERDUTY_INTEGRATION_URL");
 
 const notifications = new Notifications("notifications", {
   opsAccountId: BOUNDLESS_OPS_ACCOUNT_ID,
@@ -82,6 +83,7 @@ const notifications = new Notifications("notifications", {
   ],
   slackChannelId: boundlessAlertsSlackId,
   slackTeamId: workspaceSlackId,
+  pagerdutyIntegrationUrl,
 });
 
 // The Docker and GH tokens are used to avoid rate limiting issues when building in the pipelines.
@@ -149,3 +151,4 @@ const indexerPipeline = new IndexerPipeline("indexerPipeline", {
 export const bucketName = pulumiStateBucket.bucket.id;
 export const kmsKeyArn = pulumiSecrets.kmsKey.arn;
 export const boundlessAlertsTopicArn = notifications.slackSNSTopic.arn;
+export const boundlessPagerdutyTopicArn = notifications.pagerdutySNSTopic.arn;

--- a/infra/prover/Pulumi.prod.yaml
+++ b/infra/prover/Pulumi.prod.yaml
@@ -14,6 +14,7 @@ config:
   base-prover:GH_TOKEN_SECRET:
     secure: v1:KXu1uWAeTAyQlH22:Vz6MTNAKYLeZYsRD8xMgdoGMPB1RER5UaONIyN9mRvt79nEGBkgia+Ikn2E4PNvVzVoZGkul8EKw4pacbWel591tUwddGlUUSCYFIlL/YEJNLm0tu6pLjXbs5BJng854LMuiw0/EK2KswzZUUQ==
   base-prover:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  base-prover:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   bonsai-prover:BONSAI_API_KEY:
     secure: v1:DBLnIT+fWqeYZsZd:FEOPSijO1WHd24xhepKtRB37SnovAt7A+7QmgJJ84yUvoKAmntUYalyrTN3TvSspnpgR23dQlfM=
   bonsai-prover:PRIVATE_KEY:

--- a/infra/prover/Pulumi.staging.yaml
+++ b/infra/prover/Pulumi.staging.yaml
@@ -15,6 +15,7 @@ config:
   base-prover:GH_TOKEN_SECRET:
     secure: v1:uKW8SunjoJPWAf4l:GS38MomZJucbvxMfnp4PqigyTT4X7W9inHFdb53FOAXzhlpwIgL5fMURRviScfJaxE2l8chc+VALgMIywDoNFsc7kEvU8G/QerwZ1SWYhlLuu4w1IRi9sgrWGDhQmz62fSMYeNuNaaZG2LdZew==
   base-prover:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
+  base-prover:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   bonsai-prover:PRIVATE_KEY:
     secure: v1:XeT00OsvvQdg9y4K:jjqy1PfadM1Zo6XwgwI4Z0NmwDYA4akd3HvpD1BKQFt6YqB2QS8l03uccezLX3uFRy67UecCwDYVlP4bG+Np1ClK2O/Wm0h5n2En5XlaslU=
   bonsai-prover:BONSAI_API_KEY:

--- a/infra/prover/components/bentoBroker.ts
+++ b/infra/prover/components/bentoBroker.ts
@@ -27,12 +27,24 @@ export class BentoEC2Broker extends pulumi.ComponentResource {
         ciCacheSecret?: pulumi.Output<string>;
         githubTokenSecret?: pulumi.Output<string>;
         brokerTomlPath: string;
-        boundlessAlertsTopicArn?: string;
+        boundlessAlertsTopicArns?: string[];
         sshPublicKey?: string | pulumi.Output<string>;
     }, opts?: pulumi.ComponentResourceOptions) {
         super(name, name, opts);
 
-        const { boundlessMarketAddress, setVerifierAddress, ethRpcUrl, sshPublicKey, brokerTomlPath, privateKey, orderStreamUrl, pubSubNetIds, gitBranch, boundlessAlertsTopicArn, segmentSize } = args;
+        const {
+            boundlessMarketAddress,
+            setVerifierAddress,
+            ethRpcUrl,
+            sshPublicKey,
+            brokerTomlPath,
+            privateKey,
+            orderStreamUrl,
+            pubSubNetIds,
+            gitBranch,
+            boundlessAlertsTopicArns,
+            segmentSize
+        } = args;
 
         const region = "us-west-2";
         const serviceName = name;
@@ -574,7 +586,7 @@ reboot
             retentionInDays: 0,
         }, { parent: this });
 
-        const alarmActions = boundlessAlertsTopicArn ? [boundlessAlertsTopicArn] : [];
+        const alarmActions = boundlessAlertsTopicArns ?? [];
 
         createProverAlarms(serviceName, pulumi.output(logGroup), [logGroup, this.instance], alarmActions);
 

--- a/infra/prover/components/bonsaiBroker.ts
+++ b/infra/prover/components/bonsaiBroker.ts
@@ -26,14 +26,31 @@ export class BonsaiECSBroker extends pulumi.ComponentResource {
     ciCacheSecret?: pulumi.Output<string>;
     githubTokenSecret?: pulumi.Output<string>;
     brokerTomlPath: string;
-    boundlessAlertsTopicArn?: string;
+    boundlessAlertsTopicArns?: string[];
     dockerRemoteBuilder?: string;
   }, opts?: pulumi.ComponentResourceOptions) {
     super(`${name}-${args.chainId}`, name, opts);
 
     const isDev = pulumi.getStack() === "dev";
 
-    const { ethRpcUrl, privateKey, bonsaiApiUrl, dockerRemoteBuilder, bonsaiApiKey, orderStreamUrl, brokerTomlPath, boundlessMarketAddr: proofMarketAddr, setVerifierAddr, vpcId, privSubNetIds, dockerDir, dockerTag, ciCacheSecret, githubTokenSecret, boundlessAlertsTopicArn } = args;
+    const {
+      ethRpcUrl,
+      privateKey,
+      bonsaiApiUrl,
+      dockerRemoteBuilder,
+      bonsaiApiKey,
+      orderStreamUrl,
+      brokerTomlPath,
+      boundlessMarketAddr: proofMarketAddr,
+      setVerifierAddr,
+      vpcId,
+      privSubNetIds,
+      dockerDir,
+      dockerTag,
+      ciCacheSecret,
+      githubTokenSecret,
+      boundlessAlertsTopicArns
+    } = args;
     const serviceName = name;
 
     const ethRpcUrlSecret = new aws.secretsmanager.Secret(`${serviceName}-brokerEthRpc`);
@@ -389,7 +406,7 @@ export class BonsaiECSBroker extends pulumi.ComponentResource {
       },
     }, { dependsOn: [fileSystem, mountTargets] });
 
-    const alarmActions = boundlessAlertsTopicArn ? [boundlessAlertsTopicArn] : [];
+    const alarmActions = boundlessAlertsTopicArns ?? [];
 
     createProverAlarms(serviceName, logGroup, [service, logGroup], alarmActions);
   }

--- a/infra/prover/index.ts
+++ b/infra/prover/index.ts
@@ -32,6 +32,8 @@ export = () => {
   const githubTokenSecret = baseConfig.getSecret('GH_TOKEN_SECRET');
   const brokerTomlPath = baseConfig.require('BROKER_TOML_PATH')
   const boundlessAlertsTopicArn = baseConfig.get('SLACK_ALERTS_TOPIC_ARN');
+  const boundlessPagerdutyTopicArn = baseConfig.get('PAGERDUTY_ALERTS_TOPIC_ARN');
+  const alertsTopicArns = [boundlessAlertsTopicArn, boundlessPagerdutyTopicArn].filter(Boolean) as string[];
 
   // Bonsai Prover Config
   const bonsaiProverPrivateKey = isDev ? getEnvVar("BONSAI_PROVER_PRIVATE_KEY") : bonsaiConfig.requireSecret('PRIVATE_KEY');
@@ -61,7 +63,7 @@ export = () => {
     dockerTag,
     ciCacheSecret,
     githubTokenSecret,
-    boundlessAlertsTopicArn,
+    boundlessAlertsTopicArns: alertsTopicArns,
     sshPublicKey: bentoProverSshPublicKey
   });
 
@@ -84,7 +86,7 @@ export = () => {
       dockerTag,
       ciCacheSecret,
       githubTokenSecret,
-      boundlessAlertsTopicArn,
+      boundlessAlertsTopicArns: alertsTopicArns,
       dockerRemoteBuilder,
     });
   }

--- a/infra/slasher/Pulumi.prod.yaml
+++ b/infra/slasher/Pulumi.prod.yaml
@@ -16,3 +16,4 @@ config:
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   slasher:GH_TOKEN_SECRET:
     secure: v1:i3GxAv8H4tqMAos5:gaQ+Ameo+lRFYdu0nw/DbW4mPMAKb4SrNF3QGjtc/WQVg06y1XEt7E7DIbiTNmrkxqChb4TSqgN5ru4+e+J6C46HdTFw6KJpKqAJDt6ja2J9IgOAxiq9E1WjbMXwgmGWqJWWVGb+fgEv6kkVvQ==
+  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic

--- a/infra/slasher/Pulumi.staging.yaml
+++ b/infra/slasher/Pulumi.staging.yaml
@@ -16,3 +16,4 @@ config:
   slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   slasher:GH_TOKEN_SECRET:
     secure: v1:ax6tdJIF/DIXguKN:AOrpjbk/vEfTIF7ShLmdQbfAoy2ZTHxHJYGv48NFMlfd2HtCqmKpsZACv1Tw3wnZxt+qhjFaCah6G981Cxi8QRGsEkyunQp6QEi/RvsXQT4FGiVY/kzM4HyCDDD402x/COrClodmIL1cWVGXbQ==
+  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic


### PR DESCRIPTION
* Adds new SNS topic that forwards messages to Pagerduty
* Configures all alarms with either SEV1 or SEV2 string. These strings are used by Pagerduty to determine what severity Pagerduty incident to create. This is configured in Pagerduty's "Service Orchestration Rules" section

Not able to fully test locally, so may be follow up PRs




