### PR TITLE
make bonsai zkvm version config optional

### DIFF
--- a/broker-template.toml
+++ b/broker-template.toml
@@ -125,8 +125,6 @@ stake_balance_error_threshold = "5"
 #groth16_verify_gas_estimate = 250000
 
 [prover]
-# Optional config, if using bonsai set the zkVM version here
-bonsai_r0_zkvm_ver = "2.1.0"
 # Number of retries to poll for proving status.
 #
 # Provides a little durability for transient failures.
@@ -197,3 +195,7 @@ withdraw = false
 #batch_max_fees = "0.1"
 # Number of attempts to make to submit a batch before abandoning
 #max_submission_attempts = 2
+
+# Optional config, only needed if using bonsai to set the zkVM version header. Not necessary when
+# using Bento as the prover.
+# bonsai_r0_zkvm_ver = "2.3.0"

--- a/crates/broker/src/provers/bonsai.rs
+++ b/crates/broker/src/provers/bonsai.rs
@@ -47,7 +47,7 @@ pub struct Bonsai {
 impl Bonsai {
     pub fn new(config: ConfigLock, api_url: &str, api_key: &str) -> Result<Self, ProverError> {
         let (
-            risc0_ver,
+            bonsai_r0_zkvm_ver,
             req_retry_count,
             req_retry_sleep_ms,
             status_poll_ms,
@@ -55,7 +55,7 @@ impl Bonsai {
         ) = {
             let config = config.lock_all().unwrap();
             (
-                config.prover.bonsai_r0_zkvm_ver.as_ref().ok_or(ConfigErr::InvalidConfig)?.clone(),
+                config.prover.bonsai_r0_zkvm_ver.clone(),
                 config.prover.req_retry_count,
                 config.prover.req_retry_sleep_ms,
                 config.prover.status_poll_ms,
@@ -64,6 +64,11 @@ impl Bonsai {
         };
 
         let prover_type = if api_key.is_empty() { ProverType::Bento } else { ProverType::Bonsai };
+
+        let risc0_ver = match prover_type {
+            ProverType::Bento => risc0_zkvm::VERSION.to_string(),
+            ProverType::Bonsai => bonsai_r0_zkvm_ver.ok_or(ConfigErr::InvalidConfig)?,
+        };
 
         Ok(Self {
             client: BonsaiClient::from_parts(api_url.into(), api_key.into(), &risc0_ver)?,

--- a/infra/prover/tomls/bento/broker-dev.toml
+++ b/infra/prover/tomls/bento/broker-dev.toml
@@ -17,7 +17,6 @@ stake_balance_error_threshold = "1"
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3

--- a/infra/prover/tomls/bento/broker-prod-11155111.toml
+++ b/infra/prover/tomls/bento/broker-prod-11155111.toml
@@ -18,7 +18,6 @@ priority_requestor_addresses = ["0x0466ACfc0F27bBA9fBB7A8508f576527e81E83Bd"]
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3

--- a/infra/prover/tomls/bento/broker-prod-8453.toml
+++ b/infra/prover/tomls/bento/broker-prod-8453.toml
@@ -21,7 +21,6 @@ deny_requestor_addresses = [
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3

--- a/infra/prover/tomls/bento/broker-prod-84532.toml
+++ b/infra/prover/tomls/bento/broker-prod-84532.toml
@@ -21,7 +21,6 @@ deny_requestor_addresses = [
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3

--- a/infra/prover/tomls/bento/broker-staging-11155111.toml
+++ b/infra/prover/tomls/bento/broker-staging-11155111.toml
@@ -18,7 +18,6 @@ priority_requestor_addresses = ["0x0466ACfc0F27bBA9fBB7A8508f576527e81E83Bd"]
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3

--- a/infra/prover/tomls/bento/broker-staging-84532.toml
+++ b/infra/prover/tomls/bento/broker-staging-84532.toml
@@ -21,7 +21,6 @@ deny_requestor_addresses = [
 # lockin_priority_gas = 100
 
 [prover]
-bonsai_r0_zkvm_ver = '2.3.0'
 status_poll_retry_count = 3
 status_poll_ms = 1000
 req_retry_count = 3


### PR DESCRIPTION
Also moves the config in template to the bottom to make less visible as this is confusing. Removes the config from bento brokers in our infra also