### PR TITLE
BM-990: Event poll error to unexpected, balance alerts for order gens / slasher, scale down sep OG pricing

### DIFF
--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -243,11 +243,17 @@ async fn run(args: &MainArgs) -> Result<()> {
                         format_units(balance, "ether")?,
                         format_units(auto_deposit, "ether")?
                     );
-                    market.deposit(auto_deposit).await?;
-                    tracing::info!(
-                        "Successfully deposited {} ETH",
-                        format_units(auto_deposit, "ether")?
-                    );
+                    match market.deposit(auto_deposit).await {
+                        Ok(_) => {
+                            tracing::info!(
+                                "Successfully deposited {} ETH",
+                                format_units(auto_deposit, "ether")?
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to auto deposit ETH: {e:?}");
+                        }
+                    }
                 }
             }
         }

--- a/infra/order-generator/Pulumi.prod-11155111.yaml
+++ b/infra/order-generator/Pulumi.prod-11155111.yaml
@@ -18,7 +18,7 @@ config:
   order-generator-base:CHAIN_ID: "11155111"
   order-generator-base:INTERVAL: "300"
   order-generator-base:LOCK_STAKE_RAW: "100000000000000000" # 0.1 ETH
-  order-generator-base:MAX_PRICE_PER_MCYCLE: "0.01"
+  order-generator-base:MAX_PRICE_PER_MCYCLE: "0.0075"
   order-generator-base:MIN_PRICE_PER_MCYCLE: "0"
   order-generator-base:RAMP_UP: "600"
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -30,6 +30,10 @@ config:
   order-generator-base:TX_TIMEOUT: "120"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:9iJ6gE5+gp4aipMW:lZlt7k89kafxnLvr8Qe0sStef/3gNEOcr67breAfH/sSrlgL4m6k081WHMUpaU2doI683Sd0TQ+kSnbLKINXfxvqiw/EFfhz4SxOks6d9UI=
-  order-generator-offchain:AUTO_DEPOSIT: "20"
+  order-generator-offchain:AUTO_DEPOSIT: "15"
+  order-generator-offchain:WARN_BALANCE_BELOW: "50"
+  order-generator-offchain:ERROR_BALANCE_BELOW: "25"
+  order-generator-onchain:WARN_BALANCE_BELOW: "50"
+  order-generator-onchain:ERROR_BALANCE_BELOW: "25"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:X0x504eGSlReaNWU:HHKOYSpWFvByYG23SRcGA2/uvj0i5S09Jfof+tNB/S1ooLrm8vmZ+QXhS3+8loVt8dIKS3H9U4svS5CrV5FHZNQXlAa74cQ3McoDQsIIQ84=

--- a/infra/order-generator/Pulumi.prod-8453.yaml
+++ b/infra/order-generator/Pulumi.prod-8453.yaml
@@ -28,7 +28,11 @@ config:
   #order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   order-generator-base:TIMEOUT: "1800"
   order-generator-base:TX_TIMEOUT: "90"
-  order-generator-offchain:AUTO_DEPOSIT: "0.05"
+  order-generator-offchain:AUTO_DEPOSIT: "0.015"
+  order-generator-offchain:WARN_BALANCE_BELOW: "0.01"
+  order-generator-offchain:ERROR_BALANCE_BELOW: "0.005"
+  order-generator-onchain:WARN_BALANCE_BELOW: "0.01"
+  order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:/VtYD3aNdYBoGYNY:Zf9aAMkbScrZ1/sZVbYPM8pHT6v5afTGybLg4XCvGdONvP4/e9qtNnhSeSdNjUBJv6KSKdBwUNWHN65RlxpwqVYbL+XceV7DYd8sBlZy4f4=
   order-generator-onchain:PRIVATE_KEY:

--- a/infra/order-generator/Pulumi.staging.yaml
+++ b/infra/order-generator/Pulumi.staging.yaml
@@ -20,7 +20,7 @@ config:
   order-generator-base:CHAIN_ID: "11155111"
   order-generator-base:INTERVAL: "300"
   order-generator-base:LOCK_STAKE_RAW: "100000000000000000" # 0.1 ETH
-  order-generator-base:MAX_PRICE_PER_MCYCLE: "0.01"
+  order-generator-base:MAX_PRICE_PER_MCYCLE: "0.0075"
   order-generator-base:MIN_PRICE_PER_MCYCLE: "0"
   order-generator-base:RAMP_UP: "600"
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -31,6 +31,10 @@ config:
   order-generator-base:TX_TIMEOUT: "120"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:/PAo8IW1iSC4PfVa:j+e1NmKVKprC8cRWBPmmQ5GT9O4ppUeU2VYFdpPiZDZHHCW6GCrTbHO+1BWu1rinjCT1lppKhzXhxBXlVabTVdwPOfjYZO7lF4g+dQjqq5U=
-  order-generator-offchain:AUTO_DEPOSIT: "20"
+  order-generator-offchain:AUTO_DEPOSIT: "15"
+  order-generator-offchain:WARN_BALANCE_BELOW: "50"
+  order-generator-offchain:ERROR_BALANCE_BELOW: "25"
+  order-generator-onchain:WARN_BALANCE_BELOW: "50"
+  order-generator-onchain:ERROR_BALANCE_BELOW: "25"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:mCtZDPI169gCEzCS:fs7WOQUknWQ3SgRy1tJWLzSqrm0DFlDyBlOy0FvCr+qPgOPpdedminnQHR4Em1kBoJteJ0H1iUKfNsaE0NUZOk3RAmCdGtsnu/QiYkHQAiQ=

--- a/infra/order-generator/index.ts
+++ b/infra/order-generator/index.ts
@@ -111,6 +111,8 @@ export = () => {
 
   const offchainConfig = new pulumi.Config("order-generator-offchain");
   const autoDeposit = offchainConfig.require('AUTO_DEPOSIT');
+  const offchainWarnBalanceBelow = offchainConfig.get('WARN_BALANCE_BELOW');
+  const offchainErrorBalanceBelow = offchainConfig.get('ERROR_BALANCE_BELOW');
   const offchainPrivateKey = isDev ? pulumi.output(getEnvVar("OFFCHAIN_PRIVATE_KEY")) : offchainConfig.requireSecret('PRIVATE_KEY');
   new OrderGenerator('offchain', {
     chainId,
@@ -118,6 +120,8 @@ export = () => {
     privateKey: offchainPrivateKey,
     pinataJWT,
     ethRpcUrl,
+    warnBalanceBelow: offchainWarnBalanceBelow,
+    errorBalanceBelow: offchainErrorBalanceBelow,
     offchainConfig: {
       autoDeposit,
       orderStreamUrl,
@@ -140,10 +144,14 @@ export = () => {
   });
 
   const onchainConfig = new pulumi.Config("order-generator-onchain");
+  const onchainWarnBalanceBelow = onchainConfig.get('WARN_BALANCE_BELOW');
+  const onchainErrorBalanceBelow = onchainConfig.get('ERROR_BALANCE_BELOW');
   const onchainPrivateKey = isDev ? pulumi.output(getEnvVar("ONCHAIN_PRIVATE_KEY")) : onchainConfig.requireSecret('PRIVATE_KEY');
   new OrderGenerator('onchain', {
     chainId,
     stackName,
+    warnBalanceBelow: onchainWarnBalanceBelow,
+    errorBalanceBelow: onchainErrorBalanceBelow,
     privateKey: onchainPrivateKey,
     pinataJWT,
     ethRpcUrl,

--- a/infra/prover/components/brokerAlarms.ts
+++ b/infra/prover/components/brokerAlarms.ts
@@ -146,6 +146,11 @@ export const createProverAlarms = (
     threshold: 10,
   }, { period: 1800 });
 
+  // 5 log processing errors within 15 minutes in the market monitor triggers a SEV2 alarm.
+  createErrorCodeAlarm('"[B-MM-502]"', 'market-monitor-log-processing-error', Severity.SEV2, {
+    threshold: 5,
+  }, { period: 900 });
+
   // Any 1 unexpected error in the market monitor triggers a SEV2 alarm.
   createErrorCodeAlarm('"[B-MM-500]"', 'market-monitor-unexpected-error', Severity.SEV2);
 

--- a/infra/slasher/Pulumi.prod-11155111.yaml
+++ b/infra/slasher/Pulumi.prod-11155111.yaml
@@ -19,3 +19,5 @@ config:
   slasher:ETH_RPC_URL:
     secure: v1:TJcLbCNiy5dxnl8s:fyJTFm9B+ikSyIxfIVjkfvB9yQz5oaZUyM5ZfQHVWpUg9u+K8/A2LoGUCNqByNlEZszOpKZYn10Opz3yQosdh4Jl5iSmhQeZKR5bGFW6QgOB/Oq/YA==
   slasher:TX_TIMEOUT: "120"
+  slasher:WARN_BALANCE_BELOW: "5"
+  slasher:ERROR_BALANCE_BELOW: "2"

--- a/infra/slasher/Pulumi.prod-8453.yaml
+++ b/infra/slasher/Pulumi.prod-8453.yaml
@@ -19,3 +19,5 @@ config:
   slasher:SKIP_ADDRESSES: ""
   #slasher:SLACK_ALERTS_TOPIC_ARN: "arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic"
   slasher:TX_TIMEOUT: "60"
+  slasher:WARN_BALANCE_BELOW: "0.01"
+  slasher:ERROR_BALANCE_BELOW: "0.005"

--- a/infra/slasher/Pulumi.staging.yaml
+++ b/infra/slasher/Pulumi.staging.yaml
@@ -19,3 +19,5 @@ config:
     secure: v1:Hj/bfCVDhATl+X8L:7F0bJRV5f7CJsXKzLNN0izCjtnExs8yM5+We/KnPBeMLHp0DJMjzm8i/7cTcLBAc6Bfi7v+v/T2zO5LsXLe6K3wIqJHaJwiX9A+jvXQuBDT5bkAexw==
   slasher:CHAIN_ID: "11155111"
   slasher:TX_TIMEOUT: "120"
+  slasher:WARN_BALANCE_BELOW: "5"
+  slasher:ERROR_BALANCE_BELOW: "2"


### PR DESCRIPTION
* Changed Market monitor event poll error to unexpected. Currently a single rpc error here is unexpected, wrapping in an error code with a higher threshold
* Added balance alerts for order gens and slasher. As part of this also changes auto deposit to not error out on fail, since now we have balance alerts that will tell us when eth balances are low
* Slightly scaled down max mycle price for the order gens on Sepolia. We're going through sepETH fast