### PR TITLE
Fix log ID check to correctly insert seen IDs

### DIFF
--- a/crates/boundless-cli/src/commands/povw/prepare.rs
+++ b/crates/boundless-cli/src/commands/povw/prepare.rs
@@ -303,7 +303,7 @@ async fn fetch_work_receipts(
 
         if info_log_id != log_id {
             // Log any unknown log IDs we find, but only once.
-            if !seen_log_ids.insert(info_log_id) {
+            if seen_log_ids.insert(info_log_id) {
                 tracing::warn!("Skipping receipts with log ID {info_log_id:x} in Bento storage");
             }
             tracing::debug!("Skipping receipt with key {}; log ID does not match", info.key);


### PR DESCRIPTION
The condition if !seen_log_ids.insert(info_log_id) was inverted.

HashSet::insert() returns:
- true if the value was not previously in the set (first time seeing this log ID)
- false if the value was already in the set (seen before)

Before: The warning was shown for every receipt with log ID 0, not just the first.
After: The warning is shown only once per unique log ID.