### PR TITLE
BM-2353: avoid requiring image ID to be specified for skipping requestor preflight

### DIFF
--- a/crates/boundless-market/src/request_builder/preflight_layer.rs
+++ b/crates/boundless-market/src/request_builder/preflight_layer.rs
@@ -66,6 +66,41 @@ impl PreflightLayer {
         };
         Ok(env)
     }
+
+    /// Ensures image_id is set, computing from program (inline or fetched) if needed.
+    async fn ensure_image_id(&self, params: RequestParams) -> anyhow::Result<RequestParams> {
+        if params.image_id.is_some() {
+            return Ok(params);
+        }
+        let program = match params.require_program() {
+            Ok(bytes) => bytes.to_vec(),
+            Err(_) => {
+                let url = params.require_program_url()?;
+                fetch_url(url.as_str()).await?
+            }
+        };
+        let image_id = risc0_zkvm::compute_image_id(&program)?;
+        Ok(params.with_image_id(image_id))
+    }
+
+    /// Best-effort: fills executor cache when we have all precomputed data.
+    async fn fill_executor_cache_if_ready(&self, params: &RequestParams) {
+        let (Some(image_id), Some(request_input), Some(cycles), Some(journal)) = (
+            params.image_id,
+            params.request_input.as_ref(),
+            params.cycles,
+            params.journal.as_ref(),
+        ) else {
+            return;
+        };
+        let Ok(env) = self.fetch_env(request_input).await else {
+            return;
+        };
+        tracing::debug!("Filling executor cache for {image_id} with {cycles} cycles");
+        self.executor
+            .insert_execution_data(&image_id.to_string(), &env.stdin, cycles, journal.bytes.clone())
+            .await;
+    }
 }
 
 impl Adapt<PreflightLayer> for RequestParams {
@@ -76,34 +111,8 @@ impl Adapt<PreflightLayer> for RequestParams {
         tracing::trace!("Processing {self:?} with PreflightLayer");
 
         if self.cycles.is_some() && self.journal.is_some() {
-            // Compute image_id from program if not yet provided.
-            if self.image_id.is_none() {
-                if let Ok(program_url) = self.require_program_url() {
-                    let program = fetch_url(program_url).await?;
-                    let image_id = risc0_zkvm::compute_image_id(&program)?;
-                    self = self.with_image_id(image_id);
-                }
-            }
-
-            if let (Some(image_id), Some(request_input), Some(cycles), Some(journal)) =
-                (self.image_id, self.request_input.as_ref(), self.cycles, self.journal.as_ref())
-            {
-                if let Ok(env) = layer.fetch_env(request_input).await {
-                    // If we have all values to skip re-executing in future steps, fill the
-                    // executor cache to avoid redundant executions.
-                    tracing::debug!("Filling executor cache for {image_id} with {cycles} cycles");
-                    layer
-                        .executor
-                        .insert_execution_data(
-                            &image_id.to_string(),
-                            &env.stdin,
-                            cycles,
-                            journal.bytes.clone(),
-                        )
-                        .await;
-                }
-            }
-
+            self = layer.ensure_image_id(self).await?;
+            layer.fill_executor_cache_if_ready(&self).await;
             return Ok(self);
         }
 


### PR DESCRIPTION
Fix from #1574 to not require image ID on request params to be filled by this point, diff to example tested with:

```diff
diff --git a/crates/boundless-market/examples/submit_echo.rs b/crates/boundless-market/examples/submit_echo.rs
index 5f84c655..b6a74f2a 100644
--- a/crates/boundless-market/examples/submit_echo.rs
+++ b/crates/boundless-market/examples/submit_echo.rs
@@ -53,8 +53,21 @@ async fn main() -> Result<()> {
         .build()
         .await?;
 
-    // Build and submit request using the builder pattern
-    let request = client.new_request().with_program(ECHO_ELF).with_stdin(b"Hello, Boundless!");
+    let input = b"Hello, Boundless!";
+
+    // For ECHO guest, journal == input
+    let journal = risc0_zkvm::Journal::new(input.to_vec());
+    // Static cycle count (doesn't need to be accurate for testing cache pre-fill)
+    let cycles = 1_000_000u64;
+
+    // Provide cycles, journal, and image_id to skip execution during preflight.
+    // The PreflightLayer will pre-fill the executor cache for pricing checks.
+    let request = client
+        .new_request()
+        .with_program(ECHO_ELF)
+        .with_stdin(input)
+        .with_cycles(cycles)
+        .with_journal(journal);
 
     let (request_id, expires_at) = client.submit(request).await?;
     println!("Submitted request: {:x}", request_id);

```