### PR TITLE
BM-1310: Log session id for preflights, add function for getting proof prover

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -977,7 +977,7 @@ impl<P: Provider> BoundlessMarketService<P> {
         request_id: U256,
         lower_bound: Option<u64>,
         upper_bound: Option<u64>,
-    ) -> Result<(Bytes, Bytes), MarketError> {
+    ) -> Result<(Bytes, Bytes, Address), MarketError> {
         let mut upper_block = upper_bound.unwrap_or(self.get_latest_block_number().await?);
         let start_block = lower_bound.unwrap_or(upper_block.saturating_sub(
             self.event_query_config.block_range * self.event_query_config.max_iterations,
@@ -1005,7 +1005,11 @@ impl<P: Provider> BoundlessMarketService<P> {
             let logs = event_filter.query().await?;
 
             if let Some((event, _)) = logs.first() {
-                return Ok((event.fulfillment.journal.clone(), event.fulfillment.seal.clone()));
+                return Ok((
+                    event.fulfillment.journal.clone(),
+                    event.fulfillment.seal.clone(),
+                    event.prover,
+                ));
             }
 
             // Move the upper_block down for the next iteration
@@ -1075,7 +1079,25 @@ impl<P: Provider> BoundlessMarketService<P> {
     ) -> Result<(Bytes, Bytes), MarketError> {
         match self.get_status(request_id, None).await? {
             RequestStatus::Expired => Err(MarketError::RequestHasExpired(request_id)),
-            RequestStatus::Fulfilled => self.query_fulfilled_event(request_id, None, None).await,
+            RequestStatus::Fulfilled => {
+                let (journal, seal, _) = self.query_fulfilled_event(request_id, None, None).await?;
+                Ok((journal, seal))
+            }
+            _ => Err(MarketError::RequestNotFulfilled(request_id)),
+        }
+    }
+
+    /// Returns the prover address for a request that is fulfilled.
+    pub async fn get_request_fulfillment_prover(
+        &self,
+        request_id: U256,
+    ) -> Result<Address, MarketError> {
+        match self.get_status(request_id, None).await? {
+            RequestStatus::Expired => Err(MarketError::RequestHasExpired(request_id)),
+            RequestStatus::Fulfilled => {
+                let (_, _, prover) = self.query_fulfilled_event(request_id, None, None).await?;
+                Ok(prover)
+            }
             _ => Err(MarketError::RequestNotFulfilled(request_id)),
         }
     }
@@ -1119,7 +1141,9 @@ impl<P: Provider> BoundlessMarketService<P> {
             match status {
                 RequestStatus::Expired => return Err(MarketError::RequestHasExpired(request_id)),
                 RequestStatus::Fulfilled => {
-                    return self.query_fulfilled_event(request_id, None, None).await;
+                    let (journal, seal, _) =
+                        self.query_fulfilled_event(request_id, None, None).await?;
+                    return Ok((journal, seal));
                 }
                 _ => {
                     tracing::info!(

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -526,12 +526,14 @@ where
                 &input_id,
                 vec![],
                 /* TODO assumptions */ Some(exec_limit_cycles),
+                &order_id,
             )
             .await
         {
             Ok(res) => {
                 tracing::debug!(
-                    "Preflight execution of {order_id} with {} mcycles completed in {} seconds",
+                    "Preflight execution of {order_id} with session id {} and {} mcycles completed in {} seconds",
+                    res.id,
                     res.stats.total_cycles / 1_000_000,
                     res.elapsed_time
                 );

--- a/crates/broker/src/provers/bonsai.rs
+++ b/crates/broker/src/provers/bonsai.rs
@@ -192,7 +192,7 @@ impl StatusPoller {
                         return Err(ProverError::MissingStatus);
                     };
                     tracing::trace!(
-                        "Proof {proof_id:?} succeeded with user cycles: {} and total cycles: {}",
+                        "Session {proof_id:?} succeeded with user cycles: {} and total cycles: {}",
                         stats.cycles,
                         stats.total_cycles
                     );
@@ -289,6 +289,7 @@ impl Prover for Bonsai {
         input_id: &str,
         assumptions: Vec<String>,
         executor_limit: Option<u64>,
+        order_id: &str,
     ) -> Result<ProofResult, ProverError> {
         self.retry_only(
             || async {
@@ -310,6 +311,9 @@ impl Prover for Bonsai {
                     )
                     .await?;
 
+                tracing::debug!(
+                    "Created session for preflight: {preflight_id:?} for order id {order_id:?} with image id {image_id} and input id {input_id}"
+                );
                 let poller = StatusPoller {
                     poll_sleep_ms: self.status_poll_ms,
                     retry_counts: self.status_poll_retry_count,

--- a/crates/broker/src/provers/default.rs
+++ b/crates/broker/src/provers/default.rs
@@ -149,6 +149,7 @@ impl Prover for DefaultProver {
         input_id: &str,
         assumptions: Vec<String>,
         executor_limit: Option<u64>,
+        _order_id: &str,
     ) -> Result<ProofResult, ProverError> {
         let image = self
             .get_image(image_id)
@@ -425,7 +426,8 @@ mod tests {
         prover.upload_image(&image_id, ECHO_ELF.to_vec()).await.unwrap();
 
         // Run preflight
-        let result = prover.preflight(&image_id, &input_id, vec![], None).await.unwrap();
+        let result =
+            prover.preflight(&image_id, &input_id, vec![], None, "test_order_id").await.unwrap();
         assert!(!result.id.is_empty());
         assert!(result.stats.segments > 0 && result.stats.user_cycles > 0);
 

--- a/crates/broker/src/provers/mod.rs
+++ b/crates/broker/src/provers/mod.rs
@@ -106,6 +106,7 @@ pub trait Prover {
         input_id: &str,
         assumptions: Vec<String>,
         executor_limit: Option<u64>,
+        order_id: &str,
     ) -> Result<ProofResult, ProverError>;
     async fn prove_stark(
         &self,


### PR DESCRIPTION
Seeing some strange behavior with the preflights, and would be much easier to debug if we logged the session ids exactly when we create them + log them with the order id in the string so we can pull them with 1 log query.

The API change to the prover here doesn't make the most sense as we shouldn't really pass in order id, but its the quickest way to get the session ids. Happy to revert later for a cleaner solution.

Also adding a function for getting the prover of a fulfillment, which will be useful for the proof indexer