### PR TITLE
BM-1225: Make RPC errors in monitor/picker known. Raise threshold for submitter alarms

### DIFF
--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -52,6 +52,9 @@ pub enum OrderMonitorErr {
     #[error("{code} Order already locked", code = self.code())]
     AlreadyLocked,
 
+    #[error("{code} RPC error: {0:?}", code = self.code())]
+    RpcErr(anyhow::Error),
+
     #[error("{code} Unexpected error: {0:?}", code = self.code())]
     UnexpectedError(#[from] anyhow::Error),
 }
@@ -65,6 +68,7 @@ impl CodedError for OrderMonitorErr {
             OrderMonitorErr::LockTxFailed(_) => "[B-OM-007]",
             OrderMonitorErr::AlreadyLocked => "[B-OM-009]",
             OrderMonitorErr::InsufficientBalance => "[B-OM-010]",
+            OrderMonitorErr::RpcErr(_) => "[B-OM-011]",
             OrderMonitorErr::UnexpectedError(_) => "[B-OM-500]",
         }
     }
@@ -626,7 +630,7 @@ where
             .provider
             .get_balance(self.provider.default_signer_address())
             .await
-            .context("Failed to get current wallet balance")?;
+            .map_err(|err| OrderMonitorErr::RpcErr(err.into()))?;
 
         // Calculate gas units required for committed orders
         let committed_orders = self.db.get_committed_orders().await?;

--- a/infra/prover/components/brokerAlarms.ts
+++ b/infra/prover/components/brokerAlarms.ts
@@ -229,6 +229,11 @@ export const createProverAlarms = (
     threshold: 3,
   }, { period: 300 });
 
+  // 3 rpc errors within 15 minutes in the order picker triggers a SEV2 alarm.
+  createErrorCodeAlarm('"[B-OP-005]"', 'order-picker-rpc-error', Severity.SEV2, {
+    threshold: 3,
+  }, { period: 900 });
+
   //
   // Order Monitor
   //
@@ -256,7 +261,10 @@ export const createProverAlarms = (
     threshold: 3,
   }, { period: 3600 });
 
-
+  // 3 rpc errors within 15 minutes in the order monitor triggers a SEV2 alarm.
+  createErrorCodeAlarm('"[B-OM-011]"', 'order-monitor-rpc-error', Severity.SEV2, {
+    threshold: 3,
+  }, { period: 900 });
 
   //
   // Prover
@@ -317,8 +325,11 @@ export const createProverAlarms = (
     threshold: 4,
   }, { period: 3600 }, "Some requests in a batch expired before submission twice in an hour");
 
-  // Any 1 request expired before submission triggers a SEV2 alarm.
-  createErrorCodeAlarm('"[B-SUB-002]"', 'submitter-market-error-submission', Severity.SEV2);
+  // Any 2 market errors triggers a SEV2 alarm. Note we occasionally see these errors and on retry they
+  // succeed, so we alert on 2.
+  createErrorCodeAlarm('"[B-SUB-002]"', 'submitter-market-error-submission', Severity.SEV2, {
+    threshold: 2,
+  });
 
   // 4 failures to submit a batch within 2 hours due to timeouts in the submitter triggers a SEV2 alarm.
   // This may indicate a misconfiguration of the tx timeout config.


### PR DESCRIPTION
We've seen some RPC errors when getting wallet balances that are currently Unexpected errors. Catching them and setting a higher threshold.

Also raising the threshold on the market error alert in the submitter. We retry in the submitter and often see recovery from those errors, so no need to alert unless it fails multiple times.