### PR TITLE
Fix setting of lower block limit in boundless povw CLI

### DIFF
--- a/crates/boundless-cli/src/commands/povw/claim_reward.rs
+++ b/crates/boundless-cli/src/commands/povw/claim_reward.rs
@@ -79,7 +79,7 @@ pub struct PovwClaimReward {
     /// rewards claim. If all log update events to claim occured in fewer than the specified number
     /// of days, this command will not scan for events in the full range.
     #[clap(long, default_value_t = 30)]
-    pub days: u64,
+    pub days: u32,
     /// Chunk size to use when querying the RPC node for events using `eth_getLogs`.
     ///
     /// If using a free-tier RPC provider, you may need to set this to a lower value. You may also
@@ -113,7 +113,7 @@ impl PovwClaimReward {
         let latest_block_number =
             provider.get_block_number().await.context("Failed to query the block number")?;
         let search_limit_time =
-            SystemTime::now().checked_sub(24 * HOUR).context("Invalid number of days")?;
+            SystemTime::now().checked_sub(self.days * 24 * HOUR).context("Invalid number of days")?;
         let lower_limit_block_number = block_number_near_timestamp(
             &provider,
             latest_block_number,


### PR DESCRIPTION
Fix usage of the --days flag on the Boundless claim CLI. On `main`, the arg is actually unused, meaning that no matter its setting the max search depth would be 1 day. This fixes the issues such that thee flag is respected.
