### PR TITLE
BM-2083: Add CI for requestor lists

### DIFF
--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -23,15 +23,6 @@
           "estimatedMaxInputSizeMB": 1000
         }
       }
-    },
-    {
-      "address": "0x734df7809c4ef94da037449c287166d114503198",
-      "chainId": 8452,
-      "name": "SigleCountMin": 50000,
-      "estimatedMcycleCountMax": 55000,
-      "estimatedMaxInputSizeMB": 1000
     }
-  }
-}
-]
+  ]
 }


### PR DESCRIPTION
A typo in these files would go undetected before rolling out to provers. Adding basic CI to check JSON format.