### PR TITLE
fix invalid license references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,10 +13,10 @@ Licensed Work:        Boundless-xyz
                       The Licensed Work is (c) Boundless Foundation
 
 Additional Use Grant: Any uses listed and defined at
-                      https://github.com/boundless-xyz/boundless/license/boundless-license-grants
+                      https://github.com/boundless-xyz/boundless/blob/main/licenses/boundless-license-grants
 
 Change Date:          The earlier of 2026-02-06 or a date specified at
-                      https://github.com/boundless-xyz/boundless/license/boundless-license-date
+                      https://github.com/boundless-xyz/boundless/blob/main/licenses/boundless-license-date
 
 Change License:       Apache 2.0
 


### PR DESCRIPTION
The changes include:
- Updated the path from `/license/boundless-license-grants` to `/blob/main/licenses/boundless-license-grants`
- Updated the path from `/license/boundless-license-date` to `/blob/main/licenses/boundless-license-date`

These corrections ensure proper access to the license documentation.