### PR TITLE
BM-1869: fix bento debug build (clap) and pass through env

### DIFF
--- a/bento/crates/workflow/src/lib.rs
+++ b/bento/crates/workflow/src/lib.rs
@@ -163,11 +163,11 @@ pub struct Args {
     cleanup_poll_interval: u64,
 
     /// Disable cron to clean up completed jobs in taskdb.
-    #[clap(env = "BENTO_DISABLE_COMPLETED_CLEANUP")]
+    #[clap(long, env = "BENTO_DISABLE_COMPLETED_CLEANUP")]
     disable_completed_cleanup: bool,
 
     /// Disable cron to clean up stuck tasks in taskdb.
-    #[clap(env = "BENTO_DISABLE_STUCK_TASK_CLEANUP")]
+    #[clap(long, env = "BENTO_DISABLE_STUCK_TASK_CLEANUP")]
     disable_stuck_task_cleanup: bool,
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,7 @@ x-agent-common: &agent-common
     context: .
     dockerfile: ${AGENT_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.0/bento-bundle-linux-amd64.tar.gz}
+      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.1/bento-bundle-linux-amd64.tar.gz}
   restart: always
   depends_on:
     postgres:
@@ -74,7 +74,7 @@ x-broker-common: &broker-common
     context: .
     dockerfile: ${BROKER_DOCKERFILE:-dockerfiles/broker.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.1.0/broker}
+      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.1.1/broker}
   mem_limit: 2G
   cpus: 2
   stop_grace_period: 3h
@@ -180,6 +180,10 @@ services:
       <<: *base-environment
       # Default to 4 max client connections if not set (work, poll for requeue, completed cleanup, stuck tasks cleanup)
       DB_MAX_CONNECTIONS: ${DB_MAX_CONNECTIONS:-4}
+      CLEANUP_POLL_INTERVAL:
+      STUCK_TASKS_POLL_INTERVAL:
+      BENTO_DISABLE_COMPLETED_CLEANUP:
+      BENTO_DISABLE_STUCK_TASK_CLEANUP:
 
     entrypoint: /app/agent -t aux --monitor-requeue --redis-ttl ${REDIS_TTL:-57600}
 
@@ -204,7 +208,7 @@ services:
       context: .
       dockerfile: ${REST_API_DOCKERFILE:-dockerfiles/rest_api.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.0/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.1/bento-bundle-linux-amd64.tar.gz}
     restart: always
     depends_on:
       postgres:
@@ -270,7 +274,7 @@ services:
       context: .
       dockerfile: ${BENTO_CLI_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.0/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.1.1/bento-bundle-linux-amd64.tar.gz}
     restart: always
     depends_on:
       rest_api:


### PR DESCRIPTION
- Fixes debug build of bento (clap is finnicky and for some reason only runtime errors in debug mode with this)
- Pass through env vars relating to cleanup from host in compose
- bumps version of prebuilts to 1.1.1 to match latest (this is tedious)