### PR TITLE
BM-986: configure expired requests alarm

### DIFF
--- a/infra/indexer/components/alarms.ts
+++ b/infra/indexer/components/alarms.ts
@@ -87,7 +87,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
                 },
                 {
                     id: "sr",
-                    expression: "IF(a + b > 0, a / (a + b), 1)",
+                    expression: "IF(a + b > 0, IF(a / (a + b) < 0.2, 0, IF(AND(a / (a + b) < 0.8, b >= 5), 0, 1)), 1)",
                     label: "SuccessRate",
                     returnData: true,
                 },


### PR DESCRIPTION
Given that this can be triggered with invalid requests, changes the condition to be if <20% of requests are being fulfilled or if <80% of requests are fulfilled and the number of failed requests are more than 5.

This can still be triggered somewhat easily, and I think this configuration is still bad, just trying to guess a balance given unclear what the alarm would look like given how easily it is to trigger accidentally (and at very little cost if submitting off-chain)