### PR TITLE
BM-2259: fix docker compose and infra parsing of RPC_URL variables with ansible

### DIFF
--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -70,6 +70,7 @@ This Ansible role deploys the Boundless prover stack using Docker Compose as a s
 | ------------------------ | ------------ | --------------------------- |
 | `prover_private_key`     | `""`         | Prover wallet private key   |
 | `prover_rpc_url`         | `""`         | RPC URL for blockchain      |
+| `prover_rpc_urls`        | `""`         | Comma-separated RPC URLs    |
 | `prover_povw_log_id`     | `""`         | POVW log contract address   |
 | `prover_broker_toml_url` | (GitHub URL) | URL to broker.toml template |
 

--- a/ansible/roles/prover/defaults/main.yml
+++ b/ansible/roles/prover/defaults/main.yml
@@ -50,6 +50,7 @@ prover_binary_url: "https://github.com/boundless-xyz/boundless/releases/download
 # Broker configuration (if enabled)
 prover_private_key: ""
 prover_rpc_url: ""
+prover_rpc_urls: ""
 prover_povw_log_id: ""
 
 # Broker configuration URL

--- a/ansible/roles/prover/templates/docker-compose.env.j2
+++ b/ansible/roles/prover/templates/docker-compose.env.j2
@@ -41,7 +41,9 @@ PROVER_PRIVATE_KEY={{ prover_private_key }}
 {% if prover_povw_log_id is defined and prover_povw_log_id | string | length > 0 %}
 POVW_LOG_ID={{ prover_povw_log_id }}
 {% endif %}
+{% if prover_rpc_url is defined and prover_rpc_url | string | length > 0 %}
+PROVER_RPC_URL={{ prover_rpc_url }}
+{% endif %}
 {% if prover_rpc_urls is defined and prover_rpc_urls | string | length > 0 %}
 PROVER_RPC_URLS={{ prover_rpc_urls }}
 {% endif %}
-

--- a/compose.yml
+++ b/compose.yml
@@ -52,7 +52,7 @@ x-exec-agent-common: &exec-agent-common
     [
       "/bin/sh",
       "-c",
-      "/app/agent -t exec --segment-po2 $SEGMENT_SIZE --redis-ttl $REDIS_TTL",
+      "/app/agent -t exec --segment-po2 $$SEGMENT_SIZE --redis-ttl $$REDIS_TTL",
     ]
 
 x-broker-environment: &broker-environment
@@ -219,16 +219,16 @@ services:
       <<: *base-environment
       # Default to 4 max client connections if not set (work, poll for requeue, completed cleanup, stuck tasks cleanup)
       DB_MAX_CONNECTIONS: ${DB_MAX_CONNECTIONS:-4}
-      CLEANUP_POLL_INTERVAL: ${CLEANUP_POLL_INTERVAL:-}
-      STUCK_TASKS_POLL_INTERVAL: ${STUCK_TASKS_POLL_INTERVAL:-}
-      BENTO_DISABLE_COMPLETED_CLEANUP: ${BENTO_DISABLE_COMPLETED_CLEANUP:-}
-      BENTO_DISABLE_STUCK_TASK_CLEANUP: ${BENTO_DISABLE_STUCK_TASK_CLEANUP:-}
+      CLEANUP_POLL_INTERVAL:
+      STUCK_TASKS_POLL_INTERVAL:
+      BENTO_DISABLE_COMPLETED_CLEANUP:
+      BENTO_DISABLE_STUCK_TASK_CLEANUP:
       REDIS_TTL: ${REDIS_TTL:-57600}
     entrypoint:
       [
         "/bin/sh",
         "-c",
-        "/app/agent -t aux --monitor-requeue --redis-ttl $REDIS_TTL",
+        "/app/agent -t aux --monitor-requeue --redis-ttl $$REDIS_TTL",
       ]
 
   # GPU Prover Agent - automatically detects and uses all available GPUs


### PR DESCRIPTION
#1432 broke the compose file so fix to that, and then adding support for URL/URLS where one of each was missing from ansible compose env and defaults respectively.