### PR TITLE
BM-2351: reduce pub visibility of secondary

### DIFF
--- a/crates/boundless-cli/src/commands/requestor/submit.rs
+++ b/crates/boundless-cli/src/commands/requestor/submit.rs
@@ -64,10 +64,10 @@ impl RequestorSubmit {
         let client = requestor_config
             .client_builder_with_signer(global_config.tx_timeout)?
             .with_storage_provider_config(&self.storage_config)?
+            .with_skip_preflight(self.no_preflight)
             .build()
             .await
-            .context("Failed to build Boundless Client")?
-            .with_skip_preflight(self.no_preflight);
+            .context("Failed to build Boundless Client")?;
 
         let network_name = network_name_from_chain_id(client.deployment.market_chain_id);
         let display = DisplayManager::with_network(network_name);

--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -750,12 +750,7 @@ pub type StandardClient = Client<
 >;
 
 impl<P, St, Si> Client<P, St, StandardRequestBuilder<P, St>, Si> {
-    /// Set whether to skip preflight/pricing checks on the request builder.
-    ///
-    /// If `true`, preflight checks are skipped.
-    /// If `false`, preflight checks are run.
-    /// If not called, falls back to checking the `BOUNDLESS_IGNORE_PREFLIGHT` environment variable.
-    pub fn with_skip_preflight(mut self, skip: bool) -> Self {
+    fn with_skip_preflight(mut self, skip: bool) -> Self {
         if let Some(ref mut builder) = self.request_builder {
             builder.skip_preflight = Some(skip);
         }


### PR DESCRIPTION
With #1570, would be confusing to have methods exposed from both. This keeps the API surface smaller.