### PR TITLE
BM-1602: format causes into bento err string

### DIFF
--- a/bento/crates/workflow/src/lib.rs
+++ b/bento/crates/workflow/src/lib.rs
@@ -257,7 +257,7 @@ impl Agent {
             };
 
             if let Err(err) = self.process_work(&task).await {
-                let mut err_str = err.to_string();
+                let mut err_str = format!("{:#}", err);
                 if !err_str.contains("stopped intentionally due to session limit")
                     && !err_str.contains("Session limit exceeded")
                 {


### PR DESCRIPTION
This removed the error context, which avoided the handling of the exec limit error on broker side. This formatting will also help readability for other errors.