### PR TITLE
Cache order IDs that have been priced to avoid duplicates

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -252,11 +252,12 @@ where
         tracing::debug!("Pricing order {order_id}");
 
         // Short circuit if the order has been locked.
-        if self
-            .db
-            .is_request_locked(U256::from(order.request.id))
-            .await
-            .context("Failed to check if request is locked before pricing")?
+        if order.fulfillment_type == FulfillmentType::LockAndFulfill
+            && self
+                .db
+                .is_request_locked(U256::from(order.request.id))
+                .await
+                .context("Failed to check if request is locked before pricing")?
         {
             tracing::debug!("Order {order_id} is already locked, skipping");
             return Ok(Skip);

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -251,6 +251,17 @@ where
         let order_id = order.id();
         tracing::debug!("Pricing order {order_id}");
 
+        // Short circuit if the order has been locked.
+        if self
+            .db
+            .is_request_locked(U256::from(order.request.id))
+            .await
+            .context("Failed to check if request is locked")?
+        {
+            tracing::debug!("Order {order_id} is already locked, skipping");
+            return Ok(Skip);
+        }
+
         let (min_deadline, allowed_addresses_opt) = {
             let config = self.config.lock_all().context("Failed to read config")?;
             (config.market.min_deadline, config.market.allow_client_addresses.clone())

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -256,7 +256,7 @@ where
             .db
             .is_request_locked(U256::from(order.request.id))
             .await
-            .context("Failed to check if request is locked")?
+            .context("Failed to check if request is locked before pricing")?
         {
             tracing::debug!("Order {order_id} is already locked, skipping");
             return Ok(Skip);


### PR DESCRIPTION
This is originally motivated by issues with a RPC provider sending duplicates of on-chain events, but this can be useful otherwise to avoid an order being spammed and re-priced multiple times. Also added a check if locked before pricing, to avoid cases where there is a delay in observing where an order is already locked.

Draft atm to rethink if there is a cleaner way to do this.