### PR TITLE
BM-2041: Justfile: Remove check-docs and check-deployments from check command

### DIFF
--- a/justfile
+++ b/justfile
@@ -81,7 +81,7 @@ test-db action="setup":
     fi
 
 # Run all formatting and linting checks
-check: check-links check-license check-format check-clippy check-docs check-deployments
+check: check-links check-license check-format check-clippy
 
 # Check links in markdown files
 check-links:


### PR DESCRIPTION
#1371 broke the justfile by forgetting to remove the check-docs and check-deployments commands when running check