### PR TITLE
lower order stream server max size

### DIFF
--- a/crates/order-stream/src/lib.rs
+++ b/crates/order-stream/src/lib.rs
@@ -415,7 +415,7 @@ impl AppState {
     }
 }
 
-const MAX_ORDER_SIZE: usize = 25 * 1024 * 1024; // 25 mb
+const MAX_ORDER_SIZE: usize = 100 * 1024; // 100 KiB
 
 #[derive(OpenApi, Debug, Deserialize)]
 #[openapi(


### PR DESCRIPTION
Generally orders are around 1.5kb in json, so don't need more than this