### PR TITLE
BM-1724: Fix indexer table for last updated

### DIFF
--- a/crates/indexer/migrations/20_fix_order_stream_timestamp_type.sql
+++ b/crates/indexer/migrations/20_fix_order_stream_timestamp_type.sql
@@ -1,2 +1,11 @@
-ALTER TABLE order_stream_state
-ALTER COLUMN last_processed_timestamp TYPE TEXT;
+-- Drop and recreate the table with the correct column type
+-- This is safe because the table was just created in migration 18
+DROP TABLE IF EXISTS order_stream_state;
+
+CREATE TABLE IF NOT EXISTS order_stream_state (
+    id BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    last_processed_timestamp TEXT
+);
+
+INSERT INTO order_stream_state (id) VALUES (TRUE)
+  ON CONFLICT (id) DO NOTHING;

--- a/justfile
+++ b/justfile
@@ -43,6 +43,7 @@ test-cargo-example:
 test-cargo-db:
     just test-db setup
     DATABASE_URL={{DATABASE_URL}} RISC0_DEV_MODE=1 cargo test -p order-stream -- --include-ignored
+    DATABASE_URL={{DATABASE_URL}} RISC0_DEV_MODE=1 cargo test -p boundless-indexer -- --include-ignored
     DATABASE_URL={{DATABASE_URL}} RISC0_DEV_MODE=1 cargo test -p boundless-cli -- --include-ignored
     just test-db clean
 


### PR DESCRIPTION
Seeing 
```
Error: FATAL: Error running the indexer: Database error: SQL error ColumnDecode { index: 
"last_processed_timestamp", source: AnyDriverError("Any driver does not support the Postgres type 
PgTypeInfo(Timestamptz)") }
```
on staging. This fixes.