### PR TITLE
BM-1358: Lower opt-level on dev profile to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,9 @@ url = "2.5"
 uuid = { version = "1.7", features = ["v4"] }
 utoipa = "5.2"
 
-# Always optimize; building and running the guest takes much longer without optimization.
+# Apply some optimizations on dev profile, to speed up tests.
 [profile.dev]
-opt-level = 3
+opt-level = 1
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
Our root `Cargo.toml` has `opt-level=3` for dev builds. This means that `cargo test` and `cargo build` will take longer by default, but also produce more optimized code. There is a comment on this setting which indicates this is potentially a hold-over from a much earlier version of risc0 where every host binary included the prover (which must be built with opt-level=3 for reasonable performance). Because we _don't_ do this anymore, and use prebuild `r0vm` binaries instead, using `opt-level=3` is likely not necessary. 

This PR is open to see if CI will run faster end-to-end with `opt-level=1`. I am choosing to try `opt-level=1` first instead the default for `dev` profile, because a little optimization _can_ make tests significantly faster in codebases with a lot of hashing, signature checking, etc.
