### PR TITLE
Wipe slasher db

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -179,7 +179,7 @@ fn extract_tx_log<E: SolEvent + Debug + Clone>(
 
     match &logs[..] {
         [log] => Ok(log.clone()),
-        [] => Err(anyhow!("transaction did not emit event {}", E::SIGNATURE)),
+        [] => Err(anyhow!("transaction 0x{:x} did not emit event {}", receipt.transaction_hash, E::SIGNATURE)),
         _ => Err(anyhow!(
             "transaction emitted more than one event with signature {}, {:#?}",
             E::SIGNATURE,

--- a/infra/slasher/index.ts
+++ b/infra/slasher/index.ts
@@ -176,7 +176,7 @@ export = () => {
   });
 
   // EFS
-  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev4`, {
+  const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev5`, {
     encrypted: true,
     tags: {
       Name: serviceName,


### PR DESCRIPTION
There are currently some issues in Prod where the slasher is stuck trying to slash requests from a previous market version. This is stopping it from progressing through blocks. Wiping to start fresh.