### PR TITLE
BM-1376: bump bento image to 2.3.1

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ x-base-environment: &base-environment
   RUST_BACKTRACE: 1
 
 x-agent-common: &agent-common
-  image: risczero/risc0-bento-agent:2.3.0@sha256:5b029fb8074b3273b45e6e8fb4d6dbd86000a216688d8f1429eb893686cc1ff8
+  image: risczero/risc0-bento-agent:2.3.1@sha256:7873f18005efff03fc5399f1bdcb6760cda7ffbd4fdd4d9c39aedee8972e0a0d
   restart: always
   depends_on:
     - postgres
@@ -182,7 +182,7 @@ services:
       stack: 90000000
 
   rest_api:
-    image: risczero/risc0-bento-rest-api:2.3.0@sha256:caa6012548777a461b4e487d673bd0d23606f97cdecea9d1612fafd8fa8a9102
+    image: risczero/risc0-bento-rest-api:2.3.1@sha256:71dafe532d4e1ada47989b63cf04b2e2bae6b62eebb5d47973e875e2eddf6c3a
     restart: always
     depends_on:
       - postgres

--- a/crates/guest/util/identity/Cargo.lock
+++ b/crates/guest/util/identity/Cargo.lock
@@ -659,7 +659,6 @@ version = "0.1.0"
 dependencies = [
  "postcard",
  "risc0-zkvm",
- "risc0-zkvm-platform",
 ]
 
 [[package]]
@@ -1054,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910c2023c39ac1e23dd4f7acdff086333f31ca608035f96c74366a79c098de3b"
+checksum = "9684b333c1c5d83f29ce2a92314ccfafd9d8cdfa6c4e19c07b97015d2f1eb9d0"
 dependencies = [
  "anyhow",
  "borsh",

--- a/crates/guest/util/identity/Cargo.toml
+++ b/crates/guest/util/identity/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 
 [dependencies]
 postcard = "1.0"
-risc0-zkvm = { version = "2.3", default-features = false, features = ["std", "unstable", "disable-dev-mode"] }
-risc0-zkvm-platform = { version = "2.0", default-features = false, features = ["sys-getenv"] }
+risc0-zkvm = { version = "2.3.1", default-features = false, features = ["std", "unstable", "disable-dev-mode"] }
 
 [patch.crates-io]
 sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }


### PR DESCRIPTION
Looking at the diff https://github.com/risc0/risc0/compare/v2.3.0...v2.3.1 it seems not necessary to update our min version in our libraries to be this version. Feel free to share a reason why this might be necessary. (cc @capossele I know you suggested updating the cargo locked deps)