### PR TITLE
BM-2225: use aggregation_prover

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -1094,7 +1094,7 @@ where
         let submitter = Arc::new(submitter::Submitter::new(
             self.db.clone(),
             config.clone(),
-            prover.clone(),
+            aggregation_prover.clone(),
             self.provider.clone(),
             self.deployment().set_verifier_address,
             self.deployment().boundless_market_address,


### PR DESCRIPTION
https://github.com/boundless-xyz/boundless/pull/1416 introduced an `aggregation prover` that stores tasks data under a different api_key due to a higher priority; as such, when fetching the blake3Groth16 seal the query was failing due to an api_key mismatch.