### PR TITLE
Reuse the old expired nonce when retrying Causing the proof to be unable to be submitted.

### DIFF
--- a/crates/boundless-market/src/nonce_layer.rs
+++ b/crates/boundless-market/src/nonce_layer.rs
@@ -88,12 +88,29 @@ where
         let semaphore = self.get_account_semaphore(from_address).await;
         let _permit = semaphore.acquire().await.unwrap();
 
-        // Fetch the pending nonce if not already set
-        if request.nonce.is_none() {
-            let pending_nonce = self.inner.get_transaction_count(from_address).pending().await?;
+        // Always fetch the latest pending nonce to avoid nonce conflicts
+        let pending_nonce = self.inner.get_transaction_count(from_address).pending().await?;
+        
+        // If request already has a nonce, check if it's still valid
+        if let Some(existing_nonce) = request.nonce {
+            if existing_nonce < pending_nonce {
+                tracing::warn!(
+                    "NonceProvider::send_with_nonce_management - stale nonce detected: {} < {}, updating to latest",
+                    existing_nonce,
+                    pending_nonce
+                );
+                request.nonce = Some(pending_nonce);
+            } else {
+                tracing::trace!(
+                    "NonceProvider::send_with_nonce_management - using existing nonce {} for address: {}",
+                    existing_nonce,
+                    from_address
+                );
+            }
+        } else {
             request.nonce = Some(pending_nonce);
             tracing::trace!(
-                "NonceProvider::send_with_nonce_management - set nonce {} for address: {}",
+                "NonceProvider::send_with_nonce_management - set fresh nonce {} for address: {}",
                 pending_nonce,
                 from_address
             );

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -539,11 +539,28 @@ where
                     return Ok(());
                 }
                 Err(err) => {
-                    tracing::warn!(
-                        "Batch submission attempt {}/{} failed. Error: {err:?}",
-                        attempt + 1,
-                        max_batch_submission_attempts,
-                    );
+                    // Check if this is a nonce-related error
+                    let error_msg = err.to_string().to_lowercase();
+                    let is_nonce_error = error_msg.contains("nonce too low") 
+                        || error_msg.contains("nonce already used")
+                        || error_msg.contains("nonce gap");
+                    
+                    if is_nonce_error {
+                        tracing::warn!(
+                            "Batch submission attempt {}/{} failed with nonce error: {err:?}. Will retry with fresh nonce.",
+                            attempt + 1,
+                            max_batch_submission_attempts,
+                        );
+                        
+                        // Add a small delay to allow the nonce to settle
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    } else {
+                        tracing::warn!(
+                            "Batch submission attempt {}/{} failed. Error: {err:?}",
+                            attempt + 1,
+                            max_batch_submission_attempts,
+                        );
+                    }
                     errors.push(err);
                 }
             }


### PR DESCRIPTION
  broker-1            | 2025-07-29T01:06:19.510185Z ERROR broker::order_monitor: Failed to lock order: 
  0xc2db89b2bd434ceac6c74fbc0b2ad3a280e66db0df3a8aca-0x847df2e46d5bf4998759c9c51bbc0ca24e5957948f5eeb3b83a171c160151943-LockAndFulfill 
  - [B-OM-500] - decoding err, missing data, code: -32000 msg: nonce too low: next nonce 11841, tx nonce 11840 


Ensure that the correct nonce is used for each retry.