### PR TITLE
BM-2158: adjust min asg to be desired count

### DIFF
--- a/infra/prover-cluster/components/WorkerClusterComponent.ts
+++ b/infra/prover-cluster/components/WorkerClusterComponent.ts
@@ -71,7 +71,7 @@ export class WorkerClusterComponent extends BaseComponent {
             ...config,
             launchTemplateId: launchTemplate.launchTemplate.id,
             launchTemplateUserData: pulumi.output(launchTemplate.launchTemplate.userData).apply(u => u || ""),
-            minSize: 15,
+            minSize: config.proverCount < 15 ? config.proverCount : 15,
             maxSize: 100,
             desiredCapacity: config.proverCount,
             componentType: "prover",


### PR DESCRIPTION
This seems like simplest workaround, but alternatively could make these configurable per cluster. Nightly is broken without this because `desired > min`