### PR TITLE
lower bento peak prove khz

### DIFF
--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -682,7 +682,8 @@ where
             let proof_time_seconds = total_commited_cycles.div_ceil(1_000).div_ceil(peak_prove_khz);
             let mut prover_available_at = started_proving_at + proof_time_seconds;
             if prover_available_at < now {
-                tracing::warn!("Proofs are behind what is estimated from peak_prove_khz config. Consider lowering this value to avoid overlocking orders.");
+                let seconds_behind = now - prover_available_at;
+                tracing::warn!("Proofs are behind what is estimated from peak_prove_khz config by {} seconds. Consider lowering this value to avoid overlocking orders.", seconds_behind);
                 prover_available_at = now;
             }
             tracing::debug!("Already committed to {} orders, with a total cycle count of {}, a peak khz limit of {}, started working on them at {}, we estimate the prover will be available in {} seconds", 

--- a/infra/prover/tomls/bento/broker-dev.toml
+++ b/infra/prover/tomls/bento/broker-dev.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.00001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 1000
+peak_prove_khz = 120
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bento/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bento/broker-prod-11155111.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 150
+peak_prove_khz = 120
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bento/broker-prod-8453.toml
+++ b/infra/prover/tomls/bento/broker-prod-8453.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 150
+peak_prove_khz = 120
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bento/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bento/broker-staging-11155111.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 150
+peak_prove_khz = 120
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 150
+peak_prove_khz = 120
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"


### PR DESCRIPTION
Under load, this value is set higher than the nodes can consistently hit.