### PR TITLE
BM-1571: Fix order picker error context formatting

### DIFF
--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -78,19 +78,19 @@ type PreflightCache = Arc<Cache<PreflightCacheKey, PreflightCacheValue>>;
 #[derive(Error, Debug, Clone)]
 #[non_exhaustive]
 pub enum OrderPickerErr {
-    #[error("{code} failed to fetch / push input: {0}", code = self.code())]
+    #[error("{code} failed to fetch / push input: {0:#}", code = self.code())]
     FetchInputErr(#[source] Arc<anyhow::Error>),
 
-    #[error("{code} failed to fetch / push image: {0}", code = self.code())]
+    #[error("{code} failed to fetch / push image: {0:#}", code = self.code())]
     FetchImageErr(#[source] Arc<anyhow::Error>),
 
     #[error("{code} invalid request: {0}", code = self.code())]
     RequestError(Arc<RequestError>),
 
-    #[error("{code} RPC error: {0:?}", code = self.code())]
+    #[error("{code} RPC error: {0:#}", code = self.code())]
     RpcErr(Arc<anyhow::Error>),
 
-    #[error("{code} Unexpected error: {0:?}", code = self.code())]
+    #[error("{code} Unexpected error: {0:#}", code = self.code())]
     UnexpectedErr(Arc<anyhow::Error>),
 }
 


### PR DESCRIPTION
Underlying error is not printed with this format for most of the errors, removed the backtrace from others as it's multiline and hard to grep for.