### PR TITLE
add CACHE_DATE arg to dockerfiles

### DIFF
--- a/dockerfiles/broker.dockerfile
+++ b/dockerfiles/broker.dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qq update && \
     apt-get install -y -q clang
 
 SHELL ["/bin/bash", "-c"]
-
+ARG CACHE_DATE=2025-06-11  # update this date to force rebuild
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source /root/.bashrc && \
     foundryup
@@ -13,11 +13,11 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
 # for shared build environments where Github rate limiting is an issue.
 RUN --mount=type=secret,id=githubTokenSecret,target=/run/secrets/githubTokenSecret \
     if [ -f /run/secrets/githubTokenSecret ]; then \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install rust 1.85.0; \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install rust 1.85.0; \
     else \
-        curl -L https://risczero.com/install | bash && \
-        PATH="$PATH:/root/.risc0/bin" rzup install rust 1.85.0; \
+    curl -L https://risczero.com/install | bash && \
+    PATH="$PATH:/root/.risc0/bin" rzup install rust 1.85.0; \
     fi
 
 RUN cargo install cargo-chef

--- a/dockerfiles/indexer.dockerfile
+++ b/dockerfiles/indexer.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qq update && \
 SHELL ["/bin/bash", "-c"]
 
 RUN cargo install cargo-chef
-
+ARG CACHE_DATE=2025-06-11  # update this date to force rebuild
 # The indexer doesn't need r0vm to run, but its tests do need it. 
 # Cargo chef always pulls in and builds dev-dependencies, meaning that we need to install r0vm
 # to leverage chef. See https://github.com/LukeMathWalker/cargo-chef/issues/114

--- a/dockerfiles/order_generator.dockerfile
+++ b/dockerfiles/order_generator.dockerfile
@@ -5,16 +5,16 @@ RUN apt-get -qq update && \
     apt-get install -y -q clang
 
 SHELL ["/bin/bash", "-c"]
-
+ARG CACHE_DATE=2025-06-11  # update this date to force rebuild
 # Github token can be provided as a secret with the name githubTokenSecret. Useful
 # for shared build environments where Github rate limiting is an issue.
 RUN --mount=type=secret,id=githubTokenSecret,target=/run/secrets/githubTokenSecret \
     if [ -f /run/secrets/githubTokenSecret ]; then \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
     else \
-        curl -L https://risczero.com/install | bash && \
-        PATH="$PATH:/root/.risc0/bin" rzup install; \
+    curl -L https://risczero.com/install | bash && \
+    PATH="$PATH:/root/.risc0/bin" rzup install; \
     fi
 
 RUN cargo install cargo-chef

--- a/dockerfiles/order_stream.dockerfile
+++ b/dockerfiles/order_stream.dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -qq update && \
     apt-get install -y -q clang
 
 SHELL ["/bin/bash", "-c"]
-
+ARG CACHE_DATE=2025-06-11  # update this date to force rebuild
 RUN curl -L https://foundry.paradigm.xyz | bash && \
     source /root/.bashrc && \
     foundryup
@@ -13,11 +13,11 @@ RUN curl -L https://foundry.paradigm.xyz | bash && \
 # for shared build environments where Github rate limiting is an issue.
 RUN --mount=type=secret,id=githubTokenSecret,target=/run/secrets/githubTokenSecret \
     if [ -f /run/secrets/githubTokenSecret ]; then \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
     else \
-        curl -L https://risczero.com/install | bash && \
-        PATH="$PATH:/root/.risc0/bin" rzup install; \
+    curl -L https://risczero.com/install | bash && \
+    PATH="$PATH:/root/.risc0/bin" rzup install; \
     fi
 
 RUN cargo install cargo-chef

--- a/dockerfiles/slasher.dockerfile
+++ b/dockerfiles/slasher.dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -qq update && \
 SHELL ["/bin/bash", "-c"]
 
 RUN cargo install cargo-chef
-
+ARG CACHE_DATE=2025-06-11  # update this date to force rebuild
 # The slasher doesn't need r0vm to run, but its tests do need it. 
 # Cargo chef always pulls in and builds dev-dependencies, meaning that we need to install r0vm
 # to leverage chef. See https://github.com/LukeMathWalker/cargo-chef/issues/114
@@ -17,11 +17,11 @@ RUN cargo install cargo-chef
 # for shared build environments where Github rate limiting is an issue.
 RUN --mount=type=secret,id=githubTokenSecret,target=/run/secrets/githubTokenSecret \
     if [ -f /run/secrets/githubTokenSecret ]; then \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
-        GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) curl -L https://risczero.com/install | bash && \
+    GITHUB_TOKEN=$(cat /run/secrets/githubTokenSecret) PATH="$PATH:/root/.risc0/bin" rzup install; \
     else \
-        curl -L https://risczero.com/install | bash && \
-        PATH="$PATH:/root/.risc0/bin" rzup install; \
+    curl -L https://risczero.com/install | bash && \
+    PATH="$PATH:/root/.risc0/bin" rzup install; \
     fi
 
 FROM init AS planner


### PR DESCRIPTION
It seems that the cache we are using does not allow to recognize when something within rzup should get updated. Adding an ARG that we can use whenever we want to force running the rzup command