### PR TITLE
bump main version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives 1.2.0",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-bench"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-indexer"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives 1.2.0",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-order-generator"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-slasher"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "broker-stress"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "doc-test"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives 1.2.0",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -4541,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5170,7 +5170,7 @@ checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
 name = "indexer-monitor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6515,7 +6515,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "order-stream"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 homepage = "https://beboundless.xyz/"
 repository = "https://github.com/boundless-xyz/boundless/"
 
 [workspace.dependencies]
-boundless-assessor = { version = "0.10.0", path = "crates/assessor" }
-boundless-cli = { version = "0.10.0", path = "crates/boundless-cli" }
-boundless-market = { version = "0.10.0", path = "crates/boundless-market" }
+boundless-assessor = { version = "0.11.0", path = "crates/assessor" }
+boundless-cli = { version = "0.11.0", path = "crates/boundless-cli" }
+boundless-market = { version = "0.11.0", path = "crates/boundless-market" }
 boundless-market-test-utils = { path = "crates/boundless-market/test-utils" }
 
 guest-assessor = { path = "crates/guest/assessor" }

--- a/crates/guest/assessor/assessor-guest/Cargo.lock
+++ b/crates/guest/assessor/assessor-guest/Cargo.lock
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/examples/composition/Cargo.lock
+++ b/examples/composition/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/counter-with-callback/Cargo.lock
+++ b/examples/counter-with-callback/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",

--- a/examples/smart-contract-requestor/Cargo.lock
+++ b/examples/smart-contract-requestor/Cargo.lock
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market-test-utils"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hex",
  "risc0-build",


### PR DESCRIPTION
Following same pattern that existed from before, although perhaps not ideal to use a real future version