### PR TITLE
BM-1213: fix dead links (hopefully forever)

### DIFF
--- a/documentation/scripts/check-links.ts
+++ b/documentation/scripts/check-links.ts
@@ -2,7 +2,21 @@ import { readFile } from "node:fs/promises";
 import { glob } from "glob";
 
 // Add ignore list configuration
-const IGNORED_URL_PREFIXES = new Set(["https://github.com/boundless-xyz", "https://sepolia.etherscan.io"]);
+const IGNORED_URL_PREFIXES = new Set([
+  "https://github.com/boundless-xyz",
+  "https://sepolia.etherscan.io",
+  "https://polygonscan.com",
+  "https://zkevm.polygonscan.com",
+  "https://basescan.org",
+  "https://sepolia.basescan.org",
+  "https://arbiscan.io",
+  "https://sepolia.arbiscan.io",
+  "https://snowtrace.io",
+  "https://testnet.snowtrace.io",
+  "https://lineascan.build",
+  "https://sepolia.lineascan.build",
+  "https://crates.io",
+]);
 
 async function checkRemoteUrl(url: string): Promise<boolean> {
   // Check if URL starts with any of the ignored prefixes
@@ -90,7 +104,7 @@ async function localPathExists(linkPath: string): Promise<boolean> {
 }
 
 async function checkLinks() {
-  const files = await glob("**/*.md", { ignore: ["node_modules/**"] });
+  const files = await glob("**/*.{md,mdx}", { ignore: ["node_modules/**"] });
   let hasErrors = false;
 
   for (const file of files) {
@@ -150,6 +164,8 @@ async function checkLinks() {
   if (hasErrors) {
     console.error("\n❌ Some files contain invalid links");
     process.exit(1);
+  } else {
+    console.log("✅ All links are valid!");
   }
 }
 

--- a/documentation/site/pages/developers/quick-start.mdx
+++ b/documentation/site/pages/developers/quick-start.mdx
@@ -52,7 +52,7 @@ and save the deployed contract address to the .env file.
 
 ### Run the example app
 
-The [example app](apps/src/main.rs) will upload your zkVM guest to IPFS, submit a request to the market for a proof that "4" is an even number, wait for the request to be fulfilled, and then submit that proof to the EvenNumber contract, setting the value to "4".
+The [example app](https://github.com/boundless-xyz/boundless-foundry-template/blob/main/apps/src/main.rs) will upload your zkVM guest to IPFS, submit a request to the market for a proof that "4" is an even number, wait for the request to be fulfilled, and then submit that proof to the EvenNumber contract, setting the value to "4".
 
 To run the example:
 

--- a/documentation/site/pages/developers/quick-start.mdx
+++ b/documentation/site/pages/developers/quick-start.mdx
@@ -81,4 +81,4 @@ and the app will query the status of the proof request until it is fulfilled. On
 2025-03-25T17:28:26.258037Z  INFO app: The number variable for contract at address: 0x29340e3f2264d3dab1c89328b1abbce756e2ad5b is set to 4
 ```
 
-You've now requested your first proof from Boundless, received that proof and sent that proof onchain for verification. Effectively, you've offloaded computation offchain with the same trust model as onchain, all thanks to the power of ZK. This is the true power of verifiable compute. To learn more about each individual step, please refer to [Build A Program](/)
+You've now requested your first proof from Boundless, received that proof and sent that proof onchain for verification. Effectively, you've offloaded computation offchain with the same trust model as onchain, all thanks to the power of ZK. This is the true power of verifiable compute. To learn more about each individual step, please refer to [Build A Program](/developers/tutorials/build)

--- a/documentation/site/pages/developers/smart-contracts/verifier-contracts.mdx
+++ b/documentation/site/pages/developers/smart-contracts/verifier-contracts.mdx
@@ -243,11 +243,11 @@ You can find detailed information in the [version management design][version-man
 [router-11155111-etherscan]: https://sepolia.etherscan.io/address/0x925d8331ddc0a1F0d96E68CF073DFE1d92b69187#code
 [router-11155420-etherscan]: https://sepolia-optimism.etherscan.io/address/0xB369b4dd27FBfb59921d3A4a3D23AC2fc32FB908#code
 [router-src]: https://github.com/risc0/risc0-ethereum/tree/release-1.2/contracts/src/RiscZeroVerifierRouter.sol
-[term-image-id]: /terminology#image-id
-[term-journal]: /terminology#journal
-[term-receipt]: /terminology#receipt
-[term-verify]: /terminology#verify
-[term-zkvm]: /terminology#zero-knowledge-virtual-machine-zkvm
+[term-image-id]: https://dev.risczero.com/terminology#image-id
+[term-journal]: https://dev.risczero.com/terminology#journal
+[term-receipt]: https://dev.risczero.com/terminology#receipt
+[term-verify]: https://dev.risczero.com/terminology#verify
+[term-zkvm]: https://dev.risczero.com/terminology#zero-knowledge-virtual-machine-zkvm
 [timelock-1-etherscan]: https://etherscan.io/address/0x0b144E07A0826182B6b59788c34b32Bfa86Fb711#code
 [timelock-10-etherscan]: https://optimistic.etherscan.io/address/0xdc986a09728f76110ff666ee7b20d99086501d15#code
 [timelock-1101-etherscan]: https://zkevm.polygonscan.com/address/0xdc986a09728f76110ff666ee7b20d99086501d15#code

--- a/documentation/site/pages/developers/steel/history.mdx
+++ b/documentation/site/pages/developers/steel/history.mdx
@@ -90,7 +90,7 @@ For every extra 24 hours of history, this is just under 500,000 cycles in the St
 **To see example code, please see the [publisher app] for the erc20-counter example which has been updated to support Steel history.**
 
 [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
-[beacon chain]: https://ethereum.org/en/roadmap/beaconchain/
+[beacon chain]: https://ethereum.org/en/roadmap/beacon-chain/
 [Steel Commitments]: /developers/steel/commitments
 [Cancun upgrade]: https://ethereum.org/en/history/#cancun-summary
 [publisher.rs]: https://github.com/risc0/risc0-ethereum/blob/main/examples/erc20-counter/apps/src/bin/publisher.rs

--- a/documentation/site/pages/developers/tutorials/request.mdx
+++ b/documentation/site/pages/developers/tutorials/request.mdx
@@ -356,7 +356,7 @@ let (request_id, expires_at) = client.submit_onchain(request).await?; // [!code 
 #### Offchain
 
 :::note[Sumbitting offchain?]
-When using offchain requests, you are required to deposit funds into the Boundless market contract before you can make any proof requests. This can be done with the [Boundless CLI deposit subcommand](/developers/tooling/cli#1-deposit).
+When using offchain requests, you are required to deposit funds into the Boundless market contract before you can make any proof requests. This can be done with the [Boundless CLI deposit subcommand](/developers/tooling/cli#deposit).
 :::
 
 To submit a request offchain, we use:

--- a/documentation/site/pages/developers/tutorials/sensitive-inputs.mdx
+++ b/documentation/site/pages/developers/tutorials/sensitive-inputs.mdx
@@ -41,7 +41,7 @@ The general workflow for the requestor is:
 To continue, an [AWS account](https://signin.aws.amazon.com/signup?request_type=register) is required. After that, you'll need the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to set up your S3 bucket, create roles and set the required policies.
 
 :::note[If you prefer using the AWS console]
-You can follow the official instructions [Step 1: Create your first S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html#creating-bucket).
+You can follow the official instructions at [Step 1: Create your first S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/GetStartedWithS3.html#creating-bucket).
 :::
 
 To store the inputs, we will need to first create an S3 bucket. This can be done with the CLI with:
@@ -129,7 +129,7 @@ When using server-side encryption with AWS KMS keys (known as [SSE-KMS](https://
 
 This server-side encryption adds another check on top of the IAM role requirement. For some use cases, at-rest encryption is necessary for compliance (HIPAA, SOC 2 etc.).
 
-If you enabled `--sse-kms` in [Step 1](/developers/tutorials/sensitive-inputs#1-requestor-upload-the-input-file-to-s3-via-the-aws-cli), you can specify the  key policy either way the KMS console or via the AWS CLI. For up to date information on how to do that, please refer to the official AWS  [Change a Key Policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html) documentation.
+If you enabled `--sse-kms` in [Upload the input file to S3](/developers/tutorials/sensitive-inputs#3-upload-the-input-file-to-s3), you can specify the  key policy either way the KMS console or via the AWS CLI. For up to date information on how to do that, please refer to the official AWS  [Change a Key Policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html) documentation.
 
 An example key policy would be:
 
@@ -174,7 +174,7 @@ Below is an example bucket policy, copy it and save it to `prover_policy.json`:
 ```
 Only provers whose temporary credentials let them assume `<PROVER_ROLE_ARN>` can download the input file they need to start proving.
 
-The `<PROVER_ROLE_ARN>` string refers to the full *Amazon Resource Name* (ARN) of the IAM role created for the prover. This was generated during [Create the required prover role](/developers/tutorials/sensitive-inputs#create-the-required-prover-role).
+The `<PROVER_ROLE_ARN>` string refers to the full *Amazon Resource Name* (ARN) of the IAM role created for the prover. This was generated during [Create the required prover role](/developers/tutorials/sensitive-inputs#2-create-the-required-prover-role).
 
 *Make sure to replace `<PROVER_ROLE_ARN>` with the string we saved earlier*, something like:
 
@@ -202,16 +202,16 @@ If you have already uploaded your inputs using the `aws` CLI above, you can skip
 - make sure your AWS credentials are set in environment variables, specifically:
   - `S3_ACCESS` for the access key
   - `S3_SECRET` for the secret key
-  - `S3_BUCKET` for the bucket name of the bucket created in [Step 1](/developers/tutorials/sensitive-inputs#1-create-the--s3-bucket)
-  - `S3_URL` for the bucket URL of the bucket created in [Step 1](/developers/tutorials/sensitive-inputs#1-create-the--s3-bucket)
+  - `S3_BUCKET` for the bucket name of the bucket created in [Create the S3 bucket](/developers/tutorials/sensitive-inputs#1-create-the-s3-bucket)
+  - `S3_URL` for the bucket URL of the bucket created in [Create the S3 bucket](/developers/tutorials/sensitive-inputs#1-create-the-s3-bucket)
   - `AWS_REGION` for the bucket region.
   - and last, but not least, make sure `S3_NO_PRESIGNED=1`
 
 After this setup, you may request a proof programmatically as [Request a Proof](/developers/tutorials/request) recommends; your inputs will be automatically uploaded to your gated S3 bucket, however remember that you still need to go through all the necessary gating policies as laid out in this tutorial to make sure your inputs are private and only available to select provers.
 
-If you're interested in doing a one-off test, take a look at the [request subcommands](/developers/tooling/cli#2-request-subcommands) in the Boundless CLI.
+If you're interested in doing a one-off test, take a look at the [request subcommands](/developers/tooling/cli#request) in the Boundless CLI.
 
-Relevant Links: [BuiltInStorageProvider](https://docs.rs/boundless-market/latest/boundless_market/storage/enum.BuiltinStorageProvider.html), [storage_provider_from_env](https://docs.rs/boundless-market/latest/boundless_market/storage/fn.storage_provider_from_env.html).
+Relevant Links: [StorageProvider](https://docs.rs/boundless-market/latest/boundless_market/storage/trait.StorageProvider.html), [storage_provider_from_env](https://docs.rs/boundless-market/latest/boundless_market/storage/fn.storage_provider_from_env.html).
 
 ## Prover
 
@@ -234,7 +234,7 @@ The general workflow for the prover is:
 The prover has to make sure that the Docker container that runs the broker starts with two kinds of AWS credentials in its environment:
 
 1. base credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`) which will be used to call [sts::AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
-2. the role to assume (e.g. `AWS_ROLE_ARN=arn:aws:iam::<PROVER_ACCOUNT_ID>:role/ProverInputDownloadRole` which is generated when the requestor created the role during [Create the required prover role](/developers/tutorials/sensitive-inputs#create-the-required-prover-role)).
+2. the role to assume (e.g. `AWS_ROLE_ARN=arn:aws:iam::<PROVER_ACCOUNT_ID>:role/ProverInputDownloadRole` which is generated when the requestor created the role during [Create the required prover role](/developers/tutorials/sensitive-inputs#2-create-the-required-prover-role)).
 
 To set these manually, make sure the export the following environment variables before spinning up the [broker](/provers/proving-stack#what-is-the-broker):
 

--- a/documentation/site/pages/provers/broker.mdx
+++ b/documentation/site/pages/provers/broker.mdx
@@ -130,7 +130,7 @@ A Broker needs a [Bento](/provers/proving-stack#what-is-bento) instance to opera
 
 To check Bento is running correctly, you can send a sample proof workload:
 
-> Before running this, [install Bento CLI](/provers/quick-start#bento-cli-installation)
+> Before running this, [install Bento CLI](/provers/quick-start#running-a-test-proof)
 
 ```sh [Terminal]
 # In the bento directory

--- a/documentation/site/pages/provers/performance-optimization.mdx
+++ b/documentation/site/pages/provers/performance-optimization.mdx
@@ -34,7 +34,7 @@ just bento
 
 It is recommended to benchmark using an example of your actual workload. Using a representative workload will provide more accurate turn around times, and validate your program and inputs file for the proofs you plan to generate.
 
-> Before running this, [install Bento CLI](/provers/quick-start#bento-cli-installation)
+> Before running this, [install Bento CLI](/provers/quick-start#running-a-test-proof)
 
 To try a realistic example:
 

--- a/documentation/site/pages/provers/proving-stack.mdx
+++ b/documentation/site/pages/provers/proving-stack.mdx
@@ -29,11 +29,11 @@ The [Prover Quick Start](/provers/quick-start) has information about getting sta
 ## What is the Broker?
 
 :::warning
-For all provers, a staking balance is necessary to be able to cover requirements for proof request lock-in. The Broker service provides a straightforward way to [deposit funds](/provers/broker#deposit-to-the-market) to the market.
+For all provers, a staking balance is necessary to be able to cover requirements for proof request lock-in. The Broker service provides a straightforward way to [deposit funds](/provers/broker#deposit-stake-to-the-market) to the market.
 :::
 
 The [Broker](/provers/broker) is responsible for market interactions (see steps **2b.** and **4a.** in *Figure 1*) including evaluating requests to assign a price, bidding on requests to lock them, issuing proving requests to the Bento proving cluster, and submitting proof fulfillments onchain.
-Broker configuration is primarily managed through the [`broker.toml`](/provers/broker#settings) file in the Boundless directory.
+Broker configuration is primarily managed through the [`broker.toml`](/provers/broker#settings-in-brokertoml) file in the Boundless directory.
 
 <a href="/proof-lifecycle.png" >
   <img src="/proof-lifecycle.png" alt="Proof Lifecycle" />

--- a/documentation/site/pages/provers/quick-start.mdx
+++ b/documentation/site/pages/provers/quick-start.mdx
@@ -115,7 +115,7 @@ This is your wallet which will represent your prover on the market; make sure it
 ### Deposit Stake
 
 :::note[Note]
-* To read more about depositing funds to the market, please see [Deposit / Balance](/provers/broker#deposit--balance).
+* To read more about depositing funds to the market, please see [Deposit / Balance](/provers/broker#deposit-stake-to-the-market).
 :::
 
 With the environment variables set, you can now deposit USDC tokens as stake to your account balance:


### PR DESCRIPTION
fixing dead link on /developers/quick-start page that @nahoc pointed out, I looked into adding a link checker. Quickly, I realized there is already a link checker in `documentation/scripts/check-links.ts`, but clearly wasn't working as intended. 

Looking in there, it only checks `.md` files and not `.mdx` files which is what we use so only the README.md was being checked. 

This PR addresses this, and fixes the script; and fixes all the dead links the scripts finds so that the CI passes :)