### PR TITLE
BM-2271: backport #1416, #1477 to 1.2

### DIFF
--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Boundless Foundation, Inc.
+// Copyright 2026 Boundless Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +103,10 @@ mod defaults {
         Some(vec![
             "https://requestors.boundless.network/boundless-recommended-priority-list.standard.json".to_string()
         ])
+    }
+
+    pub fn allow_requestor_lists() -> Option<Vec<String>> {
+        None
     }
 
     pub const fn max_mcycle_limit() -> u64 {
@@ -311,6 +315,11 @@ pub struct MarketConf {
     ///
     /// If enabled, all requests from clients not in the allow list are skipped.
     pub allow_client_addresses: Option<Vec<Address>>,
+    /// Optional URLs to fetch requestor allow lists from.
+    ///
+    /// These lists will be periodically refreshed and merged with allow_client_addresses.
+    #[serde(default = "defaults::allow_requestor_lists")]
+    pub allow_requestor_lists: Option<Vec<String>>,
     /// Optional deny list for requestor address.
     ///
     /// If enabled, all requests from clients in the deny list are skipped.
@@ -440,6 +449,7 @@ impl Default for MarketConf {
             min_mcycle_limit: defaults::min_mcycle_limit(),
             priority_requestor_addresses: None,
             priority_requestor_lists: defaults::priority_requestor_lists(),
+            allow_requestor_lists: defaults::allow_requestor_lists(),
             max_journal_bytes: defaults::max_journal_bytes(),
             peak_prove_khz: None,
             min_deadline: defaults::min_deadline(),

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Boundless Foundation, Inc.
+// Copyright 2026 Boundless Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -490,6 +490,7 @@ pub struct Broker<P> {
     db: DbObj,
     config_watcher: ConfigWatcher,
     priority_requestors: requestor_monitor::PriorityRequestors,
+    allow_requestors: requestor_monitor::AllowRequestors,
     gas_priority_mode: Arc<tokio::sync::RwLock<PriorityMode>>,
 }
 
@@ -524,6 +525,8 @@ where
 
         let priority_requestors =
             requestor_monitor::PriorityRequestors::new(config_watcher.config.clone(), chain_id);
+        let allow_requestors =
+            requestor_monitor::AllowRequestors::new(config_watcher.config.clone(), chain_id);
 
         Ok(Self {
             args,
@@ -531,6 +534,7 @@ where
             provider: Arc::new(provider),
             config_watcher,
             priority_requestors,
+            allow_requestors,
             gas_priority_mode,
         })
     }
@@ -967,6 +971,7 @@ where
             collateral_token_decimals,
             order_state_tx.clone(),
             self.priority_requestors.clone(),
+            self.allow_requestors.clone(),
         ));
         let cloned_config = config.clone();
         let cancel_token = non_critical_cancel_token.clone();
@@ -1071,9 +1076,11 @@ where
             Ok(())
         });
 
-        // Start the RequestorMonitor to periodically fetch priority lists
-        let requestor_monitor =
-            Arc::new(requestor_monitor::RequestorMonitor::new(self.priority_requestors.clone()));
+        // Start the RequestorMonitor to periodically fetch priority and allow lists
+        let requestor_monitor = Arc::new(requestor_monitor::RequestorMonitor::new(
+            self.priority_requestors.clone(),
+            self.allow_requestors.clone(),
+        ));
         let config_clone = config.clone();
         let non_critical_cancel_token_clone = non_critical_cancel_token.clone();
         non_critical_tasks.spawn(async move {

--- a/crates/requestor-lists/src/lib.rs
+++ b/crates/requestor-lists/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Boundless Foundation, Inc.
+// Copyright 2026 Boundless Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -333,6 +333,14 @@ mod tests {
         assert_eq!(list.name, "Boundless Recommended Priority List for Large Provers");
         assert!(!list.requestors.is_empty());
         assert!(list.requestors[0].description.is_some());
+    }
+
+    #[test]
+    fn test_parse_allowed_list_example() {
+        let json = include_str!("../../../requestor-lists/boundless-allowed-list.json");
+        let list = RequestorList::from_json(json).unwrap();
+        assert_eq!(list.name, "Boundless Allowed List");
+        assert!(!list.requestors.is_empty());
     }
 
     #[test]

--- a/crates/requestor-lists/tests/parse_example_list.rs
+++ b/crates/requestor-lists/tests/parse_example_list.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Boundless Foundation, Inc.
+// Copyright 2026 Boundless Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,23 @@ fn test_parse_boundless_recommended_list() {
     assert_eq!(
         list.description,
         "List of recommended priority requestors for provers. The request sizes here should be suitable for most provers."
+    );
+    assert_eq!(list.schema_version.major, 1);
+    assert_eq!(list.schema_version.minor, 0);
+    assert_eq!(list.version.major, 1);
+    assert_eq!(list.version.minor, 0);
+    assert!(!list.requestors.is_empty());
+}
+
+#[test]
+fn test_parse_boundless_allowed_list() {
+    let json = include_str!("../../../requestor-lists/boundless-allowed-list.json");
+    let list = RequestorList::from_json(json).expect("Failed to parse list");
+
+    assert_eq!(list.name, "Boundless Allowed List");
+    assert_eq!(
+        list.description,
+        "List of requestors that are allowed to submit requests. If this list is configured, only requestors in this list will be accepted. NOTE: This file is for internal Boundless usage only. External provers should just use the priority lists (boundless-priority-list.*.json) in this directory instead."
     );
     assert_eq!(list.schema_version.major, 1);
     assert_eq!(list.schema_version.minor, 0);

--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -1,0 +1,134 @@
+{
+  "name": "Boundless Allowed List",
+  "description": "List of requestors that are allowed to submit requests. If this list is configured, only requestors in this list will be accepted. NOTE: This file is for internal Boundless usage only. External provers should just use the priority lists (boundless-priority-list.*.json) in this directory instead.",
+  "schemaVersion": {
+    "major": 1,
+    "minor": 0
+  },
+  "version": {
+    "major": 1,
+    "minor": 0
+  },
+  "requestors": [
+    {
+      "address": "0x067D62CBCC72bBb02358cEB85aBE817249AB616b",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0xa6e98d0ba0ca584509ebcbe00bb36f0c5cfcdd1b",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x418be9167e835ad820df53fd16b8fe02f796ce1c",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Acai)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0xda824d974d8bac25a0611b7ab5f091d22f63a234",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x3d089c2f2cb86d4efde153c81cabd4579784430b",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x323ec32ef13716bfdc3e0b2a96d7bd7cbcb9d57b",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Marionberry)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x2D611BE1e2E49C7b639A88b507b532DaE35e492b",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Lingonberry #2)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0xb59bb74fa0c1611eF6A4989a92C0d3ca6942fC0c",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Lingonberry #1)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x1578934C9B006B9568D884C421704d996D402B78",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x7276fa3c23c1783bdcb97258717f8f32b75919c9",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Cranberries)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0xb686f080c2c7045d13d196787c99bc9972480fd3",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Strawberry)",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x0d4b7e56a3d78af33a969938724656c886543444",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x40a86041f44443Ad137B0F89E3F852Ae588fac42",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x787134c5461170dd0743f97beb4a322b179babc2",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    }
+  ]
+}


### PR DESCRIPTION
https://github.com/boundless-xyz/boundless/pull/1416 introduced an `aggregation prover` that stores tasks data under a different api_key due to a higher priority; as such, when fetching the blake3Groth16 seal the query was failing due to an api_key mismatch.