### PR TITLE
BM-1357: Bump stake default

### DIFF
--- a/broker-template.toml
+++ b/broker-template.toml
@@ -43,7 +43,7 @@ lookback_blocks = 300 # 300 blocks ~ 1 hour @ 12s block times
 # Max stake amount, denominated in the Boundless staking token.
 #
 # Requests that require a higher stake than this will not be considered.
-max_stake = "5" # USDC
+max_stake = "25" # USDC
 # Max input / image file size allowed for downloading from request URLs.
 max_file_size = 50_000_000
 # Max retries for fetching input / image contents from URLs


### PR DESCRIPTION
Allows provers to evaluate signal proofs without being blocked by stake limits