### PR TITLE
BM-1334: Bump order stream maxconns to 1000

### DIFF
--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -124,7 +124,7 @@ pub struct Args {
     min_balance_raw: U256,
 
     /// Maximum number of WebSocket connections
-    #[clap(long, default_value = "250")]
+    #[clap(long, default_value = "1000")]
     max_connections: usize,
 
     /// Maximum size of the queue for each WebSocket connection


### PR DESCRIPTION
Our CPU/memory utilization shows as around 5%, so this should be safe with our current instance size.