### PR TITLE
BM-1158: simplify exec agent config in compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,15 @@ x-agent-common: &agent-common
   environment:
     <<: *base-environment
 
+x-exec-agent-common: &exec-agent-common
+  <<: *agent-common
+  mem_limit: 4G
+  cpus: 3
+  environment:
+    <<: *base-environment
+    RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2:-17}
+  entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE:-21}
+
 services:
   redis:
     hostname: ${REDIS_HOST:-redis}
@@ -90,26 +99,10 @@ services:
       - minio
 
   exec_agent0:
-    <<: *agent-common
-
-    mem_limit: 4G
-    cpus: 3
-
-    environment:
-      <<: *base-environment
-      RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2:-17}
-    entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE:-21}
+    <<: *exec-agent-common
 
   exec_agent1:
-    <<: *agent-common
-
-    mem_limit: 4G
-    cpus: 3
-
-    environment:
-      <<: *base-environment
-      RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2:-17}
-    entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE:-21}
+    <<: *exec-agent-common
 
   aux_agent:
     <<: *agent-common


### PR DESCRIPTION
I made this change in another PR, somehow it got reverted in a merge update it seems