### PR TITLE
refactor: update dotenv import to use ES6 style in slasher/index.ts

### DIFF
--- a/infra/slasher/index.ts
+++ b/infra/slasher/index.ts
@@ -4,9 +4,10 @@ import * as pulumi from '@pulumi/pulumi';
 import * as docker_build from '@pulumi/docker-build';
 import { ChainId, getServiceNameV1, getEnvVar, Severity } from '../util';
 import * as crypto from 'crypto';
-require('dotenv').config();
+import * as dotenv from 'dotenv';
 
 export = () => {
+  dotenv.config();
   const config = new pulumi.Config();
   const stackName = pulumi.getStack();
   const isDev = stackName === "dev";


### PR DESCRIPTION
Replace CommonJS require('dotenv').config() with ES6 import * as dotenv from 'dotenv' and move the config() call inside the exported function. This maintains consistent import style across the codebase and ensures proper initialization of environment variables at runtime