### PR TITLE
fix: stake token max denom (and bench)

### DIFF
--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -17,7 +17,7 @@ use std::{collections::HashSet, fs::File, path::PathBuf, time::Duration};
 use alloy::{
     network::EthereumWallet,
     primitives::{
-        utils::{format_units, parse_ether},
+        utils::{format_units, parse_ether, parse_units},
         U256,
     },
     providers::Provider,
@@ -185,6 +185,8 @@ pub async fn run(args: &MainArgs) -> Result<()> {
         };
     tracing::debug!("Indexer URL: {}", indexer_url);
 
+    let stake_token_decimals = boundless_client.boundless_market.stake_token_decimals().await?;
+
     // Build the first request. We will clone this request, updating the id and bidding start, to
     // create each request sent.
     let inital_request = boundless_client
@@ -196,7 +198,7 @@ pub async fn run(args: &MainArgs) -> Result<()> {
                 .with_env(env.clone())
                 .with_offer(
                     OfferParams::builder()
-                        .lock_stake(parse_ether(&bench.lockin_stake)?)
+                        .lock_stake(parse_units(&bench.lockin_stake, stake_token_decimals)?)
                         .ramp_up_period(bench.ramp_up)
                         .timeout(bench.timeout)
                         .lock_timeout(bench.lock_timeout),

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -364,7 +364,9 @@ where
         // For lock expired orders, we don't check the max stake because we can't lock those orders.
         let max_stake = {
             let config = self.config.lock_all().context("Failed to read config")?;
-            parse_ether(&config.market.max_stake).context("Failed to parse max_stake")?
+            parse_units(&config.market.max_stake, self.stake_token_decimals)
+                .context("Failed to parse max_stake")?
+                .into()
         };
 
         if !lock_expired && lockin_stake > max_stake {
@@ -2025,7 +2027,7 @@ pub(crate) mod tests {
 
         let order = ctx
             .generate_next_order(OrderParams {
-                lock_stake: parse_units("11", 18).unwrap().into(),
+                lock_stake: parse_units("11", ctx.picker.stake_token_decimals).unwrap().into(),
                 ..Default::default()
             })
             .await;


### PR DESCRIPTION
Main reason for fix is the max stake tokens config, but when doing a scan for any other missed I noticed the bench program (unused) had one so swapped that just to avoid any issues in the future