### PR TITLE
BM-1365: refactoring cycle limits

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -269,6 +269,17 @@ impl OrderRequest {
         order.proving_started_at = Some(Utc::now().timestamp().try_into().unwrap());
         order
     }
+
+    /// Returns the relevant expiration timestamp for this order based on its fulfillment type.
+    /// - For LockAndFulfill orders: returns lock expiration
+    /// - For FulfillAfterLockExpire/FulfillWithoutLocking orders: returns order expiration
+    pub fn expiry(&self) -> u64 {
+        match self.fulfillment_type {
+            FulfillmentType::LockAndFulfill => self.request.lock_expires_at(),
+            FulfillmentType::FulfillAfterLockExpire => self.request.expires_at(),
+            FulfillmentType::FulfillWithoutLocking => self.request.expires_at(),
+        }
+    }
 }
 
 impl std::fmt::Display for OrderRequest {

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -850,6 +850,12 @@ where
 
     /// Calculates the cycle limit for the preflight and also for the max cycles that this specific
     /// order variant will consider proving for.
+    ///
+    /// The reason for calculating both preflight and prove limits is to execute the order with
+    /// a large enough cycle limit for both lock and fulfill orders as well as for if the order
+    /// expires and to prove after lock expiry so that the execution can be cached and only happen
+    /// once. The prove limit is the limit for this specific order variant and decides the max
+    /// cycles the order can be for the prover to decide to commit to proving it.
     fn calculate_exec_limits(
         &self,
         order: &OrderRequest,

--- a/crates/broker/src/prioritization.rs
+++ b/crates/broker/src/prioritization.rs
@@ -136,6 +136,7 @@ mod tests {
     use crate::now_timestamp;
     use crate::order_monitor::tests::setup_om_test_context;
     use crate::order_picker::tests::{OrderParams, PickerTestCtxBuilder};
+    use crate::FulfillmentType;
     use tracing_test::traced_test;
 
     #[tokio::test]

--- a/crates/broker/src/prioritization.rs
+++ b/crates/broker/src/prioritization.rs
@@ -16,7 +16,7 @@ use crate::{
     config::{OrderCommitmentPriority, OrderPricingPriority},
     order_monitor::OrderMonitor,
     order_picker::OrderPicker,
-    FulfillmentType, OrderRequest,
+    OrderRequest,
 };
 
 use rand::seq::SliceRandom;
@@ -82,13 +82,7 @@ where
             // Already in observation time order, no sorting needed
         }
         UnifiedPriorityMode::ShortestExpiry => {
-            orders.sort_by_key(|order| {
-                let order_ref = order.as_ref();
-                match order_ref.fulfillment_type {
-                    FulfillmentType::LockAndFulfill => order_ref.request.lock_expires_at(),
-                    _ => order_ref.request.expires_at(),
-                }
-            });
+            orders.sort_by_key(|order| order.as_ref().expiry());
         }
     }
 }


### PR DESCRIPTION
These changes are to prevent redundant executions when the lock and fulfill session limit is less than the fulfill after lock one and the exec hits session limits. Also refactors the logic of the session limit calculation, to try to simplify with this added complexity of calculating both limits