### PR TITLE
BM-1356: Wipe bonsai DB, increase threshold for topping up stake

### DIFF
--- a/infra/distributor/Pulumi.prod-11155111.yaml
+++ b/infra/distributor/Pulumi.prod-11155111.yaml
@@ -19,7 +19,7 @@ config:
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:SLASHER_KEY:
     secure: v1:vsk259VkW141RyaB:C7r1PNqhYOijA3pWLcOAJsX4W955zPyXGWeA3xLwYFdFw/lbmlqc5Z5OE5Lebc4wluMtFD415gm5kd2bYZiaaUb5sZsOz56HZTphvHuvO1o=
-  distributor:STAKE_THRESHOLD: "7"
+  distributor:STAKE_THRESHOLD: "10"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:ETH_RPC_URL:
     secure: v1:JmRN0Yx2P808CPdQ:80sm4c45agFln7EyTxVaABtay7q+g/jNPW2RFuiHk1pek601Wb80QMlwtI8Kx6GuhCC7ZJU8/SETkyg36Qtrz6pt+MJGwLk3GWQ=

--- a/infra/distributor/Pulumi.prod-84532.yaml
+++ b/infra/distributor/Pulumi.prod-84532.yaml
@@ -12,7 +12,7 @@ config:
   distributor:DISTRIBUTOR_ADDRESS: 0xFc1f6D609610a479F9c7453BF3aeC8cb3849F865
   distributor:ETH_THRESHOLD: "1"
   distributor:ETH_TOP_UP_AMOUNT: "10"
-  distributor:STAKE_THRESHOLD: "7"
+  distributor:STAKE_THRESHOLD: "10"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "10"
   distributor:SCHEDULE_MINUTES: "360"

--- a/infra/distributor/Pulumi.staging-11155111.yaml
+++ b/infra/distributor/Pulumi.staging-11155111.yaml
@@ -11,7 +11,7 @@ config:
   distributor:PROVER_KEYS:
     secure: v1:TXC+1jwcXbabnnAZ:uqcnV3p8CUoZcV51S5/966bHwi4Qxy5aKvcJ+w0qgvkT4Rz9D67PKUWw6tG6+pSg/1I6FIwOhlgT+j7GYcUHrRjU8F9X3JmPewSqw11Sg8Nz5XLNEo5nbrXGwXlHIHWfTkJ8/dcm4kSQzz4qyQWQjXpqLptnXlYuYtcpY+yJvqaXaS2MUStMtX0KQlaFu+GbsQ==
   distributor:ETH_THRESHOLD: "10"
-  distributor:STAKE_THRESHOLD: "5"
+  distributor:STAKE_THRESHOLD: "10"
   distributor:ETH_TOP_UP_AMOUNT: "20"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "30"

--- a/infra/distributor/Pulumi.staging-84532.yaml
+++ b/infra/distributor/Pulumi.staging-84532.yaml
@@ -16,7 +16,7 @@ config:
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging
   distributor:SLASHER_KEY:
     secure: v1:1jzQibAoUrHjn0Iy:ixX10gWEC1WNnq8FVhWfHuqHvOEBys9o63zjaU6OZ6Lr+ooO9sficX9Djf979h1ElPk5CC5sqyzgShtZhkdPLo1YGqufpcdRrzNbAUODIWw=
-  distributor:STAKE_THRESHOLD: "7"
+  distributor:STAKE_THRESHOLD: "10"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:ETH_RPC_URL:
     secure: v1:Gbts2MDIxPZqVLfr:YTMV0vht0vt6P0Sr50BqmvgUIlh/06F7ZqWbmgGRzz6VStrQEoNiEecYsgMaP765Ai9eAv7m9F6G5DGxju5zl+uTG99hRg1jqog+

--- a/infra/prover/components/bonsaiBroker.ts
+++ b/infra/prover/components/bonsaiBroker.ts
@@ -108,7 +108,7 @@ export class BonsaiECSBroker extends pulumi.ComponentResource {
     });
 
     // EFS
-    const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev4`, {
+    const fileSystem = new aws.efs.FileSystem(`${serviceName}-efs-rev5`, {
       encrypted: true,
       tags: {
         Name: serviceName,


### PR DESCRIPTION
Few fixes for staging:

* The bonsai brokers are both erroring a lot with DB locked. Since its been a while since we monitored the staging brokers so its unclear what errors have built up in the DB and its general state, and since we want to move off EFS anyway to solve this issue once and for all, I propose we wipe the DB as a quick fix to get things rolling.

* One of the brokers is erroring due to low stake. This is happening due to the threshold for topping it up being too low in the distributor.