### PR TITLE
BM-2027: Fix prod testnet OG deployments

### DIFF
--- a/infra/order-generator/index.ts
+++ b/infra/order-generator/index.ts
@@ -223,7 +223,8 @@ export = () => {
   if (isDev && process.env.RANDOM_REQUESTOR_PRIVATE_KEY) {
     randomRequestorPrivateKey = pulumi.output(process.env.RANDOM_REQUESTOR_PRIVATE_KEY);
   } else {
-    randomRequestorPrivateKey = randomRequestorConfig.requireSecret('PRIVATE_KEY');
+    // We only deploy the random requestor on some networks, so we don't require private key.
+    randomRequestorPrivateKey = randomRequestorConfig.getSecret('PRIVATE_KEY');
   }
 
   if (randomRequestorPrivateKey) {


### PR DESCRIPTION
We don't deploy the random requestor to testnets in prod, but the code expects we do. This fixes by making it optional.