### PR TITLE
BM-2322: Extend deployment role to 2 hours session length

### DIFF
--- a/infra/bootstrap/index.ts
+++ b/infra/bootstrap/index.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as vpc from './lib/vpc';
-import { getEnvVar } from '../util';
+import { getEnvVar, DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS } from '../util';
 
 const OPS_ACCOUNT_PIPELINE_ROLE_ARN = "arn:aws:iam::968153779208:role/pipeline-role-3b97f1a";
 const OPS_ACCOUNT_LOG_LAMBDA_ROLE_ARN = "arn:aws:iam::968153779208:role/chatbot-log-fetcher-role-4d93cb1"
@@ -26,6 +26,7 @@ export = async () => {
         }
       ]
     }),
+    maxSessionDuration: DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS,
     managedPolicyArns: [
       aws.iam.ManagedPolicies.AdministratorAccess
     ]

--- a/infra/pipelines/pipelines/base/LaunchDefaultPipeline.ts
+++ b/infra/pipelines/pipelines/base/LaunchDefaultPipeline.ts
@@ -1,6 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN } from "../../accountConstants";
+import { DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS } from "../../../util";
 import { BasePipelineArgs } from "./BasePipelineArgs";
 import { LaunchBasePipeline, LaunchPipelineConfig } from "./LaunchBasePipeline";
 
@@ -210,7 +211,7 @@ ${postBuildCommands.map(cmd => `          - ${cmd}`).join('\n')}`
       pre_build:
         commands:
           - echo Assuming role $DEPLOYMENT_ROLE_ARN
-          - ASSUMED_ROLE=$(aws sts assume-role --role-arn $DEPLOYMENT_ROLE_ARN --role-session-name Deployment --output text | tail -1)
+          - ASSUMED_ROLE=$(aws sts assume-role --role-arn $DEPLOYMENT_ROLE_ARN --duration-seconds ${DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS} --role-session-name Deployment --output text | tail -1)
           - export AWS_ACCESS_KEY_ID=$(echo $ASSUMED_ROLE | awk '{print $2}')
           - export AWS_SECRET_ACCESS_KEY=$(echo $ASSUMED_ROLE | awk '{print $4}')
           - export AWS_SESSION_TOKEN=$(echo $ASSUMED_ROLE | awk '{print $5}')

--- a/infra/pipelines/pipelines/prover-cluster.ts
+++ b/infra/pipelines/pipelines/prover-cluster.ts
@@ -2,6 +2,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { BasePipelineArgs } from "./base";
 import { BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN } from "../accountConstants";
+import { DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS } from "../../util";
 
 interface ProverClusterPipelineArgs extends BasePipelineArgs {
     stagingAccountId: string;
@@ -29,7 +30,7 @@ env:
 phases:
   pre_build:
     commands:
-      - ASSUMED_ROLE=$(aws sts assume-role --role-arn $DEPLOYMENT_ROLE_ARN --role-session-name ProverClusterDeployment --output text | tail -1)
+      - ASSUMED_ROLE=$(aws sts assume-role --role-arn $DEPLOYMENT_ROLE_ARN --duration-seconds ${DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS} --role-session-name ProverClusterDeployment --output text | tail -1)
       - export AWS_ACCESS_KEY_ID=$(echo $ASSUMED_ROLE | awk '{print $2}')
       - export AWS_SECRET_ACCESS_KEY=$(echo $ASSUMED_ROLE | awk '{print $4}')
       - export AWS_SESSION_TOKEN=$(echo $ASSUMED_ROLE | awk '{print $5}')

--- a/infra/util/index.ts
+++ b/infra/util/index.ts
@@ -69,3 +69,5 @@ export enum Severity {
   SEV1 = 'SEV1',
   SEV2 = 'SEV2',
 }
+
+export const DEPLOYMENT_ROLE_MAX_SESSION_DURATION_SECONDS = 7200;


### PR DESCRIPTION
Occasionally deployments take longer than an hour. Currently this causes the role session to expire and the deployment to fail.