### PR TITLE
BM-1523: update bento rest API health check

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -230,7 +230,7 @@ services:
 
     entrypoint: /app/rest_api --bind-addr 0.0.0.0:8081 --snark-timeout ${SNARK_TIMEOUT:-180}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8081'"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Will scan through PRs to see if there is a health check planned to be added soon, but this whiffs and causes issues on startup