### PR TITLE
BM-2107: env variable to set a redis memory cap for queueing more prove segments

### DIFF
--- a/.env.broker-template
+++ b/.env.broker-template
@@ -3,7 +3,7 @@
 RUST_LOG=info
 
 REDIS_HOST=redis
-REDIS_IMG=redis:7.2.5-alpine3.19
+REDIS_IMG=valkey/valkey:9.0
 
 POSTGRES_HOST=postgres
 POSTGRES_IMG=postgres:16.3-bullseye

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -37,6 +37,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -209,7 +220,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-crypto-primitives-macros",
  "ark-ec",
  "ark-ff 0.5.0",
@@ -242,7 +253,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-poly",
  "ark-serialize 0.5.0",
@@ -404,7 +415,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
@@ -1226,6 +1237,40 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.0.4",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -2717,6 +2762,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2724,7 +2772,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -4315,6 +4363,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "puffin"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,6 +4666,15 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -5035,6 +5112,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,6 +5213,22 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust_decimal"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35affe401787a9bd846712274d97654355d21b2a2c092a3139aabe31e9022282"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -5438,6 +5560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5696,6 +5824,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -6637,6 +6771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7201,6 +7341,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "byte-unit",
  "bytemuck",
  "clap",
  "deadpool-redis",

--- a/bento/Cargo.toml
+++ b/bento/Cargo.toml
@@ -22,6 +22,7 @@ aws-sdk-s3 = "1.34"                                                       # used
 bento-client = { path = "crates/bento-client" }
 bincode = "1.3.3"
 bonsai-sdk = { version = "1.4.1", features = ["non_blocking"] }
+byte-unit = "5.1"
 bytemuck = "1.16"
 clap = { version = "4.5", features = ["derive", "env"] }
 deadpool-redis = "0.15"

--- a/bento/crates/workflow/Cargo.toml
+++ b/bento/crates/workflow/Cargo.toml
@@ -22,6 +22,7 @@ cuda = ["risc0-zkvm/cuda"]
 anyhow = { workspace = true }
 bincode = { workspace = true }
 bytemuck = { workspace = true }
+byte-unit = { workspace = true }
 clap = { workspace = true, features = ["env", "derive"] }
 deadpool-redis = { workspace = true }
 hex = { workspace = true }

--- a/bento/crates/workflow/src/bin/agent.rs
+++ b/bento/crates/workflow/src/bin/agent.rs
@@ -14,7 +14,6 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
 
     let args = Args::parse();
-    let task_stream = args.task_stream.clone();
     let agent = Agent::new(args).await.context("[BENTO-AGENT-001] Failed to initialize Agent")?;
 
     sqlx::migrate!("../taskdb/migrations")

--- a/bento/crates/workflow/src/redis.rs
+++ b/bento/crates/workflow/src/redis.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 pub use deadpool_redis::{Config, Pool as RedisPool, Runtime, redis::AsyncCommands};
-use redis::{FromRedisValue, RedisResult, ToRedisArgs};
+use redis::{ErrorKind, FromRedisValue, RedisError, RedisResult, ToRedisArgs};
 use std::time::Instant;
 use workflow_common::metrics::helpers;
 
@@ -13,6 +13,72 @@ pub fn create_pool(redis_url: &str) -> Result<RedisPool> {
     Config::from_url(redis_url)
         .create_pool(Some(Runtime::Tokio1))
         .context("Failed to init redis pool")
+}
+
+/// Snapshot of redis memory usage as reported by `INFO memory`
+#[derive(Debug, Clone, Copy)]
+pub struct RedisMemoryInfo {
+    /// Total heap reported by redis in bytes
+    pub used_memory: u64,
+    /// Configured redis `maxmemory` value (0 means unlimited)
+    pub maxmemory: u64,
+    /// Host memory as reported by redis (may reflect host, not cgroup)
+    pub total_system_memory: Option<u64>,
+}
+
+/// Fetch redis memory statistics via `INFO memory` query to redis/valkey.
+pub async fn fetch_memory_info(
+    conn: &mut deadpool_redis::Connection,
+) -> RedisResult<RedisMemoryInfo> {
+    let redis_start = Instant::now();
+    let info_result: RedisResult<String> = redis::cmd("INFO").arg("memory").query_async(conn).await;
+    let elapsed = redis_start.elapsed().as_secs_f64();
+    let status = if info_result.is_ok() { "success" } else { "error" };
+    helpers::record_redis_operation("info_memory", status, elapsed);
+    let info = info_result?;
+
+    let mut used_memory = None;
+    let mut maxmemory = None;
+    let mut total_system_memory = None;
+
+    for line in info.lines() {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once(':') {
+            match key {
+                "used_memory" => used_memory = Some(parse_memory_field("used_memory", value)?),
+                "maxmemory" => maxmemory = Some(parse_memory_field("maxmemory", value)?),
+                "total_system_memory" => {
+                    total_system_memory = Some(parse_memory_field("total_system_memory", value)?)
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let used_memory = used_memory.ok_or_else(|| missing_field_err("used_memory"))?;
+    let maxmemory = maxmemory.unwrap_or(0);
+
+    Ok(RedisMemoryInfo { used_memory, maxmemory, total_system_memory })
+}
+
+fn parse_memory_field(field: &str, value: &str) -> RedisResult<u64> {
+    value.trim().parse::<u64>().map_err(|_| {
+        RedisError::from((
+            ErrorKind::TypeError,
+            "Invalid INFO memory payload",
+            format!("Failed to parse {field} from INFO memory"),
+        ))
+    })
+}
+
+fn missing_field_err(field: &str) -> RedisError {
+    RedisError::from((
+        ErrorKind::TypeError,
+        "Incomplete INFO memory payload",
+        format!("INFO memory missing {field} field"),
+    ))
 }
 
 /// Function to set a key with an optional expiry using a pipeline

--- a/compose.yml
+++ b/compose.yml
@@ -83,13 +83,13 @@ x-broker-common: &broker-common
 services:
   redis:
     hostname: ${REDIS_HOST:-redis}
-    image: ${REDIS_IMG:-redis:7.2.5-alpine3.19}
+    image: ${REDIS_IMG:-valkey/valkey:9.0}
     restart: always
     ports:
       - 6379:6379
     volumes:
-      - redis-data:/data
-    command: redis-server --maxmemory-policy allkeys-lru --save 900 1 --appendonly yes
+      - valkey-data:/data
+    command: valkey-server --maxmemory-policy allkeys-lru --save 900 1 --appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -288,7 +288,7 @@ services:
     entrypoint: /bin/bash -c "while sleep 1; do /app/bento_cli --iter-count 500000; done"
 
 volumes:
-  redis-data:
+  valkey-data:
   postgres-data:
   minio-data:
   grafana-data:

--- a/compose.yml
+++ b/compose.yml
@@ -88,7 +88,7 @@ services:
     ports:
       - 6379:6379
     volumes:
-      - valkey-data:/data
+      - redis-data:/data
     command: valkey-server --maxmemory-policy allkeys-lru --save 900 1 --appendonly yes
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -288,7 +288,7 @@ services:
     entrypoint: /bin/bash -c "while sleep 1; do /app/bento_cli --iter-count 500000; done"
 
 volumes:
-  valkey-data:
+  redis-data:
   postgres-data:
   minio-data:
   grafana-data:

--- a/compose.yml
+++ b/compose.yml
@@ -29,15 +29,6 @@ x-agent-common: &agent-common
   environment:
     <<: *base-environment
 
-x-exec-agent-common: &exec-agent-common
-  <<: *agent-common
-  mem_limit: 4G
-  cpus: 3
-  environment:
-    <<: *base-environment
-    RISC0_KECCAK_PO2: ${RISC0_KECCAK_PO2:-17}
-  entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE:-21} --redis-ttl ${REDIS_TTL:-57600}
-
 x-broker-environment: &broker-environment
   RUST_LOG: ${RUST_LOG:-info,broker=debug,boundless_market=debug}
   # RUST_BACKTRACE: 1
@@ -168,9 +159,17 @@ services:
       - minio
 
   exec_agent:
-    <<: *exec-agent-common
+    <<: *agent-common
+    mem_limit: 4G
+    cpus: 3
+    environment:
+      <<: *base-environment
+      REDIS_MEMORY_WARNING_INTERVAL:
+      REDIS_QUEUE_MEMORY_POLL_MS:
+      REDIS_MAX_QUEUE_MEMORY:
     deploy:
       replicas: 2
+    entrypoint: /app/agent -t exec --segment-po2 ${SEGMENT_SIZE:-21} --redis-ttl ${REDIS_TTL:-57600}
 
   aux_agent:
     <<: *agent-common
@@ -184,6 +183,8 @@ services:
       STUCK_TASKS_POLL_INTERVAL:
       BENTO_DISABLE_COMPLETED_CLEANUP:
       BENTO_DISABLE_STUCK_TASK_CLEANUP:
+      REDIS_MAX_QUEUE_MEMORY:
+      REDIS_MEMORY_WARNING_INTERVAL:
 
     entrypoint: /app/agent -t aux --monitor-requeue --redis-ttl ${REDIS_TTL:-57600}
 


### PR DESCRIPTION
Sets an environment variable such that when above that redis memory usage it will warn in logs and pause execution and the queueing of more segments until the memory level below the threshold again. Aims to avoid OOM issues with redis without dealing with eviction issues.

TODO:
- [ ] Consider setting a value for this in wizard based on host machine's available memory
- [ ] Probably rename env vars, being redis based might be confusing given switch to valkey