### PR TITLE
BM-2022: retry lock transactions under same nonce with bumped fees

### DIFF
--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -61,9 +61,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 utoipa = { workspace = true }
 
-[build-dependencies]
-serde_json = { workspace = true }
-
 [dev-dependencies]
 boundless-test-utils = { workspace = true }
-tracing-test = { workspace = true }
+tracing-test = { workspace = true, features = ["no-env-filter"] }
+
+[build-dependencies]
+serde_json = { workspace = true }

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -330,7 +330,7 @@ pub struct MarketConf {
     /// Maximum number of retry attempts for lock transactions (including initial attempt)
     ///
     /// When a lock transaction times out, it will be retried with the same nonce for better RBF handling.
-    /// Defaults to 2 (1 initial attempt + 1 retry).
+    /// Defaults to 3 (1 initial attempt + 2 retries).
     #[serde(default = "defaults::max_lock_retry_attempts")]
     pub max_lock_retry_attempts: u32,
 

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -73,6 +73,10 @@ mod defaults {
         2
     }
 
+    pub const fn max_lock_retry_attempts() -> u32 {
+        2
+    }
+
     pub const fn reaper_interval_secs() -> u32 {
         60
     }
@@ -172,7 +176,7 @@ mod defaults {
     }
 
     pub const fn txn_timeout() -> u64 {
-        45
+        30
     }
 
     pub const fn single_txn_fulfill() -> bool {
@@ -323,6 +327,12 @@ pub struct MarketConf {
     /// `gas_priority_mode = { custom = { base_fee_multiplier_percentage = 300, priority_fee_multiplier_percentage = 150, priority_fee_percentile = 15.0, dynamic_multiplier_percentage = 5 } }`.
     #[serde(default = "defaults::priority_mode")]
     pub gas_priority_mode: PriorityMode,
+    /// Maximum number of retry attempts for lock transactions (including initial attempt)
+    ///
+    /// When a lock transaction times out, it will be retried with the same nonce for better RBF handling.
+    /// Defaults to 2 (1 initial attempt + 1 retry).
+    #[serde(default = "defaults::max_lock_retry_attempts")]
+    pub max_lock_retry_attempts: u32,
 
     /// DEPRECATED: lockRequest priority gas
     ///
@@ -446,6 +456,7 @@ impl Default for MarketConf {
             allow_client_addresses: None,
             deny_requestor_addresses: None,
             gas_priority_mode: defaults::priority_mode(),
+            max_lock_retry_attempts: defaults::max_lock_retry_attempts(),
             lockin_priority_gas: None,
             max_file_size: defaults::max_file_size(),
             max_fetch_retries: Some(2),

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -74,7 +74,7 @@ mod defaults {
     }
 
     pub const fn max_lock_retry_attempts() -> u32 {
-        2
+        3
     }
 
     pub const fn reaper_interval_secs() -> u32 {

--- a/crates/broker/src/order_monitor.rs
+++ b/crates/broker/src/order_monitor.rs
@@ -249,65 +249,75 @@ where
             return Err(OrderMonitorErr::AlreadyLocked);
         }
 
-        tracing::info!(
-            "Locking request: 0x{:x} for stake: {}",
-            request_id,
-            order.request.offer.lockCollateral
-        );
-        let lock_block =
-            self.market.lock_request(&order.request, order.client_sig.clone()).await.map_err(
-                |e| -> OrderMonitorErr {
-                    match e {
-                        MarketError::TxnError(txn_err) => match txn_err {
-                            TxnErr::BoundlessMarketErr(
-                                IBoundlessMarketErrors::RequestIsLocked(_),
-                            ) => OrderMonitorErr::AlreadyLocked,
-                            _ => OrderMonitorErr::LockTxFailed(txn_err.to_string()),
-                        },
-                        MarketError::RequestAlreadyLocked(_e) => OrderMonitorErr::AlreadyLocked,
-                        MarketError::TxnConfirmationError(e) => {
-                            OrderMonitorErr::LockTxNotConfirmed(e.to_string())
+        let max_lock_retry_attempts = {
+            let config =
+                self.config.lock_all().map_err(|e| OrderMonitorErr::UnexpectedError(e.into()))?;
+            config.market.max_lock_retry_attempts
+        };
+
+        // Attempt to lock with automatic retry on timeout
+        let lock_block = self
+            .market
+            .lock_request_with_retry(
+                &order.request,
+                order.client_sig.clone(),
+                max_lock_retry_attempts,
+            )
+            .await
+            .map_err(|e| -> OrderMonitorErr {
+                match e {
+                    MarketError::TxnError(txn_err) => match txn_err {
+                        TxnErr::BoundlessMarketErr(IBoundlessMarketErrors::RequestIsLocked(_)) => {
+                            OrderMonitorErr::AlreadyLocked
                         }
-                        MarketError::LockRevert(e) => {
-                            // Note: lock revert could be for any number of reasons;
-                            // 1/ someone may have locked in the block before us,
-                            // 2/ the lock may have expired,
-                            // 3/ the request may have been fulfilled,
-                            // 4/ the requestor may have withdrawn their funds
-                            // Currently we don't have a way to determine the cause of the revert.
-                            OrderMonitorErr::LockTxFailed(format!("Tx hash 0x{e:x}"))
-                        }
-                        MarketError::Error(e) => {
-                            // Insufficient balance error is thrown both when the requestor has insufficient balance,
-                            // Requestor having insufficient balance can happen and is out of our control. The prover
-                            // having insufficient balance is unexpected as we should have checked for that before
-                            // committing to locking the order.
-                            let prover_addr_str =
-                                self.prover_addr.to_string().to_lowercase().replace("0x", "");
-                            if e.to_string().contains("InsufficientBalance") {
-                                if e.to_string().to_lowercase().contains(&prover_addr_str) {
-                                    OrderMonitorErr::InsufficientBalance
-                                } else {
-                                    OrderMonitorErr::LockTxFailed(format!(
-                                        "Requestor has insufficient balance at lock time: {e}"
-                                    ))
-                                }
-                            } else if e.to_string().contains("RequestIsLocked") {
-                                OrderMonitorErr::AlreadyLocked
+                        _ => OrderMonitorErr::LockTxFailed(txn_err.to_string()),
+                    },
+                    MarketError::RequestAlreadyLocked(_e) => OrderMonitorErr::AlreadyLocked,
+                    MarketError::TxnConfirmationError(e) => {
+                        OrderMonitorErr::LockTxNotConfirmed(e.to_string())
+                    }
+                    MarketError::TxnTimedOut { source, .. } => {
+                        OrderMonitorErr::LockTxNotConfirmed(source.to_string())
+                    }
+                    MarketError::LockRevert(e) => {
+                        // Note: lock revert could be for any number of reasons;
+                        // 1/ someone may have locked in the block before us,
+                        // 2/ the lock may have expired,
+                        // 3/ the request may have been fulfilled,
+                        // 4/ the requestor may have withdrawn their funds
+                        // Currently we don't have a way to determine the cause of the revert.
+                        OrderMonitorErr::LockTxFailed(format!("Tx hash 0x{e:x}"))
+                    }
+                    MarketError::Error(e) => {
+                        // Insufficient balance error is thrown both when the requestor has insufficient balance,
+                        // Requestor having insufficient balance can happen and is out of our control. The prover
+                        // having insufficient balance is unexpected as we should have checked for that before
+                        // committing to locking the order.
+                        let prover_addr_str =
+                            self.prover_addr.to_string().to_lowercase().replace("0x", "");
+                        if e.to_string().contains("InsufficientBalance") {
+                            if e.to_string().to_lowercase().contains(&prover_addr_str) {
+                                OrderMonitorErr::InsufficientBalance
                             } else {
-                                OrderMonitorErr::UnexpectedError(e)
+                                OrderMonitorErr::LockTxFailed(format!(
+                                    "Requestor has insufficient balance at lock time: {e}"
+                                ))
                             }
-                        }
-                        _ => {
-                            if e.to_string().contains("RequestIsLocked") {
-                                OrderMonitorErr::AlreadyLocked
-                            } else {
-                                OrderMonitorErr::UnexpectedError(e.into())
-                            }
+                        } else if e.to_string().contains("RequestIsLocked") {
+                            OrderMonitorErr::AlreadyLocked
+                        } else {
+                            OrderMonitorErr::UnexpectedError(e)
                         }
                     }
-                },
-            )?;
+                    _ => {
+                        if e.to_string().contains("RequestIsLocked") {
+                            OrderMonitorErr::AlreadyLocked
+                        } else {
+                            OrderMonitorErr::UnexpectedError(e.into())
+                        }
+                    }
+                }
+            })?;
 
         // Fetch the block to retrieve the lock timestamp. This has been observed to return
         // inconsistent state between the receipt being available but the block not yet.

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -549,7 +549,10 @@ where
             }
         }
 
-        if let MarketError::TxnConfirmationError(_) = &err {
+        if matches!(
+            err,
+            MarketError::TxnConfirmationError(_) | MarketError::TxnTimedOut { .. }
+        ) {
             return Err(SubmitterErr::TxnConfirmationError(err));
         }
 


### PR DESCRIPTION
Draft until decided whether or not to re-use this nonce for other lock transactions. Would increase complexity to handle cases where the previous tx is locked, but perhaps prevents more locks than the config capacity