### PR TITLE
BM-1757: check minio for completed receipt if job not found in taskdb

### DIFF
--- a/bento/crates/api/src/lib.rs
+++ b/bento/crates/api/src/lib.rs
@@ -457,9 +457,31 @@ async fn stark_status(
     Path(job_id): Path<Uuid>,
     ExtractApiKey(api_key): ExtractApiKey,
 ) -> Result<Json<SessionStatusRes>, AppError> {
-    let job_state = taskdb::get_job_state(&state.db_pool, &job_id, &api_key)
-        .await
-        .context("Failed to get job state")?;
+    let job_state_result = taskdb::get_job_state(&state.db_pool, &job_id, &api_key).await;
+
+    // If job not found in taskdb, check MinIO for completed receipt
+    if let Err(TaskDbErr::SqlError(sqlx::Error::RowNotFound)) = &job_state_result {
+        let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{STARK_BUCKET_DIR}/{job_id}.bincode");
+        if state
+            .s3_client
+            .object_exists(&receipt_key)
+            .await
+            .context("Failed to check if receipt exists")?
+        {
+            // Receipt exists - job was completed and cleaned up from DB
+            return Ok(Json(SessionStatusRes {
+                state: Some("".into()),
+                receipt_url: Some(format!("http://{hostname}/receipts/stark/receipt/{job_id}")),
+                error_msg: None,
+                status: JobState::Done.to_string(),
+                elapsed_time: None,
+                stats: None,
+            }));
+        }
+    }
+
+    // Job exists in DB or doesn't exist anywhere - return DB result
+    let job_state = job_state_result.context("Failed to get job state")?;
 
     let (exec_stats, receipt_url) = if job_state == JobState::Done {
         let exec_stats = helpers::get_exec_stats(&state.db_pool, &job_id)
@@ -605,9 +627,28 @@ async fn groth16_status(
     Path(job_id): Path<Uuid>,
     Host(hostname): Host,
 ) -> Result<Json<SnarkStatusRes>, AppError> {
-    let job_state = taskdb::get_job_state(&state.db_pool, &job_id, &api_key)
-        .await
-        .context("Failed to get job state")?;
+    let job_state_result = taskdb::get_job_state(&state.db_pool, &job_id, &api_key).await;
+
+    // If job not found in taskdb, check MinIO for completed receipt
+    if let Err(TaskDbErr::SqlError(sqlx::Error::RowNotFound)) = &job_state_result {
+        let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{GROTH16_BUCKET_DIR}/{job_id}.bincode");
+        if state
+            .s3_client
+            .object_exists(&receipt_key)
+            .await
+            .context("Failed to check if receipt exists")?
+        {
+            // Receipt exists - job was completed and cleaned up from taskdb
+            return Ok(Json(SnarkStatusRes {
+                status: JobState::Done.to_string(),
+                error_msg: None,
+                output: Some(format!("http://{hostname}/receipts/groth16/receipt/{job_id}")),
+            }));
+        }
+    }
+
+    let job_state = job_state_result.context("Failed to get job state")?;
+
     let (error_msg, output) = match job_state {
         JobState::Running => (None, None),
         JobState::Done => {


### PR DESCRIPTION
There is currently a race condition with #1218 such that if the cleanup happens after a job is completed but before the broker polls again, it will return a failed status. This change checks minio for the receipt if not found in taskdb to avoid this issue and allow clearing pgsql more liberally in other ways also.