### PR TITLE
BM-2149: Adjust OG intervals config

### DIFF
--- a/infra/order-generator/Pulumi.l-prod-8453.yaml
+++ b/infra/order-generator/Pulumi.l-prod-8453.yaml
@@ -17,7 +17,7 @@ config:
   order-generator-base:DOCKER_TAG: latest
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:pfTxhEjN74NTG5Zk:uqeqk81UF6asWxgfbxYTzL+yhrMfY32xWCvGx+rauPVc/z1jbMHGcHMKVIWhdKuNQx3sgIL7p9C3XrFXxb9IjSv01f02I3aRsPV+OQgUQy5+AsNT9CKGUz2p3vLre+pueTXjNpDcWXzvV3YIdg==
-  order-generator-base:INTERVAL: "34"
+  order-generator-base:INTERVAL: "32"
   order-generator-base:IPFS_GATEWAY_URL: https://dweb.link
   order-generator-base:LOCK_COLLATERAL_RAW: "15000000000000000000" # 15 ZKC
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -45,7 +45,7 @@ config:
   order-generator-onchain:AUTO_DEPOSIT: "0.015"
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "1000"
-  order-generator-onchain:INTERVAL: "34"
+  order-generator-onchain:INTERVAL: "32"
   order-generator-onchain:INPUT_MAX_MCYCLES: "4000"
   order-generator-onchain:LOCK_TIMEOUT: "2100"
   order-generator-onchain:RAMP_UP: "900"


### PR DESCRIPTION
set order-generator-onchain:INTERVAL to "32" (was effectively 22 via base)
set order-generator-offchain:INTERVAL to "22" (was 14)

default: set order-generator-base:INTERVAL to "32" (just to have an explicit default)

Roughly 5T fewer cycles, with those cycles now being sent by BoB + customers