### PR TITLE
BM-1185: increase systemd stop timeout

### DIFF
--- a/infra/prover/components/bentoBroker.ts
+++ b/infra/prover/components/bentoBroker.ts
@@ -570,10 +570,11 @@ ExecStartPre=/local/create-broker-env.sh
 WorkingDirectory=/local/boundless
 ExecStart=/snap/bin/just broker up /local/.env.broker detached=false
 ExecStop=/snap/bin/just broker down
+KillSignal=SIGTERM
 Restart=always
 RestartSec=10
 TimeoutStartSec=3600
-TimeoutStopSec=120
+TimeoutStopSec=7200
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increases timeout to 2h for stop (graceful)

Also makes explicit the terminate signal (that is the default, just making sure it doesn't change in future)