### PR TITLE
BM-980: Fix order stream ws stake requirement. Adjust alerts and logs

### DIFF
--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -121,9 +121,9 @@ pub struct Args {
     #[clap(long, env)]
     boundless_market_address: Address,
 
-    /// Minimum stake balance required to connect to the WebSocket
-    #[clap(long, value_parser = parse_ether)]
-    min_balance: U256,
+    /// Minimum stake balance, in raw units, required to connect to the WebSocket
+    #[clap(long)]
+    min_balance_raw: U256,
 
     /// Maximum number of WebSocket connections
     #[clap(long, default_value = "100")]
@@ -294,7 +294,7 @@ impl From<&Args> for Config {
         Self {
             rpc_url: args.rpc_url.clone(),
             market_address: args.boundless_market_address,
-            min_balance: args.min_balance,
+            min_balance: args.min_balance_raw,
             max_connections: args.max_connections,
             queue_size: args.queue_size,
             domain: args.domain.clone(),

--- a/infra/indexer/Pulumi.prod-11155111.yaml
+++ b/infra/indexer/Pulumi.prod-11155111.yaml
@@ -16,4 +16,4 @@ config:
   indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:LfbDb8lBoozxHg+u:MSyFlUK/ayFKEXiZ2fvJuuTehwJeQBWsq4FruaZCOkxtxMpVwZnZ0frKzsLXN5UD8NRPNWC/NSfTu9oq4onmDcnn/XULgsiJerGtpuJNvjqjAwuG6GEZM61S1zoEgvI0My09F57JH7jV3OfLAQ==
-  indexer:RUST_LOG: "indexer_monitor=debug,alloy_rpc_client=info,alloy=info"
+  indexer:RUST_LOG: "indexer_monitor=debug"

--- a/infra/indexer/Pulumi.prod-11155111.yaml
+++ b/infra/indexer/Pulumi.prod-11155111.yaml
@@ -16,4 +16,4 @@ config:
   indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:GH_TOKEN_SECRET:
     secure: v1:LfbDb8lBoozxHg+u:MSyFlUK/ayFKEXiZ2fvJuuTehwJeQBWsq4FruaZCOkxtxMpVwZnZ0frKzsLXN5UD8NRPNWC/NSfTu9oq4onmDcnn/XULgsiJerGtpuJNvjqjAwuG6GEZM61S1zoEgvI0My09F57JH7jV3OfLAQ==
-  indexer:RUST_LOG: "indexer_monitor=debug"
+  indexer:RUST_LOG: "indexer_monitor=debug,alloy_rpc_client=info,alloy=info"

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -539,26 +539,26 @@ export const alarmConfig: ChainStageAlarms = {
         // Expired and slashed requests are not necessarily problems with the market. We keep these at low threshold
         // just during the initial launch for monitoring purposes.
         expiredRequests: [{
-          description: "greater than 2 expired orders in 30 minutes",
+          description: "greater than 15 expired orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 900,
+            period: 3600,
           },
           alarmConfig: {
-            threshold: 2,
+            threshold: 15,
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             comparisonOperator: "GreaterThanOrEqualToThreshold",
           }
         }],
         slashedRequests: [{
-          description: "greater than 2 slashed orders in 30 minutes",
+          description: "greater than 15 slashed orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 900,
+            period: 3600,
           },
           alarmConfig: {
-            threshold: 2,
+            threshold: 15,
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             comparisonOperator: "GreaterThanOrEqualToThreshold",
@@ -771,26 +771,26 @@ export const alarmConfig: ChainStageAlarms = {
         // Expired and slashed requests are not necessarily problems with the market. We keep these at low threshold
         // just during the initial launch for monitoring purposes.
         expiredRequests: [{
-          description: "greater than 2 expired orders in 30 minutes",
+          description: "greater than 15 expired orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800,
+            period: 3600,
           },
           alarmConfig: {
-            threshold: 2,
+            threshold: 15,
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             comparisonOperator: "GreaterThanOrEqualToThreshold",
           }
         }],
         slashedRequests: [{
-          description: "greater than 2 slashed orders in 30 minutes",
+          description: "greater than 15 slashed orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800,
+            period: 3600,
           },
           alarmConfig: {
-            threshold: 2,
+            threshold: 15,
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             comparisonOperator: "GreaterThanOrEqualToThreshold",

--- a/infra/order-stream/Pulumi.prod-11155111.yaml
+++ b/infra/order-stream/Pulumi.prod-11155111.yaml
@@ -7,7 +7,7 @@ config:
   order-stream:BYPASS_ADDRS: 0x821Abe5Dfa67c08af9a67C344C3b2651F7960136
   order-stream:DOCKER_DIR: ../../
   order-stream:DOCKER_TAG: latest
-  order-stream:MIN_BALANCE: "0.0010"
+  order-stream:MIN_BALANCE_RAW: "1000000000000000"
   order-stream:ORDER_STREAM_PING_TIME: "100"
   order-stream:ETH_RPC_URL:
     secure: v1:QijPKfdQkkzW2v0w:zn86oTJZDFE33kBUS9WbpFh8uRF7j9FZXC3KTzmk6R8oxD9CWkp1dZLJN0X6s37DzkhiXTkmIyUUuB2EZIpS7Pv2D3PYx9iTphxBbRr17NfVMkGvWg==

--- a/infra/order-stream/Pulumi.prod-8453.yaml
+++ b/infra/order-stream/Pulumi.prod-8453.yaml
@@ -7,7 +7,7 @@ config:
   order-stream:BYPASS_ADDRS: 0x821Abe5Dfa67c08af9a67C344C3b2651F7960136
   order-stream:DOCKER_DIR: ../../
   order-stream:DOCKER_TAG: latest
-  order-stream:MIN_BALANCE: "0.0010"
+  order-stream:MIN_BALANCE_RAW: "5000000"
   order-stream:ORDER_STREAM_PING_TIME: "100"
   order-stream:ETH_RPC_URL:
     secure: v1:BmDPg7C3ZPG1qfGx:LcvkKGyImYzT3zW8vxTe7ehtZWicVxDaMUFuBGaQjv/kjEH8pgb6UaDsXszBni+0SxDIasxdLxkEEnx0kpBmNHMtqPvVcQ7IWj6ogezq+iKdT4ieWXE=

--- a/infra/order-stream/Pulumi.staging.yaml
+++ b/infra/order-stream/Pulumi.staging.yaml
@@ -7,7 +7,7 @@ config:
   order-stream:BYPASS_ADDRS: 0x821Abe5Dfa67c08af9a67C344C3b2651F7960136
   order-stream:DOCKER_DIR: ../../
   order-stream:DOCKER_TAG: latest
-  order-stream:MIN_BALANCE: "0.0010"
+  order-stream:MIN_BALANCE_RAW: "1000000000000000"
   order-stream:ORDER_STREAM_PING_TIME: "100"
   order-stream:ETH_RPC_URL:
     secure: v1:iZMIczncztFwXYtI:qrmC1R9gmKYmHKl0xiBnq80TaUU3hyUbES2BauboUItSks0tDfmbHAxFznc3wFOjyF2w5xqgTpVw9TA+DYwuJ6h4JKWgqEIVIQOOat1NJ6LLGma9/A==

--- a/infra/order-stream/components/order-stream.ts
+++ b/infra/order-stream/components/order-stream.ts
@@ -24,7 +24,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       privSubNetIds: pulumi.Output<string[]>;
       pubSubNetIds: pulumi.Output<string[]>;
       githubTokenSecret?: pulumi.Output<string>;
-      minBalance: string;
+      minBalanceRaw: string;
       boundlessAddress: string;
       vpcId: pulumi.Output<string>;
       rdsPassword: pulumi.Output<string>;
@@ -46,7 +46,7 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
       privSubNetIds,
       pubSubNetIds,
       githubTokenSecret,
-      minBalance,
+      minBalanceRaw,
       boundlessAddress,
       vpcId,
       rdsPassword,
@@ -450,8 +450,8 @@ export class OrderStreamInstance extends pulumi.ComponentResource {
             ethRpcUrl,
             '--boundless-market-address',
             boundlessAddress,
-            '--min-balance',
-            minBalance,
+            '--min-balance-raw',
+            minBalanceRaw,
             '--bypass-addrs',
             bypassAddrs,
             '--domain',

--- a/infra/order-stream/index.ts
+++ b/infra/order-stream/index.ts
@@ -19,7 +19,7 @@ export = () => {
   const ciCacheSecret = config.getSecret('CI_CACHE_SECRET');
   const bypassAddrs = config.require('BYPASS_ADDRS');
   const boundlessAddress = config.require('BOUNDLESS_ADDRESS');
-  const minBalance = config.require('MIN_BALANCE');
+  const minBalanceRaw = config.require('MIN_BALANCE_RAW');
   const baseStackName = config.require('BASE_STACK');
   const orderStreamPingTime = config.requireNumber('ORDER_STREAM_PING_TIME');
   const albDomain = config.getSecret('ALB_DOMAIN');

--- a/infra/prover/components/bentoBroker.ts
+++ b/infra/prover/components/bentoBroker.ts
@@ -419,7 +419,24 @@ cat > /opt/aws/amazon-cloudwatch-agent/bin/config.json << 'EOF'
                     {
                         "file_path": "/local/docker/containers/*/*.log",
                         "log_group_name": "${name}",
-                        "log_stream_name": "${name}"
+                        "log_stream_name": "${name}",
+                        "filters": [
+                            {
+                                "type": "include",
+                                "expression": "broker"
+                            }
+                        ]
+                    },
+                    {
+                        "file_path": "/local/docker/containers/*/*.log",
+                        "log_group_name": "${name}/bento",
+                        "log_stream_name": "${name}/bento",
+                        "filters": [
+                            {
+                                "type": "exclude",
+                                "expression": "broker"
+                            }
+                        ]
                     }
                 ]
             }


### PR DESCRIPTION
* Currently you need 1 trillion USDC deposited to connect to the order stream due to the decimal difference. Adjusted it to 5 USDC.
* Changing the top level fulfillment and expired alarms. We are testing in staging/prod and seeing these alarms triggered frequently
* Splitting Bento logs from Broker logs in the Bento Broker cloudwatch logs groups
* Also making the logs on the monitor easier to parse
