### PR TITLE
BM-2276: Fix indexer API IP set to be CIDR. Add missing log group tags

### DIFF
--- a/infra/indexer/Pulumi.l-prod-8453.yaml
+++ b/infra/indexer/Pulumi.l-prod-8453.yaml
@@ -31,4 +31,4 @@ config:
   indexer:PROXY_SECRET:
     secure: v1:lJlgu7dJjEdBpg+J:49guE+TSvKTHVlf/LXakKarxpItokDS83AbT1XKJ2nAme8PrEX0Gcg==
   indexer:ALLOWED_IP_ADDRESSES:
-    secure: v1:R2J/3qxRjR2vmJfH:MZcuH1zLSlx3l1hQ5G2HFnOQZB14tiYMZOWWabM=
+    secure: v1:A5Mdx/awHcbvku4U:xbYCVcJVzRrHibChfMILD8Zeb+G9g6qNiTZMoZkR/OU=


### PR DESCRIPTION
The WAF IP sets need CIDR notation for IPs. Updated the config to store allowed ip addresses in CIDR. Also adding some missing tags to our alarms to enable one-click debugging for them in Slack.