### PR TITLE
BM-1230: Drop SNARK min buffer

### DIFF
--- a/infra/prover/tomls/bento/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bento/broker-prod-11155111.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 90
 txn_timeout = 75
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-prod-8453.toml
+++ b/infra/prover/tomls/bento/broker-prod-8453.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 90
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-prod-84532.toml
+++ b/infra/prover/tomls/bento/broker-prod-84532.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 90
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bento/broker-staging-11155111.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 90
 txn_timeout = 75
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 90
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bonsai/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-11155111.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 40
 txn_timeout = 75
 single_txn_fulfill = true
 withdraw = true

--- a/infra/prover/tomls/bonsai/broker-prod-8453.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-8453.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 40
 txn_timeout = 75
 single_txn_fulfill = true
 withdraw = true

--- a/infra/prover/tomls/bonsai/broker-prod-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-84532.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 40
 txn_timeout = 75
 single_txn_fulfill = true
 withdraw = true

--- a/infra/prover/tomls/bonsai/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bonsai/broker-staging-11155111.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 40
 txn_timeout = 75
 single_txn_fulfill = true
 withdraw = true

--- a/infra/prover/tomls/bonsai/broker-staging-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-staging-84532.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 180
+block_deadline_buffer_secs = 40
 txn_timeout = 75
 single_txn_fulfill = true
 withdraw = true


### PR DESCRIPTION
We dropped min_deadline in order to get lower latency orders being fulfilled, but forgot to drop this one. May be too low, but we'll test with this and revert if necessary