### PR TITLE
BM-1993: Update log query for prover-cluster logs

### DIFF
--- a/infra/pipelines/log-lambda/src/logQueries.ts
+++ b/infra/pipelines/log-lambda/src/logQueries.ts
@@ -13,15 +13,36 @@ ORDER BY \`@timestamp\` ASC -- Note this uses the timestamps that Cloudwatch rec
 `.trim();
 }
 
+// Based on the single-instance prover log query above
+function proverClusterQuery(logGroup: string): string {
+  // Note we have to escape two backslashes in the query string. In
+  // CW it should look like: regexp_replace(log, '\\x1b\\[[0-9;]*[mK]', '') AS msg
+  return `
+SELECT
+  \`@timestamp\`,
+  regexp_replace(
+    get_json_object(\`@message\`, '$.message'),
+    '\\\x1b\\\\[[0-9;]*[mK]',
+    ''
+  ) AS msg
+FROM \`${logGroup}\`
+--WHERE
+-- log LIKE '%order_picker%' -- Filter to services
+-- AND log LIKE '%ERROR%' -- Only see error logs
+ORDER BY \`@timestamp\` ASC -- Note this uses the timestamps that Cloudwatch received the log at, not the original timestamp
+`.trim();
+}
+
 export const SERVICE_TO_QUERY_STRING_MAPPING = (service: string, logGroup: string, metricAlarmName: string) => {
   switch (service) {
     case 'bento-prover-1':
     case 'bento-prover-2':
-    case 'bento-manager':
-    case 'bento-prover-cluster':
-    case 'bento-execution-cluster':
-    case 'bento-aux-cluster':
       return proverQuery(logGroup);
+    case 'bento-manager':
+    case 'bento-execution-cluster':
+    case 'bento-prover-cluster':
+    case 'bento-aux-cluster':
+      return proverClusterQuery(logGroup);
     case 'bonsai-prover':
       const a = `
 parse @message /Z\\s+(?<log_level>[A-Z]+)\\s+(?<service>.+?):\\s+(?<message>.+)/


### PR DESCRIPTION
Slightly different log query for prover-cluster logs that populates the @msg field correctly.