### PR TITLE
BM-2206: Indexer- simplify cloudfront caching

### DIFF
--- a/infra/indexer/components/indexer-api.ts
+++ b/infra/indexer/components/indexer-api.ts
@@ -355,7 +355,7 @@ export class IndexerApi extends pulumi.ComponentResource {
             priority: 1,
             statement: {
               rateBasedStatement: {
-                limit: 200, // 150 requests per 5 minutes per IP
+                limit: 200, // 200 requests per 5 minutes per IP
                 aggregateKeyType: 'IP',
               },
             },


### PR DESCRIPTION
We are seeing intermittent Cloudfront errors. We are using the legacy method for defining Cloudfront caching, which supposedly can cause issues. Migrating to the latest recommend setup.