### PR TITLE
BM-2056: temporarily avoid unlinking keccak inputs before proof completion

### DIFF
--- a/bento/crates/workflow/src/tasks/keccak.rs
+++ b/bento/crates/workflow/src/tasks/keccak.rs
@@ -94,6 +94,7 @@ pub async fn keccak(
     tracing::debug!("Completed keccak proving {}", request.claim_digest);
 
     // TODO refactor the keccak paths/flow with a breaking change, to avoid holding value until TTL
+    //     ref: https://linear.app/boundlessnetwork/issue/BM-2056
     // // Clean up keccak input
     // let cleanup_start = Instant::now();
     // let cleanup_result = conn.unlink::<_, ()>(&keccak_input_path).await;


### PR DESCRIPTION
Related BM-2056

Non-breaking change as a small patch to fix the issue of conflicts on keccak claim digest leading to failure. Refactor is a breaking change so would come in a release that can be breaking