### PR TITLE
BM-1329: add more info to broker.toml descriptions

### DIFF
--- a/documentation/site/pages/provers/broker.mdx
+++ b/documentation/site/pages/provers/broker.mdx
@@ -61,13 +61,13 @@ Quotation marks matter in TOML so please pay particular attention to the quotati
 | ------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------- |
 | mcycle\_price            | `".001"`      | The price (in native token of target market) of proving 1M cycles.                                             |
 | assumption\_price        | `"0.1"`       | Currently unused.                                                                                              |
-| peak\_prove\_khz         | `500`         | This should correspond to the maximum number of cycles per second (in kHz) your proving backend can operate.   |
+| peak\_prove\_khz         | `500`         | This should correspond to the maximum number of cycles per second (in kHz) your proving backend can operate - see [Benchmarking Bento](#benchmarking-bento). |
 | min\_deadline            | `150`         | This is a minimum number of blocks before the requested job expiration that Broker will attempt to lock a job. |
 | lookback\_blocks         | `100`         | This is used on Broker initialization, and sets the number of blocks to look back for candidate proofs.        |
 | max\_stake               | `"0.5"`       | The maximum amount used to lock in a job for any single order.                                                 |
 | skip\_preflight\_ids     | `[]`          | A list of `imageID`s that the Broker should skip preflight checks in format `["0xID1","0xID2"]`.               |
 | max\_file\_size          | `50_000_000`  | The maximum guest image size in bytes that the Broker will accept.                                             |
-| allow\_client\_addresses | `[]`          | When defined, this acts as a firewall to limit proving only to specific client addresses.                           |
+| allow\_client\_addresses | `["0x1234..."]` | Optional whitelist of requestor addresses. When defined, only requests from these requestor addresses will be processed. Use format `["0xAddress1", "0xAddress2"]`. |
 | lockin\_priority\_gas    | `100`         | Additional gas to add to the base price when locking in stake on a contract to increase priority.              |
 
 ## Broker Operation

--- a/documentation/site/pages/provers/requirements.mdx
+++ b/documentation/site/pages/provers/requirements.mdx
@@ -14,7 +14,7 @@ A recommended minimum configuration for proving performance:
 * RAM - 32 GB
 * Disk - 200 GB of solid state storage, NVME / SSD preferred
 * GPUs: at least one NVIDIA GPU with >= 8GB of VRAM.
-    - In testing, we've found the best performance on the following NVIDIA GPUs: 4090, 5090 and L4.
+    - In testing, we've found the best performance on the following NVIDIA GPUs: 4090, and L4.
     - While it's possible to use a single GPU, we recommend at least 10 GPUs to run a competitive prover.
 
 :::note[Optimizing your prover to be competitive]


### PR DESCRIPTION
- added a little bit more info for the 'allow_client_addresses' and 'peak_prove_khz' options