### PR TITLE
BM-1301: Adjust min price and peak kHz parameters for Bonsai Broker

### DIFF
--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -14,7 +14,7 @@ stake_balance_warn_threshold = "5"
 stake_balance_error_threshold = "1"
 priority_requestor_addresses = ["0x0466ACfc0F27bBA9fBB7A8508f576527e81E83Bd"]
 deny_requestor_addresses = [
-  "0x47c76E56Ad9316A5c1ab17CBa87a1Cc134552183", # Signal contract on Base Sepolia; proofs are too large
+  "0x5351280f80ffC14B7550638F1d2fa336D7e1d435", # Signal contract on Base Sepolia, connected to the staging market
 ]
 # max_fetch_retries = 2
 # allow_client_addresses = []

--- a/infra/prover/tomls/bonsai/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-11155111.toml
@@ -1,7 +1,7 @@
 [market]
-mcycle_price = "0.000001"
+mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 700
+peak_prove_khz = 2000
 min_deadline = 70
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bonsai/broker-prod-8453.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-8453.toml
@@ -1,7 +1,7 @@
 [market]
-mcycle_price = "0.000001"
+mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 700
+peak_prove_khz = 2000
 min_deadline = 70
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bonsai/broker-prod-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-84532.toml
@@ -1,7 +1,7 @@
 [market]
-mcycle_price = "0.000001"
+mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 700
+peak_prove_khz = 2000
 min_deadline = 70
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bonsai/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bonsai/broker-staging-11155111.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 700
+peak_prove_khz = 2000
 min_deadline = 70
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bonsai/broker-staging-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-staging-84532.toml
@@ -1,7 +1,7 @@
 [market]
 mcycle_price = "0.0000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
-peak_prove_khz = 700
+peak_prove_khz = 2000
 min_deadline = 70
 lookback_blocks = 100
 max_stake = "0.5"

--- a/infra/prover/tomls/bonsai/broker-staging-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-staging-84532.toml
@@ -15,7 +15,7 @@ stake_balance_error_threshold = "10"
 priority_requestor_addresses = [
   "0x0466ACfc0F27bBA9fBB7A8508f576527e81E83Bd",
   "0x927623523CAF64B05F5b75D8a1086f77d272dAf1",
-  "0x47c76E56Ad9316A5c1ab17CBa87a1Cc134552183", # Signal contract on Base Sepolia
+  "0x5351280f80ffC14B7550638F1d2fa336D7e1d435", # Signal contract on Base Sepolia, connected to the staging market
 ]
 # max_fetch_retries = 2
 # allow_client_addresses = []


### PR DESCRIPTION
Additionally, this updates the priority and deny lists for the staging brokers to use a deployment of the Signal contract that targets staging.