### PR TITLE
Re-add codes on failed to lock order

### DIFF
--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -518,12 +518,14 @@ where
                             match err {
                                 OrderMonitorErr::UnexpectedError(inner) => {
                                     tracing::error!(
-                                        "Failed to lock order: {order_id} - {inner:?}",
+                                        "Failed to lock order: {order_id} - {} - {inner:?}",
+                                        err.code()
                                     );
                                 }
                                 _ => {
                                     tracing::warn!(
-                                        "Soft failed to lock request: {order_id} - {err:?}",
+                                        "Soft failed to lock request: {order_id} - {} - {err:?}",
+                                        err.code()
                                     );
                                 }
                             }


### PR DESCRIPTION
Currently lock failed errors are treated as unexpected errors since the code is not printed. Re-adds the code