### PR TITLE
BM-1212: handle proving orders that were false positive skips

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -7,7 +7,7 @@ use std::{path::PathBuf, sync::Arc, time::SystemTime};
 use crate::storage::create_uri_handler;
 use alloy::{
     network::Ethereum,
-    primitives::{Address, Bytes, FixedBytes, U256},
+    primitives::{Address, Bytes, U256},
     providers::{Provider, WalletProvider},
     signers::local::PrivateKeySigner,
 };
@@ -168,11 +168,14 @@ enum FulfillmentType {
 }
 
 /// Helper function to format an order ID consistently
-fn format_order_id(
-    request_id: &U256,
-    signing_hash: &FixedBytes<32>,
+pub(crate) fn format_order_id(
+    request: &ProofRequest,
+    boundless_market_address: Address,
+    chain_id: u64,
     fulfillment_type: &FulfillmentType,
 ) -> String {
+    let request_id = &request.id;
+    let signing_hash = request.signing_hash(boundless_market_address, chain_id).unwrap();
     format!("0x{:x}-{}-{:?}", request_id, signing_hash, fulfillment_type)
 }
 
@@ -219,9 +222,12 @@ impl OrderRequest {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        let signing_hash =
-            self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-        format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        format_order_id(
+            &self.request,
+            self.boundless_market_address,
+            self.chain_id,
+            &self.fulfillment_type,
+        )
     }
 
     fn to_order(&self, status: OrderStatus) -> Order {
@@ -337,9 +343,12 @@ impl Order {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        let signing_hash =
-            self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-        format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        format_order_id(
+            &self.request,
+            self.boundless_market_address,
+            self.chain_id,
+            &self.fulfillment_type,
+        )
     }
 
     pub fn is_groth16(&self) -> bool {


### PR DESCRIPTION
There are a few edge cases where the RPC will either return that the order was not locked when it was, a timeout that marks as skipped, or some other error like inconsistent state in the RPC calls. This is a catch all to avoid this case.

This is safe to do because when the order is skipped in the order picker, the prover does not modify the state of this after. This allows an operation to shift from skipped to pending proving. 

This does not cover the case where an order is locked that has not been skipped yet (either because it hasn't been priced or some race condition where the lock event comes before the db skip). This change can come in a future change, as is more opinionated and lower urgency