### PR TITLE
BM-2127: Put behind feature flag the `zkc` module of `test-utils`

### DIFF
--- a/crates/boundless-cli/Cargo.toml
+++ b/crates/boundless-cli/Cargo.toml
@@ -73,7 +73,7 @@ alloy-node-bindings = { workspace = true }
 assert_cmd = "=2.0"
 assert_fs = "1.1"
 boundless-market = { workspace = true }
-boundless-test-utils = { workspace = true, features = ["povw"] }
+boundless-test-utils = { workspace = true, features = ["povw", "zkc"] }
 order-stream = { workspace = true }
 predicates = "3.1"
 rand = { workspace = true }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -24,6 +24,7 @@ povw = [
     "dep:bincode",
     "dep:tracing",
 ]
+zkc = []
 
 [dependencies]
 alloy = { workspace = true, features = [

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -22,6 +22,7 @@ pub mod market;
 #[cfg(feature = "povw")]
 pub mod povw;
 pub mod verifier;
+#[cfg(feature = "zkc")]
 pub mod zkc;
 
 pub mod guests {


### PR DESCRIPTION
This PR put behind a feature flag the `zkc` module of the `test-utils` crates that requires solidity json artifacts to be present in a fixed path.