### PR TITLE
BM-1465: change anyhow error logs to be one-line

### DIFF
--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -47,13 +47,13 @@ const BLOCK_TIME_SAMPLE_SIZE: u64 = 10;
 
 #[derive(Error)]
 pub enum MarketMonitorErr {
-    #[error("{code} Event polling failed: {0:?}", code = self.code())]
+    #[error("{code} Event polling failed: {0:#}", code = self.code())]
     EventPollingErr(anyhow::Error),
 
-    #[error("{code} Log processing failed: {0:?}", code = self.code())]
+    #[error("{code} Log processing failed: {0:#}", code = self.code())]
     LogProcessingFailed(anyhow::Error),
 
-    #[error("{code} Unexpected error: {0:?}", code = self.code())]
+    #[error("{code} Unexpected error: {0:#}", code = self.code())]
     UnexpectedErr(#[from] anyhow::Error),
 
     #[error("{code} Receiver dropped", code = self.code())]

--- a/crates/broker/src/offchain_market_monitor.rs
+++ b/crates/broker/src/offchain_market_monitor.rs
@@ -28,13 +28,13 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Error)]
 pub enum OffchainMarketMonitorErr {
-    #[error("WebSocket error: {0:?}")]
+    #[error("WebSocket error: {0:#}")]
     WebSocketErr(anyhow::Error),
 
     #[error("{code} Receiver dropped", code = self.code())]
     ReceiverDropped,
 
-    #[error("{code} Unexpected error: {0:?}", code = self.code())]
+    #[error("{code} Unexpected error: {0:#}", code = self.code())]
     UnexpectedErr(#[from] anyhow::Error),
 }
 

--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -32,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Error)]
 pub enum ProvingErr {
-    #[error("{code} Proving failed after retries: {0:?}", code = self.code())]
+    #[error("{code} Proving failed after retries: {0:#}", code = self.code())]
     ProvingFailed(anyhow::Error),
 
     #[error("{code} Request fulfilled by another prover", code = self.code())]
@@ -41,7 +41,7 @@ pub enum ProvingErr {
     #[error("{code} Proving timed out", code = self.code())]
     ProvingTimedOut,
 
-    #[error("{code} Unexpected error: {0:?}", code = self.code())]
+    #[error("{code} Unexpected error: {0:#}", code = self.code())]
     UnexpectedError(#[from] anyhow::Error),
 }
 

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -72,7 +72,7 @@ pub enum SubmitterErr {
     #[error("{code} Market error: {0}", code = self.code())]
     MarketError(#[from] MarketError),
 
-    #[error("{code} Unexpected error: {0:?}", code = self.code())]
+    #[error("{code} Unexpected error: {0:#}", code = self.code())]
     UnexpectedErr(#[from] anyhow::Error),
 }
 


### PR DESCRIPTION
Compacts the error log to be one-line so that it is easier to debug when grepping for the order/error

Docs on formats: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations