### PR TITLE
Reduce the size of some error enums

### DIFF
--- a/crates/boundless-market/src/storage/s3.rs
+++ b/crates/boundless-market/src/storage/s3.rs
@@ -60,7 +60,7 @@ pub enum S3StorageProviderError {
 
     /// Error type for missing configuration parameters.
     #[error("missing config parameter: {0}")]
-    Config(String),
+    Config(Box<str>),
 
     /// Error type for when S3 returns a string that fails to parse as a URL.
     #[error("failed to parse URL returned by S3: {0}")]
@@ -119,30 +119,28 @@ impl S3StorageProvider {
         let access_key = config
             .s3_access_key
             .clone()
-            .ok_or_else(|| S3StorageProviderError::Config("s3_access_key".to_string()))?;
+            .ok_or_else(|| S3StorageProviderError::Config("s3_access_key".into()))?;
 
         let secret_key = config
             .s3_secret_key
             .clone()
-            .ok_or_else(|| S3StorageProviderError::Config("s3_secret_key".to_string()))?;
+            .ok_or_else(|| S3StorageProviderError::Config("s3_secret_key".into()))?;
 
         let bucket = config
             .s3_bucket
             .clone()
-            .ok_or_else(|| S3StorageProviderError::Config("s3_bucket".to_string()))?;
-        let url = config
-            .s3_url
-            .clone()
-            .ok_or_else(|| S3StorageProviderError::Config("s3_url".to_string()))?;
+            .ok_or_else(|| S3StorageProviderError::Config("s3_bucket".into()))?;
+        let url =
+            config.s3_url.clone().ok_or_else(|| S3StorageProviderError::Config("s3_url".into()))?;
 
         let region = config
             .aws_region
             .clone()
-            .ok_or_else(|| S3StorageProviderError::Config("s3_region".to_string()))?;
+            .ok_or_else(|| S3StorageProviderError::Config("s3_region".into()))?;
 
         let presigned = config
             .s3_use_presigned
-            .ok_or_else(|| S3StorageProviderError::Config("s3_use_presigned".to_string()))?;
+            .ok_or_else(|| S3StorageProviderError::Config("s3_use_presigned".into()))?;
 
         Ok(Self::from_parts(access_key, secret_key, bucket, url, region, presigned))
     }

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -59,7 +59,7 @@ pub enum OrderPickerErr {
     FetchImageErr(#[source] anyhow::Error),
 
     #[error("{code} guest panicked: {0}", code = self.code())]
-    GuestPanic(String),
+    GuestPanic(Box<str>),
 
     #[error("{code} invalid request: {0}", code = self.code())]
     RequestError(#[from] RequestError),

--- a/crates/broker/src/provers/bonsai.rs
+++ b/crates/broker/src/provers/bonsai.rs
@@ -108,9 +108,9 @@ impl Bonsai {
                 }
                 status_code => {
                     let err_msg = status.error_msg.unwrap_or_default();
-                    return Err(ProverError::ProvingFailed(format!(
-                        "snark proving failed with status {status_code}: {err_msg}"
-                    )));
+                    return Err(ProverError::ProvingFailed(
+                        format!("snark proving failed with status {status_code}: {err_msg}").into(),
+                    ));
                 }
             }
         }
@@ -210,11 +210,11 @@ impl StatusPoller {
                 _ => {
                     let err_msg = status.error_msg.unwrap_or_default();
                     if err_msg.contains("INTERNAL_ERROR") {
-                        return Err(ProverError::ProverInternalError(err_msg.clone()));
+                        return Err(ProverError::ProverInternalError(err_msg.into()));
                     }
-                    return Err(ProverError::ProvingFailed(format!(
-                        "{proof_id:?} failed: {err_msg}"
-                    )));
+                    return Err(ProverError::ProvingFailed(
+                        format!("{proof_id:?} failed: {err_msg}").into(),
+                    ));
                 }
             }
         }
@@ -250,11 +250,11 @@ impl StatusPoller {
                 status_code => {
                     let err_msg = status.error_msg.unwrap_or_default();
                     if err_msg.contains("INTERNAL_ERROR") {
-                        return Err(ProverError::ProverInternalError(err_msg.clone()));
+                        return Err(ProverError::ProverInternalError(err_msg.into()));
                     }
-                    return Err(ProverError::ProvingFailed(format!(
-                        "snark proving failed with status {status_code}: {err_msg}"
-                    )));
+                    return Err(ProverError::ProvingFailed(
+                        format!("snark proving failed with status {status_code}: {err_msg}").into(),
+                    ));
                 }
             }
         }
@@ -383,10 +383,9 @@ impl Prover for Bonsai {
                             Ok(tx) => tx,
                             Err(e) => {
                                 tracing::error!("Failed to begin transaction: {}", e);
-                                return Err(ProverError::ProvingFailed(format!(
-                                    "Failed to begin transaction: {}",
-                                    e
-                                )));
+                                return Err(ProverError::ProvingFailed(
+                                    format!("Failed to begin transaction: {}", e).into(),
+                                ));
                             }
                         };
                         if let Err(e) =
@@ -396,10 +395,9 @@ impl Prover for Bonsai {
                                 .await
                         {
                             tracing::error!("Failed to update job state: {}", e);
-                            return Err(ProverError::ProvingFailed(format!(
-                                "Failed to update job: {}",
-                                e
-                            )));
+                            return Err(ProverError::ProvingFailed(
+                                format!("Failed to update job: {}", e).into(),
+                            ));
                         }
 
                         if let Err(e) = sqlx::query("DELETE FROM task_deps WHERE job_id = $1::uuid")
@@ -408,10 +406,9 @@ impl Prover for Bonsai {
                             .await
                         {
                             tracing::error!("Failed to delete task dependencies: {}", e);
-                            return Err(ProverError::ProvingFailed(format!(
-                                "Failed to delete task deps: {}",
-                                e
-                            )));
+                            return Err(ProverError::ProvingFailed(
+                                format!("Failed to delete task deps: {}", e).into(),
+                            ));
                         }
 
                         if let Err(e) = sqlx::query("DELETE FROM tasks WHERE job_id = $1::uuid")
@@ -420,18 +417,16 @@ impl Prover for Bonsai {
                             .await
                         {
                             tracing::error!("Failed to delete tasks: {}", e);
-                            return Err(ProverError::ProvingFailed(format!(
-                                "Failed to delete tasks: {}",
-                                e
-                            )));
+                            return Err(ProverError::ProvingFailed(
+                                format!("Failed to delete tasks: {}", e).into(),
+                            ));
                         }
 
                         if let Err(e) = tx.commit().await {
                             tracing::error!("Failed to commit transaction: {}", e);
-                            return Err(ProverError::ProvingFailed(format!(
-                                "Failed to commit transaction: {}",
-                                e
-                            )));
+                            return Err(ProverError::ProvingFailed(
+                                format!("Failed to commit transaction: {}", e).into(),
+                            ));
                         }
 
                         tracing::info!("Successfully cancelled Bento job {}", proof_id);
@@ -439,10 +434,9 @@ impl Prover for Bonsai {
                     }
                     Err(e) => {
                         tracing::error!("Failed to connect to PostgreSQL: {}", e);
-                        Err(ProverError::ProvingFailed(format!(
-                            "Failed to connect to postgres: {}",
-                            e
-                        )))
+                        Err(ProverError::ProvingFailed(
+                            format!("Failed to connect to postgres: {}", e).into(),
+                        ))
                     }
                 }
             }

--- a/crates/broker/src/provers/mod.rs
+++ b/crates/broker/src/provers/mod.rs
@@ -44,13 +44,13 @@ pub enum ProverError {
     ConfigReadErr(#[from] ConfigErr),
 
     #[error("{code} Not found: {0}", code = self.code())]
-    NotFound(String),
+    NotFound(Box<str>),
 
     #[error("{code} Stark job missing stats data", code = self.code())]
     MissingStatus,
 
     #[error("{code} Prover failure: {0}", code = self.code())]
-    ProvingFailed(String),
+    ProvingFailed(Box<str>),
 
     #[error("{code} Bincode deserilization error {0}", code = self.code())]
     BincodeErr(#[from] bincode::Error),
@@ -59,7 +59,7 @@ pub enum ProverError {
     StatusFailure,
 
     #[error("{code} Prover internal error: {0}", code = self.code())]
-    ProverInternalError(String),
+    ProverInternalError(Box<str>),
 
     #[error("{code} {0:?}", code = self.code())]
     UnexpectedError(#[from] anyhow::Error),


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts 8 bytes from 3 different `Error` enums through the use of `Box<str>`, which doesn't change any intended behavior.

Of course, 8 bytes won't make much of a runtime different in this project but it is still worthwhile IMO. 