### PR TITLE
BM-1359: Adjust pricing for bonsai brokers on base

### DIFF
--- a/infra/prover/tomls/bonsai/broker-prod-8453.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-8453.toml
@@ -1,5 +1,5 @@
 [market]
-mcycle_price = "0.0000005"
+mcycle_price = "0.0000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
 peak_prove_khz = 2000
 min_deadline = 70

--- a/infra/prover/tomls/bonsai/broker-prod-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-84532.toml
@@ -1,5 +1,5 @@
 [market]
-mcycle_price = "0.0000005"
+mcycle_price = "0.00000005"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
 peak_prove_khz = 2000
 min_deadline = 70

--- a/infra/prover/tomls/bonsai/broker-prod-84532.toml
+++ b/infra/prover/tomls/bonsai/broker-prod-84532.toml
@@ -1,5 +1,5 @@
 [market]
-mcycle_price = "0.00000005"
+mcycle_price = "0.0000001"
 mcycle_price_stake_token = "0" # will fill any lock-expired orders regardless of cost
 peak_prove_khz = 2000
 min_deadline = 70


### PR DESCRIPTION
Seeing signal proofs get skipped due to them being underpriced on the Bonsai broker, so lowering our requirements

```

2025-07-18T00:37:51.490353Z DEBUG broker::order_picker: Order 0x147c76e56ad9316a5c1ab17cba87a1cc1345521830005cb52-0x5179f8a07d37abd72af330a09c97412ff0f7fbc8631fb13d63e1efb52fb54ff1-LockAndFulfill price: 0.000000000000000000-0.010000000000000000 ETH, 0.000000000000000000-0.000000199123834614 ETH per mcycle, 0.500000 stake required, 0.000001050054600000 ETH gas cost |  
-- | --

```
