### PR TITLE
BM-1985: do not create bucket unless you need to

### DIFF
--- a/bento/crates/workflow-common/src/s3.rs
+++ b/bento/crates/workflow-common/src/s3.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, bail};
 use aws_sdk_s3::{
     Client,
     config::{Builder, Credentials, Region},
+    error::ProvideErrorMetadata,
     operation::{create_bucket::CreateBucketError, head_object::HeadObjectError},
     primitives::ByteStream,
     types::CreateBucketConfiguration,


### PR DESCRIPTION
right now bento trys to creat a bucket on every invocation of the s3 client impl. :slap: that is a bad bento, stop it.