### PR TITLE
fix: quickstart example links

### DIFF
--- a/documentation/site/pages/developers/steel/quick-start.mdx
+++ b/documentation/site/pages/developers/steel/quick-start.mdx
@@ -1,8 +1,8 @@
 # Getting Started with Steel
 
-The recommended place is to start is [Steel examples](https://github.com/risc0/risc0-ethereum/tree/main/examples), specifically the [ERC20 Counter](https://github.com/risc0/risc0-ethereum/tree/main/examples/erc20-counter) example.
+The recommended place is to start is [Steel examples](https://github.com/boundless-xyz/steel/tree/main/examples), specifically the [ERC20 Counter](https://github.com/boundless-xyz/steel/tree/main/examples/erc20-counter) example.
 
-The [create-steel-app](https://github.com/risc0/risc0-ethereum/tree/main/crates/steel/docs/create-steel-app) script will allow you to set up the erc20-counter example locally in one command:
+The [create-steel-app](https://github.com/boundless-xyz/steel/tree/main/crates/steel/docs/create-steel-app) script will allow you to set up the erc20-counter example locally in one command:
 
 ```bash
 sh <(curl -fsSL https://getsteel.xyz)
@@ -10,4 +10,4 @@ sh <(curl -fsSL https://getsteel.xyz)
 
 This example acts as your skeleton project structure for further development. Once the script is finished, you can run through a test workflow with either local proving or Bonsai proving.
 
-Further Steel documentation will guide you through the [ERC20-counter example](https://github.com/risc0/risc0-ethereum/tree/main/examples/erc20-counter) as a guide to explain Steel in detail.
+Further Steel documentation will guide you through the [ERC20-counter example](https://github.com/boundless-xyz/steel/tree/main/examples/erc20-counter) as a guide to explain Steel in detail.


### PR DESCRIPTION
Documentation links not updated on github repositry migration. More pages likely affected.