### PR TITLE
Reduce burn percentage to 20%

### DIFF
--- a/contracts/src/BoundlessMarket.sol
+++ b/contracts/src/BoundlessMarket.sol
@@ -83,7 +83,7 @@ contract BoundlessMarket is
     /// the order, or to the market treasury. This fraction controls that ratio.
     /// @dev The fee is configured as a constant to avoid accessing storage and thus paying for the
     /// gas of an SLOAD. Can only be changed via contract upgrade.
-    uint256 public constant SLASHING_BURN_BPS = 7500;
+    uint256 public constant SLASHING_BURN_BPS = 2000;
 
     /// @notice When an order is fulfilled, the market takes a fee based on the price of the order.
     /// This fraction is multiplied by the price to decide the fee.

--- a/contracts/test/BoundlessMarket.t.sol
+++ b/contracts/test/BoundlessMarket.t.sol
@@ -103,7 +103,7 @@ contract BoundlessMarketTest is Test {
 
     uint256 constant DEFAULT_BALANCE = 1000 ether;
     uint256 constant EXPECTED_DEFAULT_MAX_GAS_FOR_VERIFY = 50000;
-    uint256 constant EXPECTED_SLASH_BURN_BPS = 7500;
+    uint256 constant EXPECTED_SLASH_BURN_BPS = 2000;
 
     ReceiptClaim internal APP_CLAIM = ReceiptClaimLib.ok(APP_IMAGE_ID, sha256(APP_JOURNAL));
 
@@ -574,15 +574,16 @@ contract BoundlessMarketBasicTest is BoundlessMarketTest {
         // Attempt to withdraw funds from the stake treasury from an unauthorized account.
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, testProverAddress));
         vm.prank(testProverAddress);
-        boundlessMarket.withdrawFromStakeTreasury(0.25 ether);
+        uint256 expectedWithdrawal = 1 ether - (1 ether * EXPECTED_SLASH_BURN_BPS / 10000);
+        boundlessMarket.withdrawFromStakeTreasury(expectedWithdrawal);
 
         // Withdraw funds from the stake treasury
         vm.expectEmit(true, true, true, true);
-        emit IBoundlessMarket.StakeWithdrawal(address(boundlessMarket), 0.25 ether);
+        emit IBoundlessMarket.StakeWithdrawal(address(boundlessMarket), expectedWithdrawal);
         vm.prank(OWNER_WALLET.addr);
-        boundlessMarket.withdrawFromStakeTreasury(0.25 ether);
+        boundlessMarket.withdrawFromStakeTreasury(expectedWithdrawal);
         assert(boundlessMarket.balanceOfStake(address(boundlessMarket)) == 0);
-        assert(stakeToken.balanceOf(OWNER_WALLET.addr) == 0.25 ether);
+        assert(stakeToken.balanceOf(OWNER_WALLET.addr) == expectedWithdrawal);
     }
 
     function testWithdrawals() public {


### PR DESCRIPTION
Currently 75% of stake gets burned, which feels excessive, especially as the stake token is USDC. Lowering the burn percentage will provide more incentive for secondary fulfillment, while still providing protection against various DOS attacks.

There will need to be a second PR that we release after upgrade that updates the broker to be aware of the new lower burn amount.