### PR TITLE
handle guest panics within preflight without error logging

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -80,9 +80,6 @@ pub enum OrderPickerErr {
     #[error("{code} failed to fetch / push image: {0}", code = self.code())]
     FetchImageErr(#[source] Arc<anyhow::Error>),
 
-    #[error("{code} guest panicked: {0}", code = self.code())]
-    GuestPanic(String),
-
     #[error("{code} invalid request: {0}", code = self.code())]
     RequestError(Arc<RequestError>),
 
@@ -98,7 +95,6 @@ impl CodedError for OrderPickerErr {
         match self {
             OrderPickerErr::FetchInputErr(_) => "[B-OP-001]",
             OrderPickerErr::FetchImageErr(_) => "[B-OP-002]",
-            OrderPickerErr::GuestPanic(_) => "[B-OP-003]",
             OrderPickerErr::RequestError(_) => "[B-OP-004]",
             OrderPickerErr::RpcErr(_) => "[B-OP-005]",
             OrderPickerErr::UnexpectedErr(_) => "[B-OP-500]",
@@ -557,21 +553,25 @@ where
                                 })
                             }
                             Err(err) => match err {
-                                ProverError::ProvingFailed(ref err_msg)
-                                    if err_msg.contains("Session limit exceeded") =>
-                                {
-                                    tracing::debug!(
-                                        "Skipping order {order_id_clone} due to session limit exceeded: {}",
-                                        err_msg
-                                    );
-                                    Ok(PreflightCacheValue::Skip {
-                                        cached_limit: exec_limit_cycles,
-                                    })
-                                }
-                                ProverError::ProvingFailed(ref err_msg)
-                                    if err_msg.contains("GuestPanic") =>
-                                {
-                                    Err(OrderPickerErr::GuestPanic(err_msg.clone()))
+                                ProverError::ProvingFailed(ref err_msg) => {
+                                    if err_msg.contains("Session limit exceeded") {
+                                        tracing::debug!(
+                                            "Skipping order {order_id_clone} due to session limit exceeded: {}",
+                                            err_msg
+                                        );
+                                        Ok(PreflightCacheValue::Skip {
+                                            cached_limit: exec_limit_cycles,
+                                        })
+                                    } else if err_msg.contains("Guest panicked") {
+                                        tracing::debug!("Skipping order {order_id_clone} due to guest panic (invalid request): {}", err_msg);
+                                        Ok(PreflightCacheValue::Skip {
+                                            // Use max cached limit, to avoid re-running preflight
+                                            // for an invalid request.
+                                            cached_limit: u64::MAX,
+                                        })
+                                    } else {
+                                        Err(OrderPickerErr::UnexpectedErr(Arc::new(err.into())))
+                                    }
                                 }
                                 _ => Err(OrderPickerErr::UnexpectedErr(Arc::new(err.into()))),
                             },
@@ -602,13 +602,8 @@ where
         };
 
         // Handle the preflight result
-        let (exec_session_id, cycle_count) = match preflight_result {
-            Ok(PreflightCacheValue::Success {
-                exec_session_id,
-                cycle_count,
-                image_id,
-                input_id,
-            }) => {
+        let (exec_session_id, cycle_count) = match preflight_result? {
+            PreflightCacheValue::Success { exec_session_id, cycle_count, image_id, input_id } => {
                 tracing::debug!(
                     "Using preflight result for {order_id}: session id {} with {} mcycles",
                     exec_session_id,
@@ -621,11 +616,8 @@ where
 
                 (exec_session_id, cycle_count)
             }
-            Ok(PreflightCacheValue::Skip { .. }) => {
+            PreflightCacheValue::Skip { .. } => {
                 return Ok(Skip);
-            }
-            Err(err) => {
-                return Err(err);
             }
         };
 

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -562,7 +562,8 @@ where
                                         Ok(PreflightCacheValue::Skip {
                                             cached_limit: exec_limit_cycles,
                                         })
-                                    } else if err_msg.contains("Guest panicked") {
+                                    } else if err_msg.contains("Guest panicked") || err_msg.contains("GuestPanic") {
+                                        // Error message from bento and bonsai respectively for guest failures
                                         tracing::debug!("Skipping order {order_id_clone} due to guest panic (invalid request): {}", err_msg);
                                         Ok(PreflightCacheValue::Skip {
                                             // Use max cached limit, to avoid re-running preflight


### PR DESCRIPTION
Closes BM-1472

Adds bento version of guest panic error ("Guest panicked") to handle more gracefully. Only bonsai error string was being matched

Also switched both to just skip and not go through the error path, as this is not an error with the broker, so this avoids warn logging. This part is opinionated, so if we would rather still pass through an error and then just match on that error in the caller and not warn log in that case, it works too.