### PR TITLE
BM-2245: remove solidity comments from libraries

### DIFF
--- a/contracts/scripts/BoundlessScript.s.sol
+++ b/contracts/scripts/BoundlessScript.s.sol
@@ -10,7 +10,6 @@ import {Script, console2} from "forge-std/Script.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {ConfigLoader, DeploymentConfig} from "./Config.s.sol";
 
-/// @notice Shared library for Boundless deployment and management scripts
 library BoundlessScript {
     /// @notice Validates that an address value is not zero, with descriptive error message
     function requireLib(address value, string memory label) internal pure returns (address) {

--- a/contracts/src/config/VerifierConfig.sol
+++ b/contracts/src/config/VerifierConfig.sol
@@ -71,8 +71,6 @@ library DeploymentLib {
     }
 }
 
-/// @notice Loader for the deployment config from a given deployment.toml file.
-/// @dev This library uses Forge cheat code and can only be used in Forge script or test environments.
 library ConfigLoader {
     /// Reference the vm address without needing to inherit from Script.
     Vm private constant VM = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
@@ -117,8 +115,6 @@ library ConfigLoader {
     }
 }
 
-/// @notice Parser for the deployment config given a TOML string.
-/// @dev This library uses Forge cheat code and can only be used in Forge script or test environments.
 library ConfigParser {
     using SafeCast for uint256;
 

--- a/contracts/src/types/FulfillmentContext.sol
+++ b/contracts/src/types/FulfillmentContext.sol
@@ -18,9 +18,6 @@ struct FulfillmentContext {
     uint96 price;
 }
 
-/// @title FulfillmentContextLibrary
-/// @notice Library for packing, unpacking, and storing FulfillmentContext structs
-/// @dev Uses bit manipulation to pack all fields into a single uint256 for transient storage
 library FulfillmentContextLibrary {
     uint256 private constant VALID_MASK = 1 << 127;
     uint256 private constant EXPIRED_MASK = 1 << 126;

--- a/crates/boundless-market/src/contracts/artifacts/FulfillmentContext.sol
+++ b/crates/boundless-market/src/contracts/artifacts/FulfillmentContext.sol
@@ -18,9 +18,6 @@ struct FulfillmentContext {
     uint96 price;
 }
 
-/// @title FulfillmentContextLibrary
-/// @notice Library for packing, unpacking, and storing FulfillmentContext structs
-/// @dev Uses bit manipulation to pack all fields into a single uint256 for transient storage
 library FulfillmentContextLibrary {
     uint256 private constant VALID_MASK = 1 << 127;
     uint256 private constant EXPIRED_MASK = 1 << 126;


### PR DESCRIPTION
Closes #715
Closes #1317

Removes doc comments from solidity libraries as it causes issues with alloy parsing depending on ordering. `FulfillmentContextLibrary` should be the only one needed, but removed others to avoid issues in the future.

Couldn't ever reproduce, so perhaps was specific solidity compiler version(s) or something hardware specific.