### PR TITLE
BM-2103: Restrict indexer monitor from querying events from start of time. Fix queries.

### DIFF
--- a/crates/lambdas/indexer-monitor/src/handler.rs
+++ b/crates/lambdas/indexer-monitor/src/handler.rs
@@ -86,7 +86,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
     let now = Utc::now().timestamp() - METRIC_LAG_SECONDS;
     let now_str = chrono::DateTime::from_timestamp(now, 0).unwrap().to_rfc3339();
     let mut start_time = monitor.get_last_run().await.context("Failed to get last run time")?;
-    
+
     // Avoid fetching too many metrics/events from the database, by only fetching a maximum of 6 hours of data.
     // This is a safeguard to prevent the lambda from running indefinitely if the previous run time is not set,
     // or if the previous run time is more than 6 hours ago due to some sort of outage.
@@ -94,7 +94,7 @@ pub async fn function_handler(event: LambdaEvent<Event>) -> Result<(), Error> {
         debug!("Previous run time is more than {MAX_BACKFILL_HOURS} hours ago, setting to {MAX_BACKFILL_HOURS} hours ago. Some events may be missed.");
         start_time = now - SECONDS_PER_HOUR * MAX_BACKFILL_HOURS;
     }
-    
+
     let start_time_str = chrono::DateTime::from_timestamp(start_time, 0).unwrap().to_rfc3339();
 
     let mut metrics = vec![];


### PR DESCRIPTION
Currently the monitor isn't running as its attempting to query for every metric since the beginning of time. I think this happened when we wiped the database and we lost track of what metrics we'd processed.

Additionally some of the queries are using a field that doesn't exist in the fulfillment events table. Fixed this.

I think these two issues are why various alarms, e.g. Signal, are stuck in alarm state.