### PR TITLE
BM-2226: fix batch debug log

### DIFF
--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -691,6 +691,7 @@ impl AggregatorService {
         };
 
         if compress {
+            let batch = self.db.get_batch(batch_id).await.context("Failed to get batch")?;
             tracing::debug!(
                 "Starting groth16 compression proof for batch {batch_id} with orders {:?}",
                 batch.orders


### PR DESCRIPTION
Fixes the bug that prevented the orders to populated before logging: e.g.,:

```console
Completed groth16 compression for batch 1 with orders []
```

to 

```console
Completed groth16 compression for batch 1 with orders ["0x90f79bf6eb2c4f870365e785982e1f101e93b906906cc9bd-0x1def9ed2b5cdfcb4ef011da0262ac7103f9eb8ec19b9b3d9cc99a2d3a0d72563-LockAndFulfill"]
```