### PR TITLE
BM-2028: Use datasource names in grafana dashboards

### DIFF
--- a/dockerfiles/grafana/dashboards/bento.json
+++ b/dockerfiles/grafana/dashboards/bento.json
@@ -22,10 +22,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -72,10 +69,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
@@ -104,10 +98,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -154,10 +145,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
@@ -186,10 +174,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -236,10 +221,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
@@ -268,10 +250,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -318,10 +297,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
@@ -350,10 +326,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -400,10 +373,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
@@ -432,10 +402,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -513,10 +480,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
@@ -551,10 +515,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "P4F5E533AD20174AE"
-      },
+      "datasource": "postgres-taskdb",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -605,10 +566,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "grafana-postgresql-datasource",
-            "uid": "P4F5E533AD20174AE"
-          },
+          "datasource": "postgres-taskdb",
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,

--- a/dockerfiles/grafana/dashboards/broker.json
+++ b/dockerfiles/grafana/dashboards/broker.json
@@ -23,10 +23,7 @@
   "links": [],
   "panels": [
     {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "fe164ybfwsdmod"
-      },
+      "datasource": "broker-sqlite-datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -76,10 +73,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "fe164ybfwsdmod"
-          },
+          "datasource": "broker-sqlite-datasource",
           "queryText": "SELECT\n  id,\n  data->>'status' as status,\n  data->>'target_block' as target_lockin_block,\n  data->>'expire_block' as expire_block,\n  data->>'error_msg' as error_msg\nFROM orders;",
           "queryType": "table",
           "rawQueryText": "SELECT\n  id,\n  data->>'status' as status,\n  data->>'target_block' as target_lockin_block,\n  data->>'expire_block' as expire_block,\n  data->>'error_msg' as error_msg\nFROM orders;",
@@ -91,10 +85,7 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "fe164ybfwsdmod"
-      },
+      "datasource": "broker-sqlite-datasource",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -144,10 +135,7 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "fe164ybfwsdmod"
-          },
+          "datasource": "broker-sqlite-datasource",
           "queryText": "SELECT\n  id,\n  data->>'status' as status,\n  json_array_length(data->'orders') as order_count,\n  data->>'fees' as fees_wei,\n  data->>'orders', data->>'error_msg' as error_msg\nFROM batches;",
           "queryType": "table",
           "rawQueryText": "SELECT\n  id,\n  data->>'status' as status,\n  json_array_length(data->'orders') as order_count,\n  data->>'fees' as fees_wei,\n  data->>'orders', data->>'error_msg' as error_msg\nFROM batches;",


### PR DESCRIPTION
Broker datasource UID isn't found on a fresh install, perhaps it changed at some point. Referencing the data sources by name (or a dashboard variable) should avoid this.