### PR TITLE
fix(storage): unify S3_USE_PRESIGNED flag and deprecate S3_NO_PRESIGNED

### DIFF
--- a/crates/boundless-market/src/storage/mod.rs
+++ b/crates/boundless-market/src/storage/mod.rs
@@ -179,7 +179,7 @@ pub struct StorageProviderConfig {
     #[builder(setter(strip_option, into), default)]
     pub aws_region: Option<String>,
     /// Use presigned URLs for S3
-    #[arg(long, env, requires("s3_access_key"), default_value = "true")]
+    #[arg(long, env = "S3_USE_PRESIGNED", requires("s3_access_key"), default_value = "true")]
     #[builder(setter(strip_option), default)]
     pub s3_use_presigned: Option<bool>,
 

--- a/documentation/site/pages/developers/tutorials/sensitive-inputs.mdx
+++ b/documentation/site/pages/developers/tutorials/sensitive-inputs.mdx
@@ -205,7 +205,7 @@ If you have already uploaded your inputs using the `aws` CLI above, you can skip
   - `S3_BUCKET` for the bucket name of the bucket created in [Create the S3 bucket](/developers/tutorials/sensitive-inputs#1-create-the-s3-bucket)
   - `S3_URL` for the bucket URL of the bucket created in [Create the S3 bucket](/developers/tutorials/sensitive-inputs#1-create-the-s3-bucket)
   - `AWS_REGION` for the bucket region.
-  - and last, but not least, make sure `S3_NO_PRESIGNED=1`
+  - and last, but not least, make sure `S3_USE_PRESIGNED=false`
 
 After this setup, you may request a proof programmatically as [Request a Proof](/developers/tutorials/request) recommends; your inputs will be automatically uploaded to your gated S3 bucket, however remember that you still need to go through all the necessary gating policies as laid out in this tutorial to make sure your inputs are private and only available to select provers.
 


### PR DESCRIPTION
Closes #1048 

This PR resolves the inconsistency between `S3_USE_PRESIGNED` and `S3_NO_PRESIGNED` environment variables in the S3 storage provider.

Changes

-Added `S3_USE_PRESIGNED` as the canonical env var (default = true).
-Marked `S3_NO_PRESIGNED` as deprecated: still supported but logs a warning.
-If both are set, `S3_USE_PRESIGNED` takes precedence.
-Updated `StorageProviderConfig.s3_use_presigned` to explicitly bind `env = "S3_USE_PRESIGNED"`.
-Updated developer docs (`sensitive-inputs.mdx`) to use `S3_USE_PRESIGNED=false` instead of `S3_NO_PRESIGNED=1`.

