### PR TITLE
Prevent the zero address from being used as value recipient

### DIFF
--- a/crates/guest/povw/log-updater/src/main.rs
+++ b/crates/guest/povw/log-updater/src/main.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use alloy_sol_types::SolValue;
 use boundless_povw_guests::log_updater::{
     Input, Journal, WorkLogUpdate, RISC0_POVW_LOG_BUILDER_ID,
@@ -12,6 +13,12 @@ fn main() {
     // This means the verifier must check the value `self_image_id` written to the journal.
     env::verify(RISC0_POVW_LOG_BUILDER_ID, &borsh::to_vec(&input.update).unwrap()).unwrap();
     assert_eq!(input.update.self_image_id, RISC0_POVW_LOG_BUILDER_ID.into());
+
+    // NOTE: This check is included due to the fact that the ZKC contract does not allow sending
+    // tokens to the zero address. Specifying a value recipient of zero would mean that rewards for
+    // this update could not be distributed. Additionally, this is included to prevent accidental
+    // burning of value.
+    assert_ne!(input.value_recipient, Address::ZERO, "value recipient cannot be the zero address");
 
     // Convert the input to the Solidity struct and verify the EIP-712 signature, using the work
     // log ID as the authenticating party.

--- a/crates/guest/povw/tests/log-updater.rs
+++ b/crates/guest/povw/tests/log-updater.rs
@@ -63,6 +63,38 @@ async fn basic() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn reject_zero_value_recipient() -> anyhow::Result<()> {
+    let signer = PrivateKeySigner::random();
+    let chain_id = 31337;
+    let contract_address = address!("0x0000000000000000000000000000000000000f00");
+
+    let update = LogBuilderJournal::builder()
+        .self_image_id(RISC0_POVW_LOG_BUILDER_ID)
+        .initial_commit(Digest::new(rand::random()))
+        .updated_commit(Digest::new(rand::random()))
+        .update_value(5)
+        .work_log_id(signer.address())
+        .build()?;
+
+    let signature = WorkLogUpdate::from_log_builder_journal(update.clone(), signer.address())
+        .sign(&signer, contract_address, chain_id)
+        .await?;
+
+    let input = Input {
+        update: update.clone(),
+        value_recipient: Address::ZERO,
+        signature: signature.as_bytes().to_vec(),
+        contract_address,
+        chain_id,
+    };
+    let err = common::execute_log_updater_guest(&input).unwrap_err();
+    println!("execute_log_updater_guest failed with: {err}");
+    assert!(err.to_string().contains("value recipient cannot be the zero address"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn reject_wrong_signer() -> anyhow::Result<()> {
     let signer = PrivateKeySigner::random();
     let chain_id = 31337;


### PR DESCRIPTION
On `victor/povw`, there is an issue that is a prover specifies a value recipient of zero, they will not only burn the rewards for that update, but will be prevented from claiming rewards for any future update.

This PR fixes this by preventing a value recipient of zero from being specified. The check is added to the log builder guest, such that the update cannot be proven or posted to the PoVW Accounting contract.
