### PR TITLE
BM-1328: flesh out broker.toml descriptions

### DIFF
--- a/documentation/site/pages/provers/broker.mdx
+++ b/documentation/site/pages/provers/broker.mdx
@@ -57,18 +57,18 @@ Quotation marks matter in TOML so please pay particular attention to the quotati
 
 `broker.toml` contains the following settings for the market:
 
-| setting                  | initial value | description                                                                                                    |
-| ------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------- |
-| mcycle\_price            | `".001"`      | The price (in native token of target market) of proving 1M cycles.                                             |
-| assumption\_price        | `"0.1"`       | Currently unused.                                                                                              |
-| peak\_prove\_khz         | `500`         | This should correspond to the maximum number of cycles per second (in kHz) your proving backend can operate.   |
-| min\_deadline            | `150`         | This is a minimum number of blocks before the requested job expiration that Broker will attempt to lock a job. |
-| lookback\_blocks         | `100`         | This is used on Broker initialization, and sets the number of blocks to look back for candidate proofs.        |
-| max\_stake               | `"0.5"`       | The maximum amount used to lock in a job for any single order.                                                 |
-| skip\_preflight\_ids     | `[]`          | A list of `imageID`s that the Broker should skip preflight checks in format `["0xID1","0xID2"]`.               |
-| max\_file\_size          | `50_000_000`  | The maximum guest image size in bytes that the Broker will accept.                                             |
-| allow\_client\_addresses | `[]`          | When defined, this acts as a firewall to limit proving only to specific client addresses.                           |
-| lockin\_priority\_gas    | `100`         | Additional gas to add to the base price when locking in stake on a contract to increase priority.              |
+| setting                | initial value   | description                                                                                                                                            |
+| ---------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| mcycle_price           | `".001"`        | The price (in native token of target market) of proving 1M cycles.                                                                                     |
+| assumption_price       | `"0.1"`         | Currently unused.                                                                                                                                      |
+| peak_prove_khz         | `500`           | This should correspond to the maximum number of cycles per second (in kHz) your proving backend can operate. Please see [Benchmarking Bento](#benchmarking-bento).                                    |
+| min_deadline           | `150`           | This is a minimum number of blocks before the requested job expiration that Broker will attempt to lock a job.                                         |
+| lookback_blocks        | `100`           | This is used on Broker initialization, and sets the number of blocks to look back for candidate proofs.                                                |
+| max_stake              | `"0.5"`         | The maximum amount used to lock in a job for any single order.                                                                                         |
+| skip_preflight_ids     | `[]`            | A list of `imageID`s that the Broker should skip preflight checks in format `["0xID1","0xID2"]`.                                                       |
+| max_file_size          | `50_000_000`    | The maximum guest image size in bytes that the Broker will accept.                                                                                     |
+| allow_client_addresses | `["0x1234..."]` | Optional whitelist of requestor addresses. When defined, only requests from these requestor addresses will be processed. Use format `["0xAddress1", "0xAddress2"]`. |
+| lockin_priority_gas    | `100`           | Additional gas to add to the base price when locking in stake on a contract to increase priority.                                                      |
 
 ## Broker Operation
 


### PR DESCRIPTION
- added a little bit more info for the 'allow_client_addresses' and 'peak_prove_khz' options