### PR TITLE
fix dependencies and update default binaries to 1.0.2 when ready

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,12 @@ homepage = "https://beboundless.xyz/"
 repository = "https://github.com/boundless-xyz/boundless/"
 
 [workspace.dependencies]
-boundless-assessor = { version = "0.15.0", path = "crates/assessor" }
-boundless-cli = { version = "0.15.0", path = "crates/boundless-cli" }
-boundless-market = { version = "0.15.0", path = "crates/boundless-market" }
-boundless-rewards = { version = "0.15.0", path = "crates/rewards" }
+boundless-assessor = { version = "1.0.0", path = "crates/assessor" }
+boundless-cli = { path = "crates/boundless-cli" }
+boundless-market = { version = "1.0.0", path = "crates/boundless-market" }
+boundless-rewards = { path = "crates/rewards" }
 boundless-test-utils = { path = "crates/test-utils" }
-boundless-zkc = { version = "0.15.0", path = "crates/zkc" }
+boundless-zkc = { path = "crates/zkc" }
 boundless-povw = { path = "crates/povw" }
 distributor = { path = "crates/distributor" }
 guest-assessor = { path = "crates/guest/assessor" }

--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,7 @@ x-agent-common: &agent-common
     context: .
     dockerfile: ${AGENT_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.0/bento-bundle-linux-amd64.tar.gz}
+      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.2/bento-bundle-linux-amd64.tar.gz}
   restart: always
   depends_on:
     postgres:
@@ -76,7 +76,7 @@ x-broker-common: &broker-common
     context: .
     dockerfile: ${BROKER_DOCKERFILE:-dockerfiles/broker.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.0.0/broker}
+      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.0.2/broker}
   mem_limit: 2G
   cpus: 2
   stop_grace_period: 3h
@@ -205,7 +205,7 @@ services:
       context: .
       dockerfile: ${REST_API_DOCKERFILE:-dockerfiles/rest_api.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.0/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.2/bento-bundle-linux-amd64.tar.gz}
     restart: always
     depends_on:
       postgres:
@@ -271,7 +271,7 @@ services:
       context: .
       dockerfile: ${BENTO_CLI_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.1/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.0.2/bento-bundle-linux-amd64.tar.gz}
     restart: always
     depends_on:
       rest_api:


### PR DESCRIPTION
1.0.2 won't be valid yet, just preparing this PR for when we publish. Also noticed some deps were incorrectly versioned (and some referencing unreleased versions), so updated that in this PR too