### PR TITLE
BM-1514: bump order generator cadence and cycles

### DIFF
--- a/infra/order-generator/Pulumi.prod-8453.yaml
+++ b/infra/order-generator/Pulumi.prod-8453.yaml
@@ -11,7 +11,7 @@ config:
   order-generator-base:CHAIN_ID: "8453"
   order-generator-base:DOCKER_DIR: ../../
   order-generator-base:DOCKER_TAG: latest
-  order-generator-base:INTERVAL: "13"
+  order-generator-base:INTERVAL: "11"
   order-generator-base:LOCK_STAKE_RAW: "3500000" # $3.50 USDC
   order-generator-base:LOCK_TIMEOUT: "900"
   order-generator-base:LOG_LEVEL: info
@@ -25,11 +25,11 @@ config:
   order-generator-base:SET_VERIFIER_ADDR: 0x8C5a8b5cC272Fe2b74D18843CF9C3aCBc952a760
   order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic
   order-generator-base:TX_TIMEOUT: "90"
-  order-generator-offchain:INPUT_MAX_MCYCLES: "2200"
+  order-generator-offchain:INPUT_MAX_MCYCLES: "3000"
   order-generator-offchain:RAMP_UP: "750"
   order-generator-offchain:LOCK_TIMEOUT: "900"
   order-generator-offchain:TIMEOUT: "1500"
-  order-generator-offchain:SECONDS_PER_MCYCLE: "1"
+  order-generator-offchain:SECONDS_PER_MCYCLE: "2"
   order-generator-offchain:AUTO_DEPOSIT: "0.015"
   order-generator-offchain:WARN_BALANCE_BELOW: "0.01"
   order-generator-offchain:ERROR_BALANCE_BELOW: "0.005"


### PR DESCRIPTION
Until Kailua orders are more consistent, increasing demand temporarily to alleviate competition.

Increases off-chain cycle range and how the timeout scales with mcycles, as well as decreasing the interval across the board by ~15%