### PR TITLE
BM-958: add just installer to prover setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -336,7 +336,7 @@ configure_docker_nvidia
 install_rust
 
 # Install Just
-install_rust
+install_just
 
 # Install CUDA Toolkit
 install_cuda

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,217 +31,233 @@ LOG_FILE="/var/log/${SCRIPT_NAME%.sh}.log"
 
 # Function to display informational messages
 info() {
-    printf "\e[34m[INFO]\e[0m %s\n" "$1"
+  printf "\e[34m[INFO]\e[0m %s\n" "$1"
 }
 
 # Function to display success messages
 success() {
-    printf "\e[32m[SUCCESS]\e[0m %s\n" "$1"
+  printf "\e[32m[SUCCESS]\e[0m %s\n" "$1"
 }
 
 # Function to display error messages
 error() {
-    printf "\e[31m[ERROR]\e[0m %s\n" "$1" >&2
+  printf "\e[31m[ERROR]\e[0m %s\n" "$1" >&2
 }
 
 is_package_installed() {
-    dpkg -s "$1" &> /dev/null
+  dpkg -s "$1" &>/dev/null
 }
-
 
 # Function to check if the operating system is Ubuntu
 check_os() {
-    if [[ -f /etc/os-release ]]; then
-        # Source the os-release file to get OS information
-        # shellcheck source=/dev/null
-        . /etc/os-release
-        if [[ "${ID,,}" != "ubuntu" ]]; then
-            error "Unsupported operating system: $NAME. This script is intended for Ubuntu."
-            exit 1
-        elif [[ "${VERSION_ID,,}" != "22.04" && "${VERSION_ID,,}" != "20.04" ]]; then
-            error "Unsupported operating system verion: $VERSION. This script is intended for Ubuntu 20.04 or 22.04."
-            exit 1
-        else
-            info "Operating System: $PRETTY_NAME"
-        fi
+  if [[ -f /etc/os-release ]]; then
+    # Source the os-release file to get OS information
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    if [[ "${ID,,}" != "ubuntu" ]]; then
+      error "Unsupported operating system: $NAME. This script is intended for Ubuntu."
+      exit 1
+    elif [[ "${VERSION_ID,,}" != "22.04" && "${VERSION_ID,,}" != "20.04" ]]; then
+      error "Unsupported operating system verion: $VERSION. This script is intended for Ubuntu 20.04 or 22.04."
+      exit 1
     else
-        error "/etc/os-release not found. Unable to determine the operating system."
-        exit 1
+      info "Operating System: $PRETTY_NAME"
     fi
+  else
+    error "/etc/os-release not found. Unable to determine the operating system."
+    exit 1
+  fi
 }
 
 # Function to update and upgrade the system
 update_system() {
-    info "Updating and upgrading the system packages..."
-    {
-        sudo apt update -y
-        sudo apt upgrade -y
-    } >> "$LOG_FILE" 2>&1
-    success "System packages updated and upgraded successfully."
+  info "Updating and upgrading the system packages..."
+  {
+    sudo apt update -y
+    sudo apt upgrade -y
+  } >>"$LOG_FILE" 2>&1
+  success "System packages updated and upgraded successfully."
 }
 
 # Function to install essential packages
 install_packages() {
-    local packages=(
-        nvtop
-        ubuntu-drivers-common
-        build-essential
-        libssl-dev
-        curl
-        gnupg
-        ca-certificates
-        lsb-release
-        jq
-    )
+  local packages=(
+    nvtop
+    ubuntu-drivers-common
+    build-essential
+    libssl-dev
+    curl
+    gnupg
+    ca-certificates
+    lsb-release
+    jq
+  )
 
-    info "Installing essential packages: ${packages[*]}..."
-    {
-        sudo apt install -y "${packages[@]}"
-    } >> "$LOG_FILE" 2>&1
-    success "Essential packages installed successfully."
+  info "Installing essential packages: ${packages[*]}..."
+  {
+    sudo apt install -y "${packages[@]}"
+  } >>"$LOG_FILE" 2>&1
+  success "Essential packages installed successfully."
 }
 
 # Function to install GPU drivers
 install_gpu_drivers() {
-    info "Detecting and installing appropriate GPU drivers..."
-    {
-        sudo ubuntu-drivers install
-    } >> "$LOG_FILE" 2>&1
-    success "GPU drivers installed successfully."
+  info "Detecting and installing appropriate GPU drivers..."
+  {
+    sudo ubuntu-drivers install
+  } >>"$LOG_FILE" 2>&1
+  success "GPU drivers installed successfully."
 }
 
 # Function to install Rust
 install_rust() {
-    if command -v rustc &> /dev/null; then
-        info "Rust is already installed. Skipping Rust installation."
+  if command -v rustc &>/dev/null; then
+    info "Rust is already installed. Skipping Rust installation."
+  else
+    info "Installing Rust programming language..."
+    {
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    } >>"$LOG_FILE" 2>&1
+    # Source Rust environment variables for the current session
+    if [[ -f "$HOME/.cargo/env" ]]; then
+      # shellcheck source=/dev/null
+      source "$HOME/.cargo/env"
+      success "Rust installed successfully."
     else
-        info "Installing Rust programming language..."
-        {
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        } >> "$LOG_FILE" 2>&1
-        # Source Rust environment variables for the current session
-        if [[ -f "$HOME/.cargo/env" ]]; then
-            # shellcheck source=/dev/null
-            source "$HOME/.cargo/env"
-            success "Rust installed successfully."
-        else
-            error "Rust installation failed. ~/.cargo/env not found."
-            exit 1
-        fi
+      error "Rust installation failed. ~/.cargo/env not found."
+      exit 1
     fi
+  fi
+}
+
+# Function to install the `just` command runner
+install_just() {
+  if command -v just &>/dev/null; then
+    info "'just' is already installed. Skipping."
+    return
+  fi
+
+  info "Installing the 'just' command-runner…"
+  {
+    # Install the latest pre-built binary straight to /usr/local/bin
+    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh |
+      sudo bash -s -- --to /usr/local/bin
+  } >>"$LOG_FILE" 2>&1
+
+  success "'just' installed successfully."
 }
 
 # Function to install CUDA Toolkit
 install_cuda() {
-    if is_package_installed "cuda-toolkit"; then
-        info "CUDA Toolkit is already installed. Skipping CUDA installation."
-    else
-        info "Installing CUDA Toolkit and dependencies..."
-        {
-            local distribution
-            distribution=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"'| tr -d '\.')
-            info "Installing Nvidia CUDA keyring and repo"
-            wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/$(/usr/bin/uname -m)/cuda-keyring_1.1-1_all.deb
-            sudo dpkg -i cuda-keyring_1.1-1_all.deb
-            rm cuda-keyring_1.1-1_all.deb
-            sudo apt-get update
-            sudo apt-get install -y cuda-toolkit
-        } >> "$LOG_FILE" 2>&1
-        success "CUDA Toolkit installed successfully."
-    fi
+  if is_package_installed "cuda-toolkit"; then
+    info "CUDA Toolkit is already installed. Skipping CUDA installation."
+  else
+    info "Installing CUDA Toolkit and dependencies..."
+    {
+      local distribution
+      distribution=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | tr -d '\.')
+      info "Installing Nvidia CUDA keyring and repo"
+      wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/$(/usr/bin/uname -m)/cuda-keyring_1.1-1_all.deb
+      sudo dpkg -i cuda-keyring_1.1-1_all.deb
+      rm cuda-keyring_1.1-1_all.deb
+      sudo apt-get update
+      sudo apt-get install -y cuda-toolkit
+    } >>"$LOG_FILE" 2>&1
+    success "CUDA Toolkit installed successfully."
+  fi
 }
 
 # Function to install Docker
 install_docker() {
-    if command -v docker &> /dev/null; then
-        info "Docker is already installed. Skipping Docker installation."
-    else
-        info "Installing Docker..."
-        {
-            # Install prerequisites
-            sudo apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+  if command -v docker &>/dev/null; then
+    info "Docker is already installed. Skipping Docker installation."
+  else
+    info "Installing Docker..."
+    {
+      # Install prerequisites
+      sudo apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 
-            # Add Docker’s official GPG key
-            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      # Add Docker’s official GPG key
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-            # Set up the stable repository
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      # Set up the stable repository
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 
-            # Update package index
-            sudo apt update -y
+      # Update package index
+      sudo apt update -y
 
-            # Install Docker Engine, CLI, and Containerd
-            sudo apt install -y docker-ce docker-ce-cli containerd.io
+      # Install Docker Engine, CLI, and Containerd
+      sudo apt install -y docker-ce docker-ce-cli containerd.io
 
-            # Enable Docker
-            sudo systemctl enable docker
+      # Enable Docker
+      sudo systemctl enable docker
 
-            # Start Docker Service
-            sudo systemctl start docker
+      # Start Docker Service
+      sudo systemctl start docker
 
-        } >> "$LOG_FILE" 2>&1
-        success "Docker installed and started successfully."
-    fi
+    } >>"$LOG_FILE" 2>&1
+    success "Docker installed and started successfully."
+  fi
 }
 
 # Function to add user to Docker group
 add_user_to_docker_group() {
-    local username
-    username=$(logname 2>/dev/null || echo "$SUDO_USER")
+  local username
+  username=$(logname 2>/dev/null || echo "$SUDO_USER")
 
-    if id -nG "$username" | grep -qw "docker"; then
-        info "User '$username' is already in the 'docker' group."
-    else
-        info "Adding user '$username' to the 'docker' group..."
-        {
-            sudo usermod -aG docker "$username"
-        } >> "$LOG_FILE" 2>&1
-        success "User '$username' added to the 'docker' group."
-        info "To apply the new group membership, please log out and log back in."
-    fi
+  if id -nG "$username" | grep -qw "docker"; then
+    info "User '$username' is already in the 'docker' group."
+  else
+    info "Adding user '$username' to the 'docker' group..."
+    {
+      sudo usermod -aG docker "$username"
+    } >>"$LOG_FILE" 2>&1
+    success "User '$username' added to the 'docker' group."
+    info "To apply the new group membership, please log out and log back in."
+  fi
 }
 
 # Function to install NVIDIA Container Toolkit
 install_nvidia_container_toolkit() {
-    info "Checking NVIDIA Container Toolkit installation..."
+  info "Checking NVIDIA Container Toolkit installation..."
 
-    if is_package_installed "nvidia-docker2"; then
-        success "NVIDIA Container Toolkit (nvidia-docker2) is already installed."
-        return
-    fi
+  if is_package_installed "nvidia-docker2"; then
+    success "NVIDIA Container Toolkit (nvidia-docker2) is already installed."
+    return
+  fi
 
-    info "Installing NVIDIA Container Toolkit..."
+  info "Installing NVIDIA Container Toolkit..."
 
-    {
-        # Add the package repositories
-        local distribution
-        distribution=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')
-        curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-        curl -s -L https://nvidia.github.io/nvidia-docker/"$distribution"/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+  {
+    # Add the package repositories
+    local distribution
+    distribution=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"')
+    curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+    curl -s -L https://nvidia.github.io/nvidia-docker/"$distribution"/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
 
-        # Update the package lists
-        sudo apt update -y
+    # Update the package lists
+    sudo apt update -y
 
-        # Install the NVIDIA Docker support
-        sudo apt install -y nvidia-docker2
+    # Install the NVIDIA Docker support
+    sudo apt install -y nvidia-docker2
 
-        # Restart Docker to apply changes
-        sudo systemctl restart docker
-    } >> "$LOG_FILE" 2>&1
+    # Restart Docker to apply changes
+    sudo systemctl restart docker
+  } >>"$LOG_FILE" 2>&1
 
-    success "NVIDIA Container Toolkit installed successfully."
+  success "NVIDIA Container Toolkit installed successfully."
 }
 
 # Function to configure Docker daemon for NVIDIA
 configure_docker_nvidia() {
-    info "Configuring Docker to use NVIDIA runtime by default..."
+  info "Configuring Docker to use NVIDIA runtime by default..."
 
-    {
-        # Create Docker daemon configuration directory if it doesn't exist
-        sudo mkdir -p /etc/docker
+  {
+    # Create Docker daemon configuration directory if it doesn't exist
+    sudo mkdir -p /etc/docker
 
-        # Create or overwrite daemon.json with NVIDIA runtime configuration
-        sudo tee /etc/docker/daemon.json <<EOF
+    # Create or overwrite daemon.json with NVIDIA runtime configuration
+    sudo tee /etc/docker/daemon.json <<EOF
 {
     "default-runtime": "nvidia",
     "runtimes": {
@@ -253,29 +269,29 @@ configure_docker_nvidia() {
 }
 EOF
 
-        # Restart Docker to apply the new configuration
-        sudo systemctl restart docker
-    } >> "$LOG_FILE" 2>&1
+    # Restart Docker to apply the new configuration
+    sudo systemctl restart docker
+  } >>"$LOG_FILE" 2>&1
 
-    success "Docker configured to use NVIDIA runtime by default."
+  success "Docker configured to use NVIDIA runtime by default."
 }
 
 # Function to perform system cleanup
 cleanup() {
-    info "Cleaning up unnecessary packages..."
-    {
-        sudo apt autoremove -y
-        sudo apt autoclean -y
-    } >> "$LOG_FILE" 2>&1
-    success "Cleanup completed."
+  info "Cleaning up unnecessary packages..."
+  {
+    sudo apt autoremove -y
+    sudo apt autoclean -y
+  } >>"$LOG_FILE" 2>&1
+  success "Cleanup completed."
 }
 
 init_git_submodules() {
-    info "ensuring submodules are initialized..."
-    {
-        git submodule update --init --recursive
-    } >> "$LOG_FILE" 2>&1
-    success "git submodules initialized successfully"
+  info "ensuring submodules are initialized..."
+  {
+    git submodule update --init --recursive
+  } >>"$LOG_FILE" 2>&1
+  success "git submodules initialized successfully"
 }
 
 # =============================================================================
@@ -318,6 +334,9 @@ configure_docker_nvidia
 # Install Rust
 install_rust
 
+# Install Just
+install_just
+
 # Install CUDA Toolkit
 install_cuda
 
@@ -328,20 +347,20 @@ success "All tasks completed successfully!"
 
 # Optionally, prompt to reboot if necessary
 if [ -t 0 ]; then
-    # We're in an interactive terminal
-    read -rp "Do you want to reboot now to apply all changes? (y/N): " REBOOT
-    case "$REBOOT" in
-        [yY][eE][sS]|[yY])
-            info "Rebooting the system..."
-            reboot
-            ;;
-        *)
-            info "Reboot skipped. Please consider rebooting your system to apply all changes."
-            ;;
-    esac
+  # We're in an interactive terminal
+  read -rp "Do you want to reboot now to apply all changes? (y/N): " REBOOT
+  case "$REBOOT" in
+  [yY][eE][sS] | [yY])
+    info "Rebooting the system..."
+    reboot
+    ;;
+  *)
+    info "Reboot skipped. Please consider rebooting your system to apply all changes."
+    ;;
+  esac
 else
-    # We're in a non-interactive environment (like EC2 user data)
-    info "Running in non-interactive mode. Skipping reboot prompt."
+  # We're in a non-interactive environment (like EC2 user data)
+  info "Running in non-interactive mode. Skipping reboot prompt."
 fi
 
 # Display end message with timestamp


### PR DESCRIPTION
I noticed when running a prover on a fresh machine, that we recommend you run the setup script, and then we ask to run a lot of different `just` commands. If you're running this on a fresh machine, the script handily installs Rust, and Docker and Nvidia etc. dependencies for you, but not the `just` command runner.

It felt like it was missing, so I added it to the `setup.sh` script and verified it worked on an Ubuntu 22.04 install. 
