### PR TITLE
BM-1587: check each step before sending to redis

### DIFF
--- a/bento/crates/workflow/src/tasks/join_povw.rs
+++ b/bento/crates/workflow/src/tasks/join_povw.rs
@@ -38,6 +38,13 @@ pub async fn join_povw(agent: &Agent, job_id: &Uuid, request: &JoinReq) -> Resul
         deserialize_obj::<SuccinctReceipt<WorkClaim<ReceiptClaim>>>(&right_receipt_bytes)?,
     );
 
+    left_receipt
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify left receipt integrity")?;
+    right_receipt
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify right receipt integrity")?;
+
     tracing::debug!("Starting POVW join of receipts {} and {}", request.left, request.right);
 
     // Use POVW-specific join - this is required for POVW functionality
@@ -48,6 +55,10 @@ pub async fn join_povw(agent: &Agent, job_id: &Uuid, request: &JoinReq) -> Resul
     } else {
         return Err(anyhow::anyhow!("No prover available for join task"));
     };
+
+    joined_receipt
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify joined POVW receipt integrity")?;
 
     tracing::debug!("Completed POVW join: {} and {}", request.left, request.right);
 

--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -58,6 +58,10 @@ pub async fn keccak(
         .prove_keccak(&keccak_req)
         .context("Failed to prove_keccak")?;
 
+    keccak_receipt
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify keccak receipt integrity")?;
+
     let job_prefix = format!("job:{job_id}");
     let receipts_key = format!("{job_prefix}:{KECCAK_RECEIPT_PATH}:{task_id}");
     let keccak_receipt_bytes =

--- a/bento/crates/workflow/src/tasks/prove.rs
+++ b/bento/crates/workflow/src/tasks/prove.rs
@@ -35,6 +35,10 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
         .prove_segment(&agent.verifier_ctx, &segment)
         .context("Failed to prove segment")?;
 
+    segment_receipt
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify segment receipt integrity")?;
+
     tracing::debug!("Completed proof: {job_id} - {index}");
 
     tracing::debug!("lifting {job_id} - {index}");
@@ -48,6 +52,10 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
             .context("Missing prover from resolve task")?
             .lift_povw(&segment_receipt)
             .with_context(|| format!("Failed to POVW lift segment {index}"))?;
+
+        lift_receipt
+            .verify_integrity_with_context(&agent.verifier_ctx)
+            .context("Failed to verify lift receipt integrity")?;
 
         tracing::debug!("lifting complete {job_id} - {index}");
 
@@ -63,6 +71,10 @@ pub async fn prover(agent: &Agent, job_id: &Uuid, task_id: &str, request: &Prove
             .context("Missing prover from resolve task")?
             .lift(&segment_receipt)
             .with_context(|| format!("Failed to lift segment {index}"))?;
+
+        lift_receipt
+            .verify_integrity_with_context(&agent.verifier_ctx)
+            .context("Failed to verify lift receipt integrity")?;
 
         tracing::debug!("lifting complete {job_id} - {index}");
 

--- a/bento/crates/workflow/src/tasks/union.rs
+++ b/bento/crates/workflow/src/tasks/union.rs
@@ -46,6 +46,10 @@ pub async fn union(agent: &Agent, job_id: &Uuid, request: &UnionReq) -> Result<(
         .context("Failed to union on left/right receipt")?
         .into_unknown();
 
+    unioned
+        .verify_integrity_with_context(&agent.verifier_ctx)
+        .context("Failed to verify union receipt integrity")?;
+
     // send result to redis
     let union_result = serialize_obj(&unioned).context("Failed to serialize union receipt")?;
     let output_key = format!("{keccak_receipts_prefix}:{}", request.idx);


### PR DESCRIPTION
Add integrity checks to each phase of proving for better retry behavior.

tested with bento cli 1,2, and 19 segment counts