### PR TITLE
BM-1911: Increase packer retries for regular base AMI

### DIFF
--- a/infra/packer/bento.pkr.hcl
+++ b/infra/packer/bento.pkr.hcl
@@ -52,6 +52,12 @@ source "amazon-ebs" "boundless" {
   }
   ssh_username = "ubuntu"
 
+  # Increase wait time for AMI to be ready
+  aws_polling {
+    delay_seconds = 30
+    max_attempts  = 1200
+  }
+
   # Increase root volume size to 100GB
   launch_block_device_mappings {
     device_name = "/dev/sda1"


### PR DESCRIPTION
This mirrors the setting for the nightly AMI, which allows for substantially more attempts than the default 40, in an effort to prevent AMI creation failures.