### PR TITLE
BM-1711: update mining proof size default

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -283,7 +283,7 @@ services:
     environment:
       <<: *base-environment
       RUST_LOG: ${RUST_LOG:-info}
-    entrypoint: /bin/bash -c "while sleep 1; do /app/bento_cli --iter-count 1000000; done"
+    entrypoint: /bin/bash -c "while sleep 1; do /app/bento_cli --iter-count 2000000; done"
 
 volumes:
   redis-data:


### PR DESCRIPTION
This new value is ~20b cycles at default po2, which is ~4h for 1 5090 to prove, 4 minutes to execute so if execution agents not configured well, will minimize potential for an issue. 4h seems reasonable for single-gpu to minimize povw receipts while also not being too low for a larger prover to be less efficient with. Unopinionated about what this value is, so opinions welcome.

Also updates the default prebuilt versions for main to match latest release (to avoid those footguns)