### PR TITLE
BM-1639: [V-BND-VUL-003] Add check to reject non-canonical signatures

### DIFF
--- a/crates/assessor/src/lib.rs
+++ b/crates/assessor/src/lib.rs
@@ -42,7 +42,7 @@ pub enum Error {
     },
 
     /// Signature is non-canonical.
-    #[error("invalid signature: non-canonical s value")]
+    #[error("invalid signature: not normalized s-value")]
     SignatureNonCanonicalError,
 
     /// Predicate evaluation failure from [ProofRequest] [Requirements]

--- a/crates/boundless-cli/src/bin/boundless-ffi.rs
+++ b/crates/boundless-cli/src/bin/boundless-ffi.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
         Signature::try_from(Bytes::from_hex(args.signature.trim_start_matches("0x"))?.as_ref())?;
     // Check if the signature is non-canonical.
     if signature.normalize_s().is_some() {
-        bail!("invalid signature: non-canonical s value");
+        bail!("invalid signature: not normalized s-value");
     }
     let (fills, root_receipt, assessor_receipt) =
         prover.fulfill(&[(request, signature.as_bytes().into())]).await?;

--- a/crates/boundless-market/src/contracts/mod.rs
+++ b/crates/boundless-market/src/contracts/mod.rs
@@ -282,7 +282,7 @@ pub enum RequestError {
     SignatureError(#[from] alloy::signers::Error),
 
     /// Signature is non-canonical.
-    #[error("invalid signature: non-canonical s value")]
+    #[error("invalid signature: not normalized s-value")]
     SignatureNonCanonicalError,
 
     /// The image URL is empty.

--- a/crates/povw/src/log_updater.rs
+++ b/crates/povw/src/log_updater.rs
@@ -80,7 +80,7 @@ impl WorkLogUpdate {
         let sig = Signature::try_from(signature.as_ref())?;
         // Check if the signature is non-canonical.
         if sig.normalize_s().is_some() {
-            bail!("invalid signature: non-canonical s value");
+            bail!("invalid signature: not normalized s-value");
         }
         let addr = sig.recover_address_from_prehash(&self.signing_hash(contract_addr, chain_id))?;
         if addr == signer {


### PR DESCRIPTION
This PR adds a check to the rust library to enforce canonical signatures. This matches with the same rule implemented by OpenZeppelin’s `ECDSA.recover`.