### PR TITLE
[V-BND-VUL-004] Validate request within the assessor

### DIFF
--- a/crates/boundless-market/src/contracts/mod.rs
+++ b/crates/boundless-market/src/contracts/mod.rs
@@ -492,8 +492,7 @@ impl ProofRequest {
         contract_addr: Address,
         chain_id: u64,
     ) -> Result<Signature, RequestError> {
-        let domain = eip712_domain(contract_addr, chain_id);
-        let hash = self.eip712_signing_hash(&domain.alloy_struct());
+        let hash = self.signing_hash(contract_addr, chain_id)?;
         Ok(signer.sign_hash(&hash).await?)
     }
 
@@ -517,8 +516,7 @@ impl ProofRequest {
         chain_id: u64,
     ) -> Result<(), RequestError> {
         let sig = Signature::try_from(signature.as_ref())?;
-        let domain = eip712_domain(contract_addr, chain_id);
-        let hash = self.eip712_signing_hash(&domain.alloy_struct());
+        let hash = self.signing_hash(contract_addr, chain_id)?;
         let addr = sig.recover_address_from_prehash(&hash)?;
         if addr == self.client_address() {
             Ok(())

--- a/crates/guest/assessor/assessor-guest/src/main.rs
+++ b/crates/guest/assessor/assessor-guest/src/main.rs
@@ -51,6 +51,7 @@ fn main() {
         // by this guest. This check is not strictly needed, but reduces the chance of accidentally
         // failing to enforce a constraint.
         RequestId::try_from(fill.request.id).unwrap();
+        fill.request.validate().expect("request is not valid");
 
         // ECDSA signatures are always checked here.
         // Smart contract signatures (via EIP-1271) are checked on-chain either when a request is locked,

--- a/crates/order-stream/src/order_db.rs
+++ b/crates/order-stream/src/order_db.rs
@@ -272,10 +272,9 @@ mod tests {
     use alloy::{
         primitives::{Bytes, U256},
         signers::local::LocalSigner,
-        sol_types::SolStruct,
     };
     use boundless_market::contracts::{
-        eip712_domain, Offer, Predicate, ProofRequest, RequestInput, RequestInputType, Requirements,
+        Offer, Predicate, ProofRequest, RequestInput, RequestInputType, Requirements,
     };
     use futures_util::StreamExt;
     use risc0_zkvm::sha::Digest;
@@ -305,8 +304,7 @@ mod tests {
             },
         };
         let signature = req.sign_request(&signer, Address::ZERO, 31337).await.unwrap();
-        let domain = eip712_domain(Address::ZERO, 31337);
-        let request_digest = req.eip712_signing_hash(&domain.alloy_struct());
+        let request_digest = req.signing_hash(Address::ZERO, 31337).unwrap();
 
         Order::new(req, request_digest, signature)
     }


### PR DESCRIPTION
This PR adds request validation within the assessor and refactors `sign_request` and `verify_signature` to reuse `signing_hash` 