### PR TITLE
Lower bento max capacity, fix capacity log

### DIFF
--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -438,7 +438,7 @@ where
         chain_id: u64,
         new_order_tx: &tokio::sync::mpsc::Sender<Box<OrderRequest>>,
     ) -> Result<()> {
-        tracing::info!("Detected new on-chain request {:x}", event.requestId);
+        tracing::info!("Detected new on-chain request 0x{:x}", event.requestId);
         // Check the request id flag to determine if the request is smart contract signed. If so we verify the
         // ERC1271 signature by calling isValidSignature on the smart contract client. Otherwise we verify the
         // the signature as an ECDSA signature.

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -308,7 +308,7 @@ where
     async fn get_proving_order_capacity(
         &self,
         max_concurrent_proofs: Option<u32>,
-        previous_capacity_log: &mut String,
+        prev_orders_by_status: &mut String,
     ) -> Result<Capacity, OrderMonitorErr> {
         if max_concurrent_proofs.is_none() {
             return Ok(Capacity::Unlimited);
@@ -322,14 +322,14 @@ where
             .map_err(|e| OrderMonitorErr::UnexpectedError(e.into()))?;
         let committed_orders_count: u32 = committed_orders.len().try_into().unwrap();
 
-        Self::log_capacity(previous_capacity_log, committed_orders, max).await;
+        Self::log_capacity(prev_orders_by_status, committed_orders, max).await;
 
         let available_slots = max.saturating_sub(committed_orders_count);
         Ok(Capacity::Available(available_slots))
     }
 
     async fn log_capacity(
-        previous_capacity_log: &mut String,
+        prev_orders_by_status: &mut String,
         commited_orders: Vec<Order>,
         max: u32,
     ) {
@@ -341,9 +341,12 @@ where
 
         let capacity_log = format!("Current num committed orders: {committed_orders_count}. Maximum commitment: {max}. Committed orders: {request_id_and_status:?}");
 
-        if *previous_capacity_log != capacity_log {
+        // Note: we don't compare previous to capacity_log as it contains timestamps which cause it to always change. 
+        // We only want to log if status or num orders changes.
+        let cur_orders_by_status  = commited_orders.iter().map(|order| format!("{:?}-{}", order.status, order.id())).collect::<Vec<_>>().join(",");
+        if *prev_orders_by_status != cur_orders_by_status {
             tracing::info!("{}", capacity_log);
-            *previous_capacity_log = capacity_log;
+            *prev_orders_by_status = cur_orders_by_status;
         }
     }
 
@@ -588,12 +591,12 @@ where
         &self,
         orders: Vec<Arc<OrderRequest>>,
         config: &OrderMonitorConfig,
-        previous_capacity_log: &mut String,
+        prev_orders_by_status: &mut String,
     ) -> Result<Vec<Arc<OrderRequest>>> {
         let num_orders = orders.len();
         // Get our current capacity for proving orders given our config and the number of orders that are currently committed to be proven + fulfilled.
         let capacity = self
-            .get_proving_order_capacity(config.max_concurrent_proofs, previous_capacity_log)
+            .get_proving_order_capacity(config.max_concurrent_proofs, prev_orders_by_status)
             .await?;
         let capacity_granted = capacity
             .request_capacity(num_orders.try_into().expect("Failed to convert order count to u32"));
@@ -807,7 +810,7 @@ where
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         let mut new_orders = self.priced_order_rx.lock().await;
-        let mut previous_capacity_debug_log = String::new();
+        let mut prev_orders_by_status = String::new();
 
         loop {
             tokio::select! {
@@ -861,7 +864,7 @@ where
                             .apply_capacity_limits(
                                 valid_orders,
                                 &monitor_config,
-                                &mut previous_capacity_debug_log,
+                                &mut prev_orders_by_status,
                             )
                             .await?;
 

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -341,9 +341,13 @@ where
 
         let capacity_log = format!("Current num committed orders: {committed_orders_count}. Maximum commitment: {max}. Committed orders: {request_id_and_status:?}");
 
-        // Note: we don't compare previous to capacity_log as it contains timestamps which cause it to always change. 
+        // Note: we don't compare previous to capacity_log as it contains timestamps which cause it to always change.
         // We only want to log if status or num orders changes.
-        let cur_orders_by_status  = commited_orders.iter().map(|order| format!("{:?}-{}", order.status, order.id())).collect::<Vec<_>>().join(",");
+        let cur_orders_by_status = commited_orders
+            .iter()
+            .map(|order| format!("{:?}-{}", order.status, order.id()))
+            .collect::<Vec<_>>()
+            .join(",");
         if *prev_orders_by_status != cur_orders_by_status {
             tracing::info!("{}", capacity_log);
             *prev_orders_by_status = cur_orders_by_status;

--- a/infra/order-generator/Pulumi.staging-11155111.yaml
+++ b/infra/order-generator/Pulumi.staging-11155111.yaml
@@ -47,3 +47,4 @@ config:
   order-generator-onchain:LOCK_TIMEOUT: "900"
   order-generator-onchain:TIMEOUT: "1800"
   order-generator-onchain:SECONDS_PER_MCYCLE: "15"
+  order-generator-onchain:INPUT_MAX_MCYCLES: "500"

--- a/infra/order-generator/Pulumi.staging-84532.yaml
+++ b/infra/order-generator/Pulumi.staging-84532.yaml
@@ -48,3 +48,4 @@ config:
   order-generator-onchain:LOCK_TIMEOUT: "900"
   order-generator-onchain:TIMEOUT: "1800"
   order-generator-onchain:SECONDS_PER_MCYCLE: "15"
+  order-generator-onchain:INPUT_MAX_MCYCLES: "500"

--- a/infra/prover/tomls/bento/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bento/broker-prod-11155111.toml
@@ -1,13 +1,13 @@
 [market]
 mcycle_price = "0.000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 120
+peak_prove_khz = 80
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"
 max_file_size = 50_000_000
-max_mcycle_limit = 8000
-max_concurrent_proofs = 5
+max_mcycle_limit = 250
+max_concurrent_proofs = 2
 balance_warn_threshold = "5"
 balance_error_threshold = "1"
 stake_balance_warn_threshold = "5"

--- a/infra/prover/tomls/bento/broker-prod-8453.toml
+++ b/infra/prover/tomls/bento/broker-prod-8453.toml
@@ -1,13 +1,13 @@
 [market]
 mcycle_price = "0.000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 120
+peak_prove_khz = 80
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"
 max_file_size = 50_000_000
-max_mcycle_limit = 8000
-max_concurrent_locks = 5
+max_mcycle_limit = 250
+max_concurrent_proofs = 2
 balance_warn_threshold = "5"
 balance_error_threshold = "1"
 stake_balance_warn_threshold = "5"

--- a/infra/prover/tomls/bento/broker-prod-84532.toml
+++ b/infra/prover/tomls/bento/broker-prod-84532.toml
@@ -1,13 +1,13 @@
 [market]
 mcycle_price = "0.000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 120
+peak_prove_khz = 80
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"
 max_file_size = 50_000_000
-max_mcycle_limit = 8000
-max_concurrent_locks = 5
+max_mcycle_limit = 250
+max_concurrent_proofs = 2
 balance_warn_threshold = "5"
 balance_error_threshold = "1"
 stake_balance_warn_threshold = "5"

--- a/infra/prover/tomls/bento/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bento/broker-staging-11155111.toml
@@ -1,13 +1,13 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 120
+peak_prove_khz = 80
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"
 max_file_size = 50_000_000
-max_mcycle_limit = 8000
-max_concurrent_locks = 10
+max_mcycle_limit = 250
+max_concurrent_proofs = 2
 balance_warn_threshold = "5"
 balance_error_threshold = "1"
 stake_balance_warn_threshold = "5"

--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -1,13 +1,13 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 120
+peak_prove_khz = 80
 min_deadline = 200
 lookback_blocks = 100
 max_stake = "0.5"
 max_file_size = 50_000_000
-max_mcycle_limit = 8000
-max_concurrent_locks = 10
+max_mcycle_limit = 250
+max_concurrent_proofs = 2
 balance_warn_threshold = "5"
 balance_error_threshold = "1"
 stake_balance_warn_threshold = "5"


### PR DESCRIPTION
Bento prover is consistently overcommitting, and once it has > 2 orders committed it slows down massively. Its a small instance, so lowering max_concurrent, peak_hz, and max_mycle just to get it stable. We can raise it back up gradually.

Drive by log fixes included.