### PR TITLE
BM-2274: Remove concurrency settings from ansible.yml

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -32,9 +32,6 @@ on:
         required: false
         default: 'production'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Removed concurrency settings from the Ansible workflow.