### PR TITLE
BM-1238: Bump block_deadline_buffer_secs

### DIFF
--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -580,7 +580,10 @@ impl AggregatorService {
         };
 
         if compress {
-            tracing::debug!("Starting groth16 compression proof for batch {batch_id}");
+            tracing::debug!(
+                "Starting groth16 compression proof for batch {batch_id} with orders {:x?}",
+                batch.orders
+            );
 
             let (retry_count, sleep_ms) = {
                 let config = self.config.lock_all().context("Failed to lock config")?;
@@ -604,7 +607,10 @@ impl AggregatorService {
                     return Err(AggregatorErr::CompressionErr(err));
                 }
             };
-            tracing::debug!("Completed groth16 compression for batch {batch_id}");
+            tracing::debug!(
+                "Completed groth16 compression for batch {batch_id} with orders {:x?}",
+                batch.orders
+            );
 
             self.db
                 .complete_batch(batch_id, &compress_proof_id)

--- a/infra/prover/tomls/bento/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bento/broker-prod-11155111.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 90
+block_deadline_buffer_secs = 120
 txn_timeout = 75
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-prod-8453.toml
+++ b/infra/prover/tomls/bento/broker-prod-8453.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 90
+block_deadline_buffer_secs = 120
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-prod-84532.toml
+++ b/infra/prover/tomls/bento/broker-prod-84532.toml
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 90
+block_deadline_buffer_secs = 120
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bento/broker-staging-11155111.toml
@@ -1,5 +1,5 @@
 [market]
-mcycle_price = "0.0000005"
+mcycle_price = "0.00000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
 peak_prove_khz = 80
 min_deadline = 120
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 90
+block_deadline_buffer_secs = 120
 txn_timeout = 75
 single_txn_fulfill = true
 max_submission_attempts = 2

--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -1,5 +1,5 @@
 [market]
-mcycle_price = "0.0000005"
+mcycle_price = "0.00000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
 peak_prove_khz = 80
 min_deadline = 120
@@ -31,7 +31,7 @@ proof_retry_sleep_ms = 500
 [batcher]
 batch_max_time = 1000
 min_batch_size = 1
-block_deadline_buffer_secs = 90
+block_deadline_buffer_secs = 120
 txn_timeout = 10
 single_txn_fulfill = true
 max_submission_attempts = 2


### PR DESCRIPTION
Dialing this back a little bit as we are seeing increased errors. Compressing can take close to 2 minutes in worst case for our Bento broker