### PR TITLE
Update README.md

### DIFF
--- a/contracts/scripts/README.md
+++ b/contracts/scripts/README.md
@@ -29,7 +29,7 @@ Configurations and deployment state information is stored in `deployment.toml`.
 It contains information about each chain (e.g. name, ID, Etherscan URL), and addresses for the RISC Zero verifier and Boundless market contracts on each chain.
 
 Accompanying the `deployment.toml` file is a `deployment_secrets.toml` file with the following schema.
-It is used to store somewhat sensative API keys for RPC services and Etherscan.
+It is used to store somewhat sensitive API keys for RPC services and Etherscan.
 Note that it does not contain private keys or API keys for Fireblocks.
 It should never be committed to `git`, and the API keys should be rotated if this occurs.
 
@@ -128,7 +128,7 @@ The Boundless market is deployed and upgraded using the **UUPS (Universal Upgrad
 ### Deploy the HitPoints contract
 
 > [!NOTE]
-> This contract should only be deployed if necessary as, on most cases, should be reused.
+> This contract should only be deployed if necessary as, in most cases, should be reused.
 
 1. Dry run deployment of the HitPoints contract:
 


### PR DESCRIPTION
Hello,

I see two typos here and request correction.

First one: In the sentence "It is used to store somewhat sensative API keys for RPC services and Etherscan" the word "sensative" is misspelled. It should be "sensitive", and

Second one: In the note "This contract should only be deployed if necessary as, on most cases, should be reused" the preposition "on" is used incorrectly. It should be "in".

Thx