### PR TITLE
tests(assessor): fix mixed test attributes using test-log pass-through

### DIFF
--- a/crates/assessor/src/lib.rs
+++ b/crates/assessor/src/lib.rs
@@ -197,8 +197,7 @@ mod tests {
         <[u8; 32]>::from(digest).into()
     }
 
-    #[tokio::test]
-    #[test_log::test]
+    #[test_log::test(tokio::test)]
     async fn test_claim() {
         let signer = PrivateKeySigner::random();
         let proving_request = proving_request(1, signer.address(), B256::ZERO, vec![1]);
@@ -214,7 +213,6 @@ mod tests {
         claim.evaluate_requirements().unwrap();
     }
 
-    #[test]
     #[test_log::test]
     fn test_domain_serde() {
         let domain = eip712_domain(Address::ZERO, 1);
@@ -268,8 +266,7 @@ mod tests {
         assert_eq!(session.exit_code, ExitCode::Halted(0));
     }
 
-    #[tokio::test]
-    #[test_log::test]
+    #[test_log::test(tokio::test)]
     async fn test_assessor_e2e_singleton() {
         let signer = PrivateKeySigner::random();
         // 1. Mock and sign a request
@@ -284,8 +281,7 @@ mod tests {
         assessor(claims, vec![application_receipt]);
     }
 
-    #[tokio::test]
-    #[test_log::test]
+    #[test_log::test(tokio::test)]
     async fn test_assessor_e2e_two_leaves() {
         let signer = PrivateKeySigner::random();
         // 1. Mock and sign a request


### PR DESCRIPTION
Replace stacked #[tokio::test]/#[test] + #[test_log::test] with the correct forms.
Async tests now use #[test_log::test(tokio::test)]: test_claim, test_assessor_e2e_singleton, test_assessor_e2e_two_leaves.
Sync test keeps only #[test_log::test]: test_domain_serde.