### PR TITLE
Add disable-dev-mode in the identity util guest to show best practice

### DIFF
--- a/crates/guest/util/identity/Cargo.toml
+++ b/crates/guest/util/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 postcard = "1.0"
-risc0-zkvm = { version = "2.0.2", default-features = false, features = ["std", "unstable"] }
+risc0-zkvm = { version = "2.0.2", default-features = false, features = ["std", "unstable", "disable-dev-mode"] }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }


### PR DESCRIPTION
When using composition via receipt verification in the guest, it is best to set `disable-dev-mode`, which is recommended for any production build of a Rust program that is verifying receipts. This adds an extra protection against accidentally turning on dev mode.
