### PR TITLE
fix(broker): Implement timeout for Bonsai proof jobs

### DIFF
--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -77,6 +77,10 @@ mod defaults {
     pub const fn max_concurrent_preflights() -> u32 {
         4
     }
+
+    pub const fn proof_job_timeout_secs() -> u64 {
+        3600
+    }
 }
 
 /// Order pricing priority mode for determining which orders to price first
@@ -342,6 +346,13 @@ pub struct ProverConf {
     /// If not set, it defaults to 30 seconds.
     #[serde(default = "defaults::reaper_grace_period_secs")]
     pub reaper_grace_period_secs: u32,
+    /// Timeout for proof jobs to complete (in seconds)
+    ///
+    /// If a proof job is stuck in "RUNNING" state longer than this timeout,
+    /// the polling will stop and return a timeout error instead of waiting indefinitely.
+    /// If not set, it defaults to 3600 seconds (1 hour).
+    #[serde(default = "defaults::proof_job_timeout_secs")]
+    pub proof_job_timeout_secs: u64,
 }
 
 impl Default for ProverConf {
@@ -359,6 +370,7 @@ impl Default for ProverConf {
             max_critical_task_retries: None,
             reaper_interval_secs: defaults::reaper_interval_secs(),
             reaper_grace_period_secs: defaults::reaper_grace_period_secs(),
+            proof_job_timeout_secs: defaults::proof_job_timeout_secs(),
         }
     }
 }


### PR DESCRIPTION
Fixes #585 

This pull request addresses the issue where the broker's Bonsai prover can get stuck in an infinite polling loop if a proof job's status remains as `RUNNING` indefinitely. This prevents the prover from picking up new work and can halt the system.
This PR introduces a configurable timeout for these polling operations to ensure the broker can recover from stuck jobs and continue processing the queue.

**Implementation Details**
The solution is implemented in two main parts:
1. **Configuration**:
A new field, `proof_job_timeout_secs`, has been added to the `ProverConf` struct in `crates/broker/src/config.rs`.
It defaults to 3600 seconds (1 hour) but can be overridden in the broker's configuration file.
2. Timeout Logic:
- The infinite loop constructs in `crates/broker/src/provers/bonsai.rs` have been wrapped in a `tokio::time::timeout`.
- If the polling operation exceeds the configured timeout, it will exit gracefully and return a `ProverError::ProvingFailed` error, clearly indicating that the job timed out.
- This has been applied to all three critical polling functions - `Bonsai::compress`, `StatusPoller::poll_with_retries_session_id` and `StatusPoller::poll_with_retries_snark_id`