### PR TITLE
BM-2305: Gate `latency_mode()` behind unstable feature flag

### DIFF
--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -18,6 +18,8 @@ blake3-groth16 = [
     "dep:risc0-circuit-recursion"
 ]
 default = []
+unstable = ["unstable-latency-mode"]
+unstable-latency-mode = []
 test-utils = []
 
 [dependencies]

--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -449,14 +449,15 @@ impl<St, Si> ClientBuilder<St, Si> {
     /// The parameterization mode is used to define the offering parameters for the request.
     /// The fulfillment parameterization mode is [ParameterizationMode::fulfillment()], which is the default.
     /// The latency parameterization mode is [ParameterizationMode::latency()], which is faster and allows for faster fulfillment,
-    /// at the cost of higher prices and lower fulfillment guarantees.
+    /// at the cost of higher prices and lower fulfillment guarantees (requires `unstable` or `unstable-latency-mode` feature).
     ///
     /// # Example
     /// ```rust
     /// # use boundless_market::Client;
-    /// use boundless_market::request_builder::ParameterizationMode;
-    ///
-    /// Client::builder().with_parameterization_mode(ParameterizationMode::latency());
+    /// # use boundless_market::request_builder::ParameterizationMode;
+    /// Client::builder().with_parameterization_mode(ParameterizationMode::fulfillment());
+    /// # #[cfg(feature = "unstable-latency-mode")]
+    /// # Client::builder().with_parameterization_mode(ParameterizationMode::latency());
     /// ```
     pub fn with_parameterization_mode(self, parameterization_mode: ParameterizationMode) -> Self {
         self.config_offer_layer(|config| config.parameterization_mode(parameterization_mode))

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -132,17 +132,16 @@ pub struct OfferLayerConfig {
     ///
     /// Defines the offering parameters for the request based on the mode:
     /// - [ParameterizationMode::fulfillment] is a more conservative mode that ensures more provers can fulfill the request.
-    /// - [ParameterizationMode::latency] is a more aggressive mode that allows for faster fulfillment at the cost of higher prices and lower fulfillment guarantees.
+    /// - [ParameterizationMode::latency] is a more aggressive mode that allows for faster fulfillment at the cost of higher prices and lower fulfillment guarantees (requires `unstable` or `unstable-latency-mode` feature).
     ///
     /// The default is [ParameterizationMode::fulfillment()], which is the default fulfillment mode.
     ///
     /// # Example
     /// ```rust
     /// # use boundless_market::request_builder::{OfferLayerConfig, ParameterizationMode};
-    /// use boundless_market::request_builder::ParameterizationMode;
-    ///
-    /// OfferLayerConfig::builder().parameterization_mode(ParameterizationMode::latency());
     /// OfferLayerConfig::builder().parameterization_mode(ParameterizationMode::fulfillment());
+    /// # #[cfg(feature = "unstable-latency-mode")]
+    /// # OfferLayerConfig::builder().parameterization_mode(ParameterizationMode::latency());
     /// ```
     #[builder(setter(into), default = "Some(ParameterizationMode::fulfillment())")]
     pub parameterization_mode: Option<ParameterizationMode>,


### PR DESCRIPTION
As this mode is highly experimental and not yet fully optimized this PR gates it behind the `unstable` or `unstable-latency-mode` feature flag