### PR TITLE
memoize the order id generation

### DIFF
--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -794,6 +794,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -841,6 +842,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -956,6 +958,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -1018,6 +1021,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -1129,6 +1133,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -1243,6 +1248,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 
@@ -1365,6 +1371,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
 
         // add first order and aggregate
@@ -1404,6 +1411,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
 
         db.add_order(&order2).await.unwrap();
@@ -1476,6 +1484,7 @@ mod tests {
             chain_id: 1,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&expired_order).await.unwrap();
 
@@ -1517,6 +1526,7 @@ mod tests {
             chain_id: 1,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&valid_order).await.unwrap();
 

--- a/crates/broker/src/db/fuzz_db.rs
+++ b/crates/broker/src/db/fuzz_db.rs
@@ -119,6 +119,7 @@ fn generate_test_order(request_id: u32) -> Order {
         chain_id: 1,
         total_cycles: None,
         proving_started_at: None,
+        cached_id: Default::default(),
     }
 }
 

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{path::PathBuf, sync::Arc, time::SystemTime};
+use std::{path::PathBuf, sync::{Arc, OnceLock}, time::SystemTime};
 
 use crate::storage::create_uri_handler;
 use alloy::{
@@ -204,6 +204,8 @@ struct OrderRequest {
     total_cycles: Option<u64>,
     target_timestamp: Option<u64>,
     expire_timestamp: Option<u64>,
+    #[serde(skip)]
+    cached_id: OnceLock<String>,
 }
 
 impl OrderRequest {
@@ -225,6 +227,7 @@ impl OrderRequest {
             total_cycles: None,
             target_timestamp: None,
             expire_timestamp: None,
+            cached_id: OnceLock::new(),
         }
     }
 
@@ -232,9 +235,11 @@ impl OrderRequest {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        let signing_hash =
-            self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-        format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        self.cached_id.get_or_init(|| {
+            let signing_hash =
+                self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
+            format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        }).clone()
     }
 
     fn to_order(&self, status: OrderStatus) -> Order {
@@ -256,6 +261,7 @@ impl OrderRequest {
             compressed_proof_id: None,
             lock_price: None,
             error_msg: None,
+            cached_id: OnceLock::new(),
         }
     }
 
@@ -354,6 +360,8 @@ struct Order {
     lock_price: Option<U256>,
     /// Failure message
     error_msg: Option<String>,
+    #[serde(skip)]
+    cached_id: OnceLock<String>,
 }
 
 impl Order {
@@ -361,9 +369,11 @@ impl Order {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        let signing_hash =
-            self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-        format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        self.cached_id.get_or_init(|| {
+            let signing_hash =
+                self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
+            format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+        }).clone()
     }
 
     pub fn is_groth16(&self) -> bool {

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{path::PathBuf, sync::{Arc, OnceLock}, time::SystemTime};
+use std::{
+    path::PathBuf,
+    sync::{Arc, OnceLock},
+    time::SystemTime,
+};
 
 use crate::storage::create_uri_handler;
 use alloy::{
@@ -235,11 +239,15 @@ impl OrderRequest {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        self.cached_id.get_or_init(|| {
-            let signing_hash =
-                self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-            format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
-        }).clone()
+        self.cached_id
+            .get_or_init(|| {
+                let signing_hash = self
+                    .request
+                    .signing_hash(self.boundless_market_address, self.chain_id)
+                    .unwrap();
+                format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+            })
+            .clone()
     }
 
     fn to_order(&self, status: OrderStatus) -> Order {
@@ -369,11 +377,15 @@ impl Order {
     // This structure supports multiple different ProofRequests with the same request_id, and different
     // fulfillment types.
     pub fn id(&self) -> String {
-        self.cached_id.get_or_init(|| {
-            let signing_hash =
-                self.request.signing_hash(self.boundless_market_address, self.chain_id).unwrap();
-            format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
-        }).clone()
+        self.cached_id
+            .get_or_init(|| {
+                let signing_hash = self
+                    .request
+                    .signing_hash(self.boundless_market_address, self.chain_id)
+                    .unwrap();
+                format_order_id(&self.request.id, &signing_hash, &self.fulfillment_type)
+            })
+            .clone()
     }
 
     pub fn is_groth16(&self) -> bool {

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -1065,6 +1065,7 @@ pub(crate) mod tests {
                 boundless_market_address: self.market_address,
                 chain_id: self.anvil.chain_id(),
                 total_cycles: None,
+                cached_id: Default::default(),
             })
         }
     }

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -1437,6 +1437,7 @@ pub(crate) mod tests {
                 boundless_market_address: *boundless_market_address,
                 chain_id,
                 total_cycles: None,
+                cached_id: Default::default(),
             })
         }
 
@@ -1488,6 +1489,7 @@ pub(crate) mod tests {
                 boundless_market_address: *boundless_market_address,
                 chain_id,
                 total_cycles: None,
+                cached_id: Default::default(),
             })
         }
     }
@@ -2419,6 +2421,7 @@ pub(crate) mod tests {
             total_cycles: order1.total_cycles,
             target_timestamp: order1.target_timestamp,
             expire_timestamp: order1.expire_timestamp,
+            cached_id: Default::default(),
         });
 
         assert_eq!(order1.id(), order2.id(), "Both orders should have the same ID");
@@ -2489,12 +2492,9 @@ pub(crate) mod tests {
         ctx.new_order_tx.send(order1).await.unwrap();
 
         // Wait for the order to be processed and check for the "Added" log
-        tokio::time::timeout(
-            MIN_CAPACITY_CHECK_INTERVAL + Duration::from_secs(1),
-            ctx.priced_orders_rx.recv(),
-        )
-        .await
-        .unwrap();
+        tokio::time::timeout(MIN_CAPACITY_CHECK_INTERVAL * 2, ctx.priced_orders_rx.recv())
+            .await
+            .unwrap();
 
         // Check that we logged the task being added
         assert!(logs_contain("Current pricing tasks: ["));

--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -511,6 +511,7 @@ mod tests {
             chain_id: 1,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         }
     }
 
@@ -664,6 +665,7 @@ mod tests {
             chain_id: 1,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         db.add_order(&order).await.unwrap();
 

--- a/crates/broker/src/reaper.rs
+++ b/crates/broker/src/reaper.rs
@@ -194,6 +194,7 @@ mod tests {
             chain_id: 1,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         }
     }
 

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -818,6 +818,7 @@ mod tests {
             chain_id,
             total_cycles: None,
             proving_started_at: None,
+            cached_id: Default::default(),
         };
         let order_id = order.id();
         db.add_order(&order).await.unwrap();


### PR DESCRIPTION
To avoid redundant hashing on id calls. Keeping the API the same for simplicity.