### PR TITLE
BM-1973: Conditionally create ASG instance alarms based on ASG min size

### DIFF
--- a/infra/prover-cluster/components/ManagerComponent.ts
+++ b/infra/prover-cluster/components/ManagerComponent.ts
@@ -103,6 +103,7 @@ export class ManagerComponent extends BaseComponent {
             serviceName: "bento-manager",
             logGroupName: `/boundless/bento/${config.stackName}/manager`,
             alarmDimensions: {AutoScalingGroupName: this.managerAsg.autoScalingGroup.name},
+            minAsgSize: this.managerAsg.autoScalingGroup.minSize
         });
     }
 }

--- a/infra/prover-cluster/components/MetricAlarmComponent.ts
+++ b/infra/prover-cluster/components/MetricAlarmComponent.ts
@@ -4,10 +4,11 @@ import { ChainId, Severity } from "../../util";
 import { BaseComponent, BaseComponentConfig } from "./BaseComponent";
 
 export interface MetricAlarmConfig extends BaseComponentConfig {
-    serviceName: string,
-    logGroupName: string,
+    serviceName: string;
+    logGroupName: string;
     alertsTopicArns: string[];
     alarmDimensions: { [key: string]: pulumi.Input<string> };
+    minAsgSize: pulumi.Output<number>;
 }
 
 // Creates and manages general metric filters and alarms that can be common to multiple components
@@ -206,17 +207,21 @@ export class WorkerClusterAlarmComponent extends MetricAlarmComponent {
     }
 
     private createAutoScalingGroupAlarms = (config: MetricAlarmConfig): void => {
-        this.createMetricAlarm(config, 'asg-in-service-instances', Severity.SEV2, {
-            metricName: 'GroupInServiceInstances',
-            namespace: `AWS/AutoScaling`,
-            period: 60,
-            dimensions: config.alarmDimensions,
-            evaluationPeriods: 20,
-            datapointsToAlarm: 20,
-            statistic: 'Maximum',
-            threshold: 0,
-            comparisonOperator: 'LessThanOrEqualToThreshold'
-        }, 'Number of in service instances is 0 for 20 consecutive minutes.')
+        config.minAsgSize.apply((size => {
+            if (size > 0) {
+                this.createMetricAlarm(config, 'asg-in-service-instances', Severity.SEV2, {
+                    metricName: 'GroupInServiceInstances',
+                    namespace: `AWS/AutoScaling`,
+                    period: 60,
+                    dimensions: config.alarmDimensions,
+                    evaluationPeriods: 20,
+                    datapointsToAlarm: 20,
+                    statistic: 'Maximum',
+                    threshold: 0,
+                    comparisonOperator: 'LessThanOrEqualToThreshold'
+                }, 'Number of in service instances is 0 for 20 consecutive minutes.')
+            }
+        }));
 
         // Errors from Bento logs
 

--- a/infra/prover-cluster/components/WorkerClusterComponent.ts
+++ b/infra/prover-cluster/components/WorkerClusterComponent.ts
@@ -84,7 +84,8 @@ export class WorkerClusterComponent extends BaseComponent {
             ...config,
             serviceName: "bento-prover-cluster",
             logGroupName: `/boundless/bento/${config.stackName}/prover`,
-            alarmDimensions: { AutoScalingGroupName: this.proverAsg.autoScalingGroup.name }
+            alarmDimensions: { AutoScalingGroupName: this.proverAsg.autoScalingGroup.name },
+            minAsgSize: this.proverAsg.autoScalingGroup.minSize
         });
     }
 
@@ -116,7 +117,8 @@ export class WorkerClusterComponent extends BaseComponent {
             ...config,
             serviceName: "bento-execution-cluster",
             logGroupName: `/boundless/bento/${config.stackName}/execution`,
-            alarmDimensions: { AutoScalingGroupName: this.executionAsg.autoScalingGroup.name }
+            alarmDimensions: { AutoScalingGroupName: this.executionAsg.autoScalingGroup.name },
+            minAsgSize: this.executionAsg.autoScalingGroup.minSize
         });
     }
 
@@ -148,7 +150,8 @@ export class WorkerClusterComponent extends BaseComponent {
             ...config,
             serviceName: "bento-aux-cluster",
             logGroupName: `/boundless/bento/${config.stackName}/aux`,
-            alarmDimensions: { AutoScalingGroupName: this.auxAsg.autoScalingGroup.name }
+            alarmDimensions: { AutoScalingGroupName: this.auxAsg.autoScalingGroup.name },
+            minAsgSize: this.auxAsg.autoScalingGroup.minSize
         });
     }
 }


### PR DESCRIPTION
Only create the "in-service instances" alarm if the ASG min size is greater than 0. Fixes triggering this alarm unnecessarily for the prover cluster, which is now allowed to be empty.