### PR TITLE
BM-1363: Fix Ethereum Sepolia monitor success rate calculation

### DIFF
--- a/crates/ops-lambdas/indexer-monitor/src/monitor.rs
+++ b/crates/ops-lambdas/indexer-monitor/src/monitor.rs
@@ -267,8 +267,8 @@ impl Monitor {
             FROM request_fulfilled_events rfe
             JOIN proof_requests pr
               ON rfe.request_digest = pr.request_digest
-            WHERE pr.block_timestamp >= $1
-            AND pr.block_timestamp < $2
+            WHERE rfe.block_timestamp >= $1
+            AND rfe.block_timestamp < $2
             AND pr.client_address = $3
             "#,
         )

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -183,10 +183,10 @@ export const alarmConfig: ChainStageAlarms = {
       ],
       topLevel: {
         fulfilledRequests: [{
-          description: "less than 2 fulfilled orders in 30 minutes",
+          description: "less than 2 fulfilled orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 2,
@@ -197,10 +197,10 @@ export const alarmConfig: ChainStageAlarms = {
           }
         },
         {
-          description: "less than 1 fulfilled orders in 30 minutes",
+          description: "less than 1 fulfilled orders in 60 minutes",
           severity: Severity.SEV1,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 1,
@@ -360,10 +360,10 @@ export const alarmConfig: ChainStageAlarms = {
       ],
       topLevel: {
         fulfilledRequests: [{
-          description: "less than 2 fulfilled orders in 30 minutes",
+          description: "less than 2 fulfilled orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 2,
@@ -552,10 +552,10 @@ export const alarmConfig: ChainStageAlarms = {
       ],
       topLevel: {
         fulfilledRequests: [{
-          description: "less than 3 fulfilled orders in 30 minutes",
+          description: "less than 3 fulfilled orders in 60 minutes",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 3,
@@ -566,10 +566,10 @@ export const alarmConfig: ChainStageAlarms = {
           }
         },
         {
-          description: "less than 2 fulfilled orders in 30 minutes",
+          description: "less than 1 fulfilled orders in 60 minutes",
           severity: Severity.SEV1,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 2,


### PR DESCRIPTION
This adjusts the lambda to check the timestamp of the fulfillment rather than the timestamp of the submission so that it gets counted within the window of what is checked. This part was an autogenerated change, but seems correct from looking it over.

I also increased the alert window from 30 mins to 60 as on graceful stop, re-compilation, and then a lock and fulfill, that is very tight. Hopefully reduces false positives.