### PR TITLE
BM-1449: Move accumulated stake from provers back to distributor. Adjust distributor thresholds for base mainnet

### DIFF
--- a/infra/distributor/Pulumi.prod-11155111.yaml
+++ b/infra/distributor/Pulumi.prod-11155111.yaml
@@ -16,6 +16,7 @@ config:
   distributor:PROVER_KEYS:
     secure: v1:lvgOiMaVFr26rn0G:bd0coCCoXqQdLjliw3WqyEKxxKhHoJjNAIspAqx7ja3gw2LwILzvXZTI/sZa2JYmukkUPkBpwHDoHhdQehZT8x8gRh6cnbe6ZFvLMf2gh9S2Hx9uL9/t60oVCkE0NQOb1j2IAi6CQuJfuylvwhCRRvl93sfwCPgk9nDYZ1fnnpXo+zmaaq5DwBgkDUJMywu7tA==
   distributor:SCHEDULE_MINUTES: "360"
+  distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:SLASHER_KEY:
     secure: v1:vsk259VkW141RyaB:C7r1PNqhYOijA3pWLcOAJsX4W955zPyXGWeA3xLwYFdFw/lbmlqc5Z5OE5Lebc4wluMtFD415gm5kd2bYZiaaUb5sZsOz56HZTphvHuvO1o=

--- a/infra/distributor/Pulumi.prod-8453.yaml
+++ b/infra/distributor/Pulumi.prod-8453.yaml
@@ -6,7 +6,7 @@ config:
   distributor:DISTRIBUTOR_PRIVATE_KEY:
     secure: v1:wsMaM6eH71PkGoGO:gnW40haQnOPc/SUZaxWYyvQY4tJNe7qjkn7rgbszPuaPczv607usL0t6mXGNtCCTF2uGUaYp6q8TobbS48GS5du7EL3FVm2l3uGGOxSemok=
   distributor:ETH_THRESHOLD: "0.02"
-  distributor:ETH_TOP_UP_AMOUNT: "0.02"
+  distributor:ETH_TOP_UP_AMOUNT: "0.04"
   distributor:GH_TOKEN_SECRET:
     secure: v1:sFcUNPOUWZ1ghOjf:Y3a6CP7X6bTABqL+OxMTKA7yzNFptTWH2+ADn188fYxHTccf0qeaIF8VRfCvJ2iVnMxfoAFsMpW72mf+Gzv3seAzwLHZhbwciJ4WrFKD3bHKydiDAQepnRbogHwcMfGWi7hSkSu72ihW3sm/hQ==
   distributor:ORDER_GENERATOR_KEYS:
@@ -16,11 +16,12 @@ config:
   distributor:PROVER_KEYS:
     secure: v1:EY44pcRVdz2JuCTu:zCzN/MYur9seJdgg5lHbUQ7KoBWjAwEOmVSTNTTo1eqjVwdnREY7CvniVRO9PqEJJweMlxo1Gw8GcaZ2JPUcqGiU4ha7FVXrKDGfhNrIWcAO6IRJ2WAneHwKGBQRIjSMvuYsKXJhPQXzvTjklbKKeAMvGuaDKGM28uUEXSDHzmEYmWz4CEYWs8GHGrx+kje/wQ==
   distributor:SCHEDULE_MINUTES: "360"
+  distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:SLASHER_KEY:
     secure: v1:5h1orYNX17m3Vp3b:R1yCFR4Yks5rPn7nMs180Y7LOHPcksMwlSPBwsZz2sfUrlmpTfWXxlpv5nIewPuy89aAAS2pJQtoybTC+yGCQG50GN4xAaMw9pMPjkIGMys=
-  distributor:STAKE_THRESHOLD: "7"
-  distributor:STAKE_TOP_UP_AMOUNT: "7"
+  distributor:STAKE_THRESHOLD: "25"
+  distributor:STAKE_TOP_UP_AMOUNT: "35"
   distributor:ETH_RPC_URL:
     secure: v1:Ft8qHrOPQTypWl6L:7O1I0MEZmsPG/ptdueEjY1+NyaQf5SWILbDy2B6KWJqN5rmuM1l5FLy9KpsMnwjGinbCMWxEC97eawyILp6LluqF3yYeEzxBKD4e
   distributor:LOG_LEVEL: "info"

--- a/infra/distributor/Pulumi.prod-84532.yaml
+++ b/infra/distributor/Pulumi.prod-84532.yaml
@@ -16,6 +16,7 @@ config:
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "10"
   distributor:SCHEDULE_MINUTES: "360"
+  distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   distributor:CHAIN_ID: "84532"

--- a/infra/distributor/Pulumi.staging-11155111.yaml
+++ b/infra/distributor/Pulumi.staging-11155111.yaml
@@ -15,6 +15,7 @@ config:
   distributor:ETH_TOP_UP_AMOUNT: "20"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "30"
+  distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SCHEDULE_MINUTES: "360"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging
   distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic

--- a/infra/distributor/Pulumi.staging-84532.yaml
+++ b/infra/distributor/Pulumi.staging-84532.yaml
@@ -18,6 +18,7 @@ config:
     secure: v1:1jzQibAoUrHjn0Iy:ixX10gWEC1WNnq8FVhWfHuqHvOEBys9o63zjaU6OZ6Lr+ooO9sficX9Djf979h1ElPk5CC5sqyzgShtZhkdPLo1YGqufpcdRrzNbAUODIWw=
   distributor:STAKE_THRESHOLD: "10"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
+  distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:ETH_RPC_URL:
     secure: v1:Gbts2MDIxPZqVLfr:YTMV0vht0vt6P0Sr50BqmvgUIlh/06F7ZqWbmgGRzz6VStrQEoNiEecYsgMaP765Ai9eAv7m9F6G5DGxju5zl+uTG99hRg1jqog+
   distributor:GH_TOKEN_SECRET:

--- a/infra/distributor/index.ts
+++ b/infra/distributor/index.ts
@@ -24,6 +24,7 @@ export = () => {
   const ethTopUpAmount = isDev ? getEnvVar("ETH_TOP_UP_AMOUNT") : config.require('ETH_TOP_UP_AMOUNT');
   const stakeTopUpAmount = isDev ? getEnvVar("STAKE_TOP_UP_AMOUNT") : config.require('STAKE_TOP_UP_AMOUNT');
   const proverEthDonateThreshold = isDev ? getEnvVar("PROVER_ETH_DONATE_THRESHOLD") : config.require('PROVER_ETH_DONATE_THRESHOLD');
+  const proverStakeDonateThreshold = isDev ? getEnvVar("PROVER_STAKE_DONATE_THRESHOLD") : config.require('PROVER_STAKE_DONATE_THRESHOLD');
 
   const scheduleMinutes = config.require('SCHEDULE_MINUTES');
 
@@ -201,6 +202,7 @@ export = () => {
     ethTopUpAmount ? `--eth-top-up-amount ${ethTopUpAmount}` : '',
     stakeTopUpAmount ? `--stake-top-up-amount ${stakeTopUpAmount}` : '',
     proverEthDonateThreshold ? `--prover-eth-donate-threshold ${proverEthDonateThreshold}` : '',
+    proverStakeDonateThreshold ? `--prover-stake-donate-threshold ${proverStakeDonateThreshold}` : '',
   ]
 
   if (boundlessMarketAddr && setVerifierAddr) {


### PR DESCRIPTION
The provers have accumulated a lot of stake, presumably by winning secondary auctions. Adding logic to distributor to withdraw that value so it can be redistributed.

Also fixing the thresholds on Base Mainnet. Currently when ETH balance drops below 0.02, they are only topped back up to 0.02, creating top-ups on every distributor run.

We also let prover stake balance drop to the point where they can't participate in big orders like Signal, so setting a higher threshold and top up value for stake, in case we need to start participating again.