### PR TITLE
BM-1858: add removed sanity check from refactor

### DIFF
--- a/crates/boundless-cli/src/commands/rewards/prepare_mining.rs
+++ b/crates/boundless-cli/src/commands/rewards/prepare_mining.rs
@@ -338,14 +338,14 @@ fn check_work_receipt<T: Borrow<WorkReceipt>>(
     // NOTE: If nonce_max does not have the same log ID as nonce_min, the exec will fail.
     ensure!(
         work_claim.nonce_min.log == log_id,
-        "Receipt has a log ID that does not match the reward address: receipt: {:x}, work log: {:x}",
+        "Receipt has a log ID that does not match the work log: receipt: {:x}, work log: {:x}",
         work_claim.nonce_min.log,
         log_id
     );
 
     ensure!(
         work_claim.nonce_max.log == log_id,
-        "Receipt has a log ID that does not match the reward address: receipt: {:x}, work log: {:x}",
+        "Receipt has a log ID that does not match the work log: receipt: {:x}, work log: {:x}",
         work_claim.nonce_max.log,
         log_id
     );


### PR DESCRIPTION
Adding the `check_work_receipt` sanity check, which was removed in the CLI refactor should be sufficient, but I noticed there were some other sanity checks that did not match upstream r0 so I added those to future proof in case those others could be hit in the future in some case.