### PR TITLE
Make distributor continue on transient errors

### DIFF
--- a/crates/distributor/src/main.rs
+++ b/crates/distributor/src/main.rs
@@ -180,10 +180,28 @@ async fn run(args: &MainArgs) -> Result<()> {
                 .with_to(distributor_address)
                 .with_value(transfer_amount);
 
-            let pending_tx = prover_provider.send_transaction(tx).await?;
+            let pending_tx = match prover_provider.send_transaction(tx).await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to send ETH transfer transaction from prover {} to distributor: {:?}. Skipping.",
+                        prover_address, e
+                    );
+                    continue;
+                }
+            };
 
             // Wait for the transaction to be confirmed
-            let receipt = pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await?;
+            let receipt = match pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await {
+                Ok(receipt) => receipt,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to watch ETH transfer transaction from prover {} to distributor: {:?}. Skipping.",
+                        prover_address, e
+                    );
+                    continue;
+                }
+            };
 
             tracing::info!(
                 "Transfer completed: {:x} from prover {} for {} ETH to distributor",
@@ -223,7 +241,13 @@ async fn run(args: &MainArgs) -> Result<()> {
                 .await?;
 
             // Withdraw stake from market to prover
-            prover_client.boundless_market.withdraw_stake(withdraw_amount).await?;
+            if let Err(e) = prover_client.boundless_market.withdraw_stake(withdraw_amount).await {
+                tracing::error!(
+                    "Failed to withdraw stake from boundless market for prover {}: {:?}. Skipping.",
+                    prover_address, e
+                );
+                continue;
+            }
 
             tracing::info!(
                 "Withdrawn {} stake from market for prover {}. Now transferring to distributor",
@@ -235,10 +259,24 @@ async fn run(args: &MainArgs) -> Result<()> {
             let stake_token = distributor_client.boundless_market.stake_token_address().await?;
             let stake_token_contract = IERC20::new(stake_token, prover_provider.clone());
 
-            let pending_tx =
-                stake_token_contract.transfer(distributor_address, withdraw_amount).send().await?;
+            let pending_tx = match stake_token_contract.transfer(distributor_address, withdraw_amount).send().await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to send stake transfer transaction from prover {} to distributor: {:?}. Skipping.",
+                        prover_address, e
+                    );
+                    continue;
+                }
+            };
 
-            pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await?;
+            if let Err(e) = pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await {
+                tracing::error!(
+                    "Failed to watch stake transfer transaction from prover {} to distributor: {:?}. Skipping.",
+                    prover_address, e
+                );
+                continue;
+            }
 
             tracing::info!(
                 "Stake transfer completed from prover {} for {} stake to distributor",
@@ -291,10 +329,27 @@ async fn run(args: &MainArgs) -> Result<()> {
                 format_units(prover_stake_balance_market, stake_token_decimals)?,
                 format_units(prover_stake_balance_contract, stake_token_decimals)?
             );
-            let pending_tx =
-                stake_token_contract.transfer(prover_address, transfer_amount).send().await?;
+            let pending_tx = match stake_token_contract.transfer(prover_address, transfer_amount).send().await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to send stake transfer transaction from distributor to prover {}: {:?}. Skipping.",
+                        prover_address, e
+                    );
+                    continue;
+                }
+            };
 
-            let receipt = pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await?;
+            let receipt = match pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await {
+                Ok(receipt) => receipt,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to watch stake transfer transaction from distributor to prover {}: {:?}. Skipping.",
+                        prover_address, e
+                    );
+                    continue;
+                }
+            };
 
             tracing::info!("Stake transfer completed: {:x} from distributor to prover {}. About to deposit stake", receipt, prover_address);
 
@@ -309,10 +364,16 @@ async fn run(args: &MainArgs) -> Result<()> {
             prover_stake_balance_contract =
                 stake_token_contract.balanceOf(prover_address).call().await?;
 
-            prover_client
+            if let Err(e) = prover_client
                 .boundless_market
                 .deposit_stake_with_permit(prover_stake_balance_contract, prover_key)
-                .await?;
+                .await {
+                tracing::error!(
+                    "Failed to deposit stake to boundless market for prover {}: {:?}. Skipping.",
+                    prover_address, e
+                );
+                continue;
+            }
             tracing::info!("Stake deposit completed for prover {}", prover_address);
         }
     }
@@ -360,9 +421,27 @@ async fn run(args: &MainArgs) -> Result<()> {
                 .with_to(address)
                 .with_value(transfer_amount);
 
-            let pending_tx = distributor_client.provider().send_transaction(tx).await?;
+            let pending_tx = match distributor_client.provider().send_transaction(tx).await {
+                Ok(tx) => tx,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to send ETH transfer transaction from distributor to {}: {:?}. Skipping.",
+                        address, e
+                    );
+                    continue;
+                }
+            };
 
-            let receipt = pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await?;
+            let receipt = match pending_tx.with_timeout(Some(TX_TIMEOUT)).watch().await {
+                Ok(receipt) => receipt,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to watch ETH transfer transaction from distributor to {}: {:?}. Skipping.",
+                        address, e
+                    );
+                    continue;
+                }
+            };
 
             tracing::info!(
                 "ETH transfer completed: {:x}. {} ETH from distributor to {}",

--- a/infra/distributor/Pulumi.prod-11155111.yaml
+++ b/infra/distributor/Pulumi.prod-11155111.yaml
@@ -15,7 +15,7 @@ config:
   distributor:PROVER_ETH_DONATE_THRESHOLD: "10"
   distributor:PROVER_KEYS:
     secure: v1:lvgOiMaVFr26rn0G:bd0coCCoXqQdLjliw3WqyEKxxKhHoJjNAIspAqx7ja3gw2LwILzvXZTI/sZa2JYmukkUPkBpwHDoHhdQehZT8x8gRh6cnbe6ZFvLMf2gh9S2Hx9uL9/t60oVCkE0NQOb1j2IAi6CQuJfuylvwhCRRvl93sfwCPgk9nDYZ1fnnpXo+zmaaq5DwBgkDUJMywu7tA==
-  distributor:SCHEDULE_MINUTES: "360"
+  distributor:SCHEDULE_MINUTES: "240"
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:SLASHER_KEY:

--- a/infra/distributor/Pulumi.prod-8453.yaml
+++ b/infra/distributor/Pulumi.prod-8453.yaml
@@ -15,7 +15,7 @@ config:
   distributor:PROVER_ETH_DONATE_THRESHOLD: "0.02"
   distributor:PROVER_KEYS:
     secure: v1:EY44pcRVdz2JuCTu:zCzN/MYur9seJdgg5lHbUQ7KoBWjAwEOmVSTNTTo1eqjVwdnREY7CvniVRO9PqEJJweMlxo1Gw8GcaZ2JPUcqGiU4ha7FVXrKDGfhNrIWcAO6IRJ2WAneHwKGBQRIjSMvuYsKXJhPQXzvTjklbKKeAMvGuaDKGM28uUEXSDHzmEYmWz4CEYWs8GHGrx+kje/wQ==
-  distributor:SCHEDULE_MINUTES: "360"
+  distributor:SCHEDULE_MINUTES: "240"
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:SLASHER_KEY:

--- a/infra/distributor/Pulumi.prod-84532.yaml
+++ b/infra/distributor/Pulumi.prod-84532.yaml
@@ -15,7 +15,7 @@ config:
   distributor:STAKE_THRESHOLD: "10"
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "10"
-  distributor:SCHEDULE_MINUTES: "360"
+  distributor:SCHEDULE_MINUTES: "240"
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-prod
   distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic

--- a/infra/distributor/Pulumi.staging-11155111.yaml
+++ b/infra/distributor/Pulumi.staging-11155111.yaml
@@ -16,7 +16,7 @@ config:
   distributor:STAKE_TOP_UP_AMOUNT: "10"
   distributor:PROVER_ETH_DONATE_THRESHOLD: "30"
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "150.0"
-  distributor:SCHEDULE_MINUTES: "360"
+  distributor:SCHEDULE_MINUTES: "240"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging
   distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   distributor:ETH_RPC_URL:

--- a/infra/distributor/Pulumi.staging-84532.yaml
+++ b/infra/distributor/Pulumi.staging-84532.yaml
@@ -12,7 +12,7 @@ config:
   distributor:PROVER_ETH_DONATE_THRESHOLD: "10"
   distributor:PROVER_KEYS:
     secure: v1:2vOtFYU4tCpTWOtn:YKw9Zc/qts4XmbSpkeWKq5tXCkPOmp8dhaE9HjoMnPKLaX91QjJEZZHZSEAiDbBRpqD/8mTQisxm0BQhSYNJoy0u22a8Bq89jZYiMGHQCP7RuOgXZ//TPd+ZdGPAWKf79Lf8m63sXSd7Zuzgu4z6RbC7T2Nn7+gSN9Ztt6iqQeZT06g1swLsQpeuEzYiVrl7Eg==
-  distributor:SCHEDULE_MINUTES: "360"
+  distributor:SCHEDULE_MINUTES: "240"
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging
   distributor:SLASHER_KEY:
     secure: v1:1jzQibAoUrHjn0Iy:ixX10gWEC1WNnq8FVhWfHuqHvOEBys9o63zjaU6OZ6Lr+ooO9sficX9Djf979h1ElPk5CC5sqyzgShtZhkdPLo1YGqufpcdRrzNbAUODIWw=


### PR DESCRIPTION
Had a couple of instances where the distributor errored out due to RPC errors, then a subsequent address didn't get topped up. Adding some basic handling of errors so we skip the current address on error and still attempt to top up other addresses. Also changing to run every 4 hours.