### PR TITLE
BM-2352: Revert skipping preflight on order generator

### DIFF
--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -175,8 +175,7 @@ async fn run(args: &MainArgs) -> Result<()> {
         .with_private_key(args.private_key.clone())
         .with_balance_alerts(balance_alerts)
         .with_timeout(Some(Duration::from_secs(args.tx_timeout)))
-        .with_funding_mode(FundingMode::BelowThreshold(parse_ether("0.01").unwrap()))
-        .with_skip_preflight(true);
+        .with_funding_mode(FundingMode::BelowThreshold(parse_ether("0.01").unwrap()));
 
     if args.submit_offchain {
         client = client.config_offer_layer(|config| {


### PR DESCRIPTION
Enable back preflights checks on order generators after the fix in #1574 