### PR TITLE
BM-1410: log job ID on proving failed log

### DIFF
--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -341,8 +341,9 @@ impl ProvingService {
             }
             Err(err) => {
                 tracing::error!(
-                    "Order {} failed to prove after {} retries: {err:?}",
+                    "Order {} with job id {} failed to prove after {} retries: {err:?}",
                     order_id,
+                    order.proof_id.as_deref().unwrap_or("<invalid>"),
                     proof_retry_count
                 );
 


### PR DESCRIPTION
Given the proving failed, would have been helpful to log the bento/bonsai job ID to make debugging purposes easier