### PR TITLE
BM-1307: Support fetching of ERC-1271 authorized requests in `boundless` cli

### DIFF
--- a/crates/boundless-cli/src/bin/boundless.rs
+++ b/crates/boundless-cli/src/bin/boundless.rs
@@ -55,7 +55,7 @@ use alloy::{
     network::Ethereum,
     primitives::{
         utils::{format_ether, format_units, parse_ether, parse_units},
-        Address, Bytes, FixedBytes, TxKind, B256, U256,
+        Address, FixedBytes, TxKind, B256, U256,
     },
     providers::{Provider, ProviderBuilder},
     rpc::types::{TransactionInput, TransactionRequest},
@@ -703,8 +703,12 @@ async fn handle_proving_command(cmd: &ProvingCommands, client: StandardClient) -
                 serde_yaml::from_reader(reader).context("failed to parse request from YAML")?
             } else if let Some(request_id) = request_id {
                 tracing::debug!("Loading request from blockchain: 0x{:x}", request_id);
-                let order = client.fetch_order(*request_id, *tx_hash, *request_digest).await?;
-                order.request
+                let (req, _signature) =
+                    client.fetch_proof_request(*request_id, *tx_hash, *request_digest).await?;
+                // TODO: We should check the signature here. If the signature is invalid, this
+                // might lead to wasted time. Note though that if the signature is invalid it can
+                // never be used to effect onchain state (e.g. locking or fulfilling).
+                req
             } else {
                 bail!("execute requires either a request file path or request ID")
             };
@@ -755,23 +759,30 @@ async fn handle_proving_command(cmd: &ProvingCommands, client: StandardClient) -
                 let client = client.clone();
                 let boundless_market = client.boundless_market.clone();
                 async move {
-                    let order = client
-                        .fetch_order(
+                    let (req, sig) = client
+                        .fetch_proof_request(
                             *request_id,
                             tx_hashes.as_ref().map(|tx_hashes| tx_hashes[i]),
                             request_digests.as_ref().map(|request_digests| request_digests[i]),
                         )
                         .await?;
-                    tracing::debug!("Fetched order details: {:?}", order.request);
+                    tracing::debug!("Fetched order details: {req:?}");
 
-                    let sig: Bytes = order.signature.as_bytes().into();
-                    order.request.verify_signature(
-                        &sig,
-                        client.deployment.boundless_market_address,
-                        boundless_market.get_chain_id().await?,
-                    )?;
+                    if !req.is_smart_contract_signed() {
+                        req.verify_signature(
+                            &sig,
+                            client.deployment.boundless_market_address,
+                            boundless_market.get_chain_id().await?,
+                        )?;
+                    } else {
+                        // TODO: Provide a way to check the EIP1271 auth.
+                        tracing::debug!(
+                            "Skipping authorization check on smart contract signed request 0x{:x}",
+                            U256::from(req.id)
+                        );
+                    }
                     let is_locked = boundless_market.is_locked(*request_id).await?;
-                    Ok::<_, anyhow::Error>((order, sig, is_locked))
+                    Ok::<_, anyhow::Error>((req, sig, is_locked))
                 }
             });
 
@@ -780,14 +791,14 @@ async fn handle_proving_command(cmd: &ProvingCommands, client: StandardClient) -
             let mut unlocked_requests = Vec::new();
 
             for result in results {
-                let (order, sig, is_locked) = result?;
+                let (req, sig, is_locked) = result?;
                 // If the request is not locked in, we need to "price" which checks the requirements
                 // and assigns a price. Otherwise, we don't. This vec will be a singleton if not locked
                 // and empty if the request is locked.
                 if !is_locked {
-                    unlocked_requests.push(UnlockedRequest::new(order.request.clone(), sig));
+                    unlocked_requests.push(UnlockedRequest::new(req.clone(), sig.clone()));
                 }
-                orders.push(order);
+                orders.push((req, sig));
             }
 
             let (fills, root_receipt, assessor_receipt) = prover.fulfill(&orders).await?;
@@ -817,17 +828,21 @@ async fn handle_proving_command(cmd: &ProvingCommands, client: StandardClient) -
         ProvingCommands::Lock { request_id, request_digest, tx_hash } => {
             tracing::info!("Locking proof request 0x{:x}", request_id);
 
-            let order = client.fetch_order(*request_id, *tx_hash, *request_digest).await?;
-            tracing::debug!("Fetched order details: {:?}", order.request);
+            let (request, signature) =
+                client.fetch_proof_request(*request_id, *tx_hash, *request_digest).await?;
+            tracing::debug!("Fetched order details: {request:?}");
 
-            let sig: Bytes = order.signature.as_bytes().into();
-            order.request.verify_signature(
-                &sig,
-                client.deployment.boundless_market_address,
-                client.boundless_market.get_chain_id().await?,
-            )?;
+            // If the request is smart contract signed, the preflight of the lock request
+            // transaction will revert, since it includes the ERC1271 signature check.
+            if !request.is_smart_contract_signed() {
+                request.verify_signature(
+                    &signature,
+                    client.deployment.boundless_market_address,
+                    client.boundless_market.get_chain_id().await?,
+                )?;
+            }
 
-            client.boundless_market.lock_request(&order.request, sig, None).await?;
+            client.boundless_market.lock_request(&request, signature, None).await?;
             tracing::info!("Successfully locked request 0x{:x}", request_id);
             Ok(())
         }
@@ -888,8 +903,10 @@ async fn benchmark(
             request_id
         );
 
-        let order = client.fetch_order(*request_id, None, None).await?;
-        let request = order.request;
+        let (request, _signature) = client.fetch_proof_request(*request_id, None, None).await?;
+        // TODO: We should check the signature here. If the signature is invalid, this might lead
+        // to wasted time on an invalid request. This is acceptable for now because the purpose of
+        // this command is benchmarking.
 
         tracing::debug!("Fetched request 0x{:x}", request_id);
         tracing::debug!("Image URL: {}", request.imageUrl);

--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -24,7 +24,6 @@ use alloy::{
     },
 };
 use alloy_primitives::{Signature, B256};
-use alloy_sol_types::SolStruct;
 use anyhow::{anyhow, bail, Context, Result};
 use risc0_aggregation::SetInclusionReceipt;
 use risc0_ethereum_contracts::set_verifier::SetVerifierService;
@@ -40,7 +39,7 @@ use crate::{
     deployments::Deployment,
     dynamic_gas_filler::DynamicGasFiller,
     nonce_layer::NonceProvider,
-    order_stream_client::{Order, OrderStreamClient},
+    order_stream_client::OrderStreamClient,
     request_builder::{
         FinalizerConfigBuilder, OfferLayer, OfferLayerConfigBuilder, RequestBuilder,
         RequestIdLayer, RequestIdLayerConfigBuilder, StandardRequestBuilder,
@@ -858,37 +857,52 @@ where
         Ok((journal, receipt))
     }
 
-    /// Fetch an order as a proof request and signature pair.
+    /// Fetch a proof request and its signature, querying first offchain, and then onchain.
     ///
-    /// If the request is not found in the boundless market, it will be fetched from the order stream service.
-    pub async fn fetch_order(
+    /// This method does not verify the signature, and the order cannot be guarenteed to be
+    /// authorized by this call alone.
+    ///
+    /// The request is first looked up offchain using the order stream service, then onchain using
+    /// event queries. The offchain query is sent first, since it is quick to check. Querying
+    /// onchain uses event logs, and will take more time to find requests that are further in the
+    /// past.
+    ///
+    /// Providing a `tx_hash` will speed up onchain queries, by fetching the transaction containing
+    /// the request. Providing the `request_digest` allows differentiating between multiple
+    /// requests with the same ID. If set to `None`, the first found request matching the ID will
+    /// be returned.
+    pub async fn fetch_proof_request(
         &self,
         request_id: U256,
         tx_hash: Option<B256>,
         request_digest: Option<B256>,
-    ) -> Result<Order, ClientError> {
-        match self.boundless_market.get_submitted_request(request_id, tx_hash).await {
-            Ok((request, signature_bytes)) => {
-                let domain = self.boundless_market.eip712_domain().await?;
-                let digest = request.eip712_signing_hash(&domain.alloy_struct());
-                if let Some(expected_digest) = request_digest {
-                    if digest != expected_digest {
-                        return Err(ClientError::RequestError(RequestError::DigestMismatch));
-                    }
+    ) -> Result<(ProofRequest, Bytes), ClientError> {
+        if let Some(ref order_stream_client) = self.offchain_client {
+            tracing::debug!("Querying the order stream for request: 0x{request_id:x} using request_digest {request_digest:?}");
+            match order_stream_client.fetch_order(request_id, request_digest).await {
+                Ok(order) => {
+                    tracing::debug!("Found request 0x{request_id:x} offchain");
+                    return Ok((order.request, Bytes::from(order.signature.as_bytes())));
                 }
-                Ok(Order {
-                    request,
-                    request_digest: digest,
-                    signature: Signature::try_from(signature_bytes.as_ref())
-                        .map_err(|_| ClientError::Error(anyhow!("Failed to parse signature")))?,
-                })
+                Err(err) => {
+                    tracing::error!(
+                        "Error querying order stream for request 0x{request_id:x}; err = {err}"
+                    );
+                }
             }
-            Err(_) => Ok(self
-                .offchain_client
-                .as_ref()
-                .context("Request not found on-chain and order stream client not available. Please provide an order stream URL")?
-                .fetch_order(request_id, request_digest)
-                .await?),
+        } else {
+            tracing::debug!("Skipping query for request offchain; no order stream client provided");
+        }
+
+        tracing::debug!(
+            "Querying the blockchain for request: 0x{request_id:x} using tx_hash {tx_hash:?}"
+        );
+        match self.boundless_market.get_submitted_request(request_id, tx_hash).await {
+            Ok((proof_request, signature)) => Ok((proof_request, signature)),
+            Err(err @ MarketError::RequestNotFound(_)) => Err(err.into()),
+            err @ Err(_) => err
+                .with_context(|| format!("error querying for 0x{request_id:x} onchain"))
+                .map_err(Into::into),
         }
     }
 }

--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -885,9 +885,14 @@ where
                     return Ok((order.request, Bytes::from(order.signature.as_bytes())));
                 }
                 Err(err) => {
-                    tracing::error!(
-                        "Error querying order stream for request 0x{request_id:x}; err = {err}"
-                    );
+                    // TODO: Provide a type-safe way to handle this error.
+                    if err.to_string().contains("No order found") {
+                        tracing::debug!("Request 0x{request_id:x} not found offchain");
+                    } else {
+                        tracing::error!(
+                            "Error querying order stream for request 0x{request_id:x}; err = {err}"
+                        );
+                    }
                 }
             }
         } else {

--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -1095,6 +1095,7 @@ impl<P: Provider> BoundlessMarketService<P> {
                 .context("Failed to get transaction")?
                 .context("Transaction not found")?;
             let inputs = tx_data.input();
+            // TODO: This should parse from events rather than calldata.
             let calldata = IBoundlessMarket::submitRequestCall::abi_decode(inputs)
                 .context("Failed to decode input")?;
             return Ok((calldata.request, calldata.clientSignature));

--- a/crates/boundless-market/src/order_stream_client.rs
+++ b/crates/boundless-market/src/order_stream_client.rs
@@ -92,6 +92,7 @@ pub struct Order {
     #[schema(value_type = Object)]
     pub request_digest: B256,
     /// Order signature
+    // TODO: This should not be Signature. It should be Bytes or Vec<u8>.
     #[schema(value_type = Object)]
     pub signature: Signature,
 }

--- a/crates/indexer/tests/basic.rs
+++ b/crates/indexer/tests/basic.rs
@@ -6,19 +6,16 @@ use std::{process::Command, time::Duration};
 
 use alloy::{
     node_bindings::Anvil,
-    primitives::{Address, Bytes, Signature, U256},
+    primitives::{Address, Bytes, U256},
     providers::Provider,
     rpc::types::BlockNumberOrTag,
     signers::Signer,
 };
 use boundless_cli::{DefaultProver, OrderFulfilled};
 use boundless_indexer::test_utils::TestDb;
-use boundless_market::{
-    contracts::{
-        boundless_market::FulfillmentTx, Offer, Predicate, PredicateType, ProofRequest, RequestId,
-        RequestInput, Requirements,
-    },
-    order_stream_client::Order,
+use boundless_market::contracts::{
+    boundless_market::FulfillmentTx, Offer, Predicate, PredicateType, ProofRequest, RequestId,
+    RequestInput, Requirements,
 };
 use boundless_market_test_utils::{
     create_test_ctx, ASSESSOR_GUEST_ELF, ECHO_ID, ECHO_PATH, SET_BUILDER_ELF,
@@ -116,16 +113,8 @@ async fn test_e2e() {
     ctx.customer_market.submit_request_with_signature(&request, client_sig.clone()).await.unwrap();
     ctx.prover_market.lock_request(&request, client_sig.clone(), None).await.unwrap();
 
-    let (fill, root_receipt, assessor_receipt) = prover
-        .fulfill(&[Order {
-            request: request.clone(),
-            request_digest: request
-                .signing_hash(ctx.deployment.boundless_market_address, anvil.chain_id())
-                .unwrap(),
-            signature: Signature::try_from(client_sig.as_ref()).unwrap(),
-        }])
-        .await
-        .unwrap();
+    let (fill, root_receipt, assessor_receipt) =
+        prover.fulfill(&[(request.clone(), client_sig.clone())]).await.unwrap();
     let order_fulfilled =
         OrderFulfilled::new(fill.clone(), root_receipt, assessor_receipt).unwrap();
     ctx.prover_market
@@ -329,16 +318,8 @@ async fn test_monitoring() {
     ctx.customer_market.deposit(U256::from(1)).await.unwrap();
     ctx.customer_market.submit_request_with_signature(&request, client_sig.clone()).await.unwrap();
     ctx.prover_market.lock_request(&request, client_sig.clone(), None).await.unwrap();
-    let (fill, root_receipt, assessor_receipt) = prover
-        .fulfill(&[Order {
-            request: request.clone(),
-            request_digest: request
-                .signing_hash(ctx.deployment.boundless_market_address, anvil.chain_id())
-                .unwrap(),
-            signature: Signature::try_from(client_sig.as_ref()).unwrap(),
-        }])
-        .await
-        .unwrap();
+    let (fill, root_receipt, assessor_receipt) =
+        prover.fulfill(&[(request.clone(), client_sig.clone())]).await.unwrap();
     let order_fulfilled =
         OrderFulfilled::new(fill.clone(), root_receipt, assessor_receipt).unwrap();
     let fulfillment = FulfillmentTx::new(order_fulfilled.fills, order_fulfilled.assessorReceipt)


### PR DESCRIPTION
The `Order` struct used throughout the code base makes a bad assumption that all signatures are ECDSA, and can be parsed by `alloy`. Signatures should not be parsed, and instead should be handled as bytes expect where they are verified. Fixing this issue is a much deeper refactor, but this PR starts by refactoring the method to fetch an order from the market, with the immediate goal of supporting handling of ERC1271 authorized requests in the `boundless` CLI.