### PR TITLE
BM-1685: Add @neutronmoderator to CODEOWNERS for /docs/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # precedence.
 
 *                                      @boundless-xyz/maintainers @capossele @Wollac @zeroecco @austinabell @willemolding @zeroecco @ec2
-/docs/                                 @boundless-xyz/maintainers @capossele @Wollac @zeroecco @austinabell @willemolding @zeroecco @ec2
+/docs/                                 @boundless-xyz/maintainers @capossele @Wollac @zeroecco @austinabell @willemolding @zeroecco @ec2 @neutronmoderator


### PR DESCRIPTION
Added @neutronmoderator as a code owner for the /docs/ directory.