### PR TITLE
BM-2006: fix max journal bytes to not apply to claim digest match predicate

### DIFF
--- a/crates/boundless-cli/src/commands/requestor/submit.rs
+++ b/crates/boundless-cli/src/commands/requestor/submit.rs
@@ -27,7 +27,8 @@ use boundless_market::{
     storage::{fetch_url, StorageProviderConfig},
 };
 use clap::Args;
-use risc0_zkvm::{compute_image_id, default_executor, sha::Digest, ExecutorEnv, SessionInfo};
+use risc0_zkvm::sha::{Digest, Digestible};
+use risc0_zkvm::{compute_image_id, default_executor, ExecutorEnv, ReceiptClaim, SessionInfo};
 
 use crate::{
     config::{GlobalConfig, RequestorConfig},
@@ -104,7 +105,7 @@ impl RequestorSubmit {
         if !self.no_preflight {
             display.info("Running request preflight check");
             let (image_id, session_info) = execute(&request).await?;
-            let journal = session_info.journal.bytes;
+            let journal = &session_info.journal.bytes;
 
             // Verify image ID
             if let Some(claim) = &session_info.receipt_claim {
@@ -120,12 +121,15 @@ impl RequestorSubmit {
             }
             let predicate = Predicate::try_from(request.requirements.predicate.clone())?;
 
+            let expected_claim_digest = ReceiptClaim::ok(image_id, journal.clone()).digest();
             ensure!(
                 predicate.eval(&FulfillmentData::from_image_id_and_journal(image_id, journal.clone())).is_some(),
-                "Preflight failed: Predicate evaluation failed. Journal: {}, Predicate type: {:?}, Predicate data: {}",
-                hex::encode(&journal),
+                "Preflight failed: Predicate evaluation failed. Journal: {}, Predicate type: {:?}, Predicate data: {}, Expected claim digest: {}, Expected journal digest: {}",
+                hex::encode(journal),
                 request.requirements.predicate.predicateType,
-                hex::encode(&request.requirements.predicate.data)
+                hex::encode(&request.requirements.predicate.data),
+                hex::encode(expected_claim_digest),
+                hex::encode(session_info.journal.digest())
             );
 
             display.success("Preflight check passed");

--- a/crates/broker/src/order_picker.rs
+++ b/crates/broker/src/order_picker.rs
@@ -48,8 +48,8 @@ use alloy::{
 use anyhow::{Context, Result};
 use boundless_market::{
     contracts::{
-        boundless_market::BoundlessMarketService, FulfillmentData, Predicate, RequestError,
-        RequestInputType,
+        boundless_market::BoundlessMarketService, FulfillmentData, Predicate, PredicateType,
+        RequestError, RequestInputType,
     },
     selector::SupportedSelectors,
 };
@@ -788,7 +788,10 @@ where
         // ensure the journal is a size we are willing to submit on-chain
         let max_journal_bytes =
             self.config.lock_all().context("Failed to read config")?.market.max_journal_bytes;
-        if journal.len() > max_journal_bytes {
+        let order_predicate_type = order.request.requirements.predicate.predicateType;
+        if matches!(order_predicate_type, PredicateType::PrefixMatch | PredicateType::DigestMatch)
+            && journal.len() > max_journal_bytes
+        {
             return Ok(Skip {
                 reason: format!(
                     "order journal larger than set limit ({} > {})",


### PR DESCRIPTION
Also includes some more information on the requestor submit on predicate mismatch, to make it more easy to update `DigestMatch` and `ClaimDigestMatch` if incorrect from client side.