### PR TITLE
docs: Fixed a typo: "Whgen" → "When" in file requirements.mdx

### DIFF
--- a/documentation/site/pages/provers/requirements.mdx
+++ b/documentation/site/pages/provers/requirements.mdx
@@ -49,5 +49,5 @@ To get started with the Broker and deposit stake to the market contract, please 
 :::
 
 The Boundless Market works via an escrow system.
-Whgen provers win a bid on a [proof request](/provers/proof-lifecycle#3-provers-bid-on-the-request), they require tokens to cover staking requirements for the request, as specified by the client.
+When provers win a bid on a [proof request](/provers/proof-lifecycle#3-provers-bid-on-the-request), they require tokens to cover staking requirements for the request, as specified by the client.
 The recommended way to carry out market interactions, such as depositing stake, is to use the [Broker](/provers/broker#broker-configuration), an optional service which runs within the Bento docker compose stack.


### PR DESCRIPTION
Made a small typo correction in requirements.mdx, changing "Whgen" to "When".   It's a minor fix that most readers would understand, but it's better.