### PR TITLE
BM-1157: only cancel proof on proving order status

### DIFF
--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -229,18 +229,13 @@ impl ProvingService {
             let order_id = order.id();
             if order.expire_timestamp.unwrap() < now {
                 tracing::warn!("Order {} had expired on proving task start", order_id);
-                if let Some(proof_id) = &order.proof_id {
-                    cancel_proof_and_fail_order(
-                        &self.prover,
-                        &self.db,
-                        proof_id,
-                        &order_id,
-                        "Order expired on startup",
-                    )
-                    .await;
-                } else {
-                    handle_order_failure(&self.db, &order_id, "Order expired on startup").await;
-                }
+                cancel_proof_and_fail_order(
+                    &self.prover,
+                    &self.db,
+                    &order,
+                    "Order expired on startup",
+                )
+                .await;
             }
             let prove_serv = self.clone();
 

--- a/crates/broker/src/utils.rs
+++ b/crates/broker/src/utils.rs
@@ -9,7 +9,7 @@ use boundless_market::{
     selector::{ProofType, SupportedSelectors},
 };
 
-use crate::{config::ConfigLock, OrderRequest};
+use crate::{config::ConfigLock, Order, OrderRequest, OrderStatus};
 
 /// Gas allocated to verifying a smart contract signature. Copied from BoundlessMarket.sol.
 pub const ERC1271_MAX_GAS_FOR_CHECK: u64 = 100000;
@@ -21,20 +21,21 @@ pub const ERC1271_MAX_GAS_FOR_CHECK: u64 = 100000;
 pub async fn cancel_proof_and_fail_order(
     prover: &crate::provers::ProverObj,
     db: &crate::db::DbObj,
-    proof_id: &str,
-    order_id: &str,
+    order: &Order,
     failure_reason: &'static str,
 ) {
-    tracing::debug!("Cancelling proof {} for order {}", proof_id, order_id);
-    if let Err(err) = prover.cancel_stark(proof_id).await {
-        tracing::warn!(
-            "[B-UTL-001] Failed to cancel proof {proof_id} with reason: {failure_reason} for order {order_id}: {err}",
-        );
+    let order_id = order.id();
+    if matches!(order.status, OrderStatus::Proving) {
+        let proof_id = order.proof_id.as_ref().unwrap();
+        tracing::debug!("Cancelling proof {} for order {}", proof_id, order_id);
+        if let Err(err) = prover.cancel_stark(proof_id).await {
+            tracing::warn!("[B-UTL-001] Failed to cancel proof {proof_id} with reason: {failure_reason} for order {order_id}: {err}");
+        }
     }
 
     // TODO in the case of a failure to cancel, the estimated capacity will be incorrect. Still
     // setting the order as failed to avoid infinite loops of cancellations.
-    if let Err(err) = db.set_order_failure(order_id, failure_reason).await {
+    if let Err(err) = db.set_order_failure(&order_id, failure_reason).await {
         tracing::error!(
             "Failed to set order {order_id} as failed for reason {failure_reason}: {err}",
         );

--- a/crates/broker/src/utils.rs
+++ b/crates/broker/src/utils.rs
@@ -25,11 +25,12 @@ pub async fn cancel_proof_and_fail_order(
     failure_reason: &'static str,
 ) {
     let order_id = order.id();
-    if matches!(order.status, OrderStatus::Proving) {
-        let proof_id = order.proof_id.as_ref().unwrap();
-        tracing::debug!("Cancelling proof {} for order {}", proof_id, order_id);
-        if let Err(err) = prover.cancel_stark(proof_id).await {
-            tracing::warn!("[B-UTL-001] Failed to cancel proof {proof_id} with reason: {failure_reason} for order {order_id}: {err}");
+    if let Some(proof_id) = order.proof_id.as_ref() {
+        if matches!(order.status, OrderStatus::Proving) {
+            tracing::debug!("Cancelling proof {} for order {}", proof_id, order_id);
+            if let Err(err) = prover.cancel_stark(proof_id).await {
+                tracing::warn!("[B-UTL-001] Failed to cancel proof {proof_id} with reason: {failure_reason} for order {order_id}: {err}");
+            }
         }
     }
 


### PR DESCRIPTION
Shouldn't matter too much with reaper changes, but also simplifies some code. Avoids calling cancel unless the order is in the proving state, to avoid calling cancel on a completed proof.