### PR TITLE
BM-2395: use `gateway.beboundless.cloud` as ipfs gateway

### DIFF
--- a/infra/order-generator/Pulumi.l-prod-11155111.yaml
+++ b/infra/order-generator/Pulumi.l-prod-11155111.yaml
@@ -18,7 +18,7 @@ config:
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:R9fQgMpBuzjpJ7Bc:k0n/Ge/THuxbfMgnqW9621TLbLbSfwjACH+jsSZPZGUoCW+qUxXn5+q1n/9MCehtNGwCmC2Z6XaoAEt8RjDwQXreFZEbeBXOdLbpQu+gPxRwsBEUvjKF4aMHfeV1Fvy+v4GAocDaq39fYstZKg==
   order-generator-base:INTERVAL: "600"
-  order-generator-base:IPFS_GATEWAY_URL: https://dweb.link
+  order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "5000000000000000000"
   order-generator-base:LOG_LEVEL: "info,boundless_market=debug"
   order-generator-offchain:MAX_PRICE_PER_MCYCLE: "0.00002"

--- a/infra/order-generator/Pulumi.l-prod-8453.yaml
+++ b/infra/order-generator/Pulumi.l-prod-8453.yaml
@@ -18,7 +18,7 @@ config:
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:pfTxhEjN74NTG5Zk:uqeqk81UF6asWxgfbxYTzL+yhrMfY32xWCvGx+rauPVc/z1jbMHGcHMKVIWhdKuNQx3sgIL7p9C3XrFXxb9IjSv01f02I3aRsPV+OQgUQy5+AsNT9CKGUz2p3vLre+pueTXjNpDcWXzvV3YIdg==
   order-generator-base:INTERVAL: "32"
-  order-generator-base:IPFS_GATEWAY_URL: https://dweb.link
+  order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "15000000000000000000" # 15 ZKC
   order-generator-base:LOCK_TIMEOUT: "900"
   order-generator-base:LOG_LEVEL: "info,boundless_market=debug"

--- a/infra/order-generator/Pulumi.l-prod-84532.yaml
+++ b/infra/order-generator/Pulumi.l-prod-84532.yaml
@@ -10,7 +10,7 @@ config:
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:b7E6meJxy+d4v/gz:U+bgbXCKPP7mHJNg/unTGAXSkgEJ3BNn0e/1MaMoiha8sE3jvrvgsydkcWWMkfh8u3SPVzAc+cWVWBaWSJeFfvd04ZzP1eFBy5ScCvwSyBrMUTfsK8Ix6UuH3jD08OvEkkFYXL9Yzn6ZhWKceg==
   order-generator-base:INTERVAL: "600"
-  order-generator-base:IPFS_GATEWAY_URL: https://dweb.link
+  order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "5000000000000000000"
   order-generator-base:COLLATERAL_TOKEN_ADDRESS: 0x8d4dA4b7938471A919B08F941461b2ed1679d7bb
   order-generator-base:LOCK_TIMEOUT: "900"

--- a/infra/order-generator/Pulumi.l-staging-84532.yaml
+++ b/infra/order-generator/Pulumi.l-staging-84532.yaml
@@ -11,7 +11,7 @@ config:
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:HE58lw5Sc9CwM6RH:gckFeDbAiHFC5h1J2WyLhiF5yg9CbO9SCb3JwRWxdOfpcryWOl0YTpDyqwfv26fzET/SW2GhMxp2LVooo9K8WJG5gtwoxBh6tkwXDaTUh1yOupyM4ToO9Rimsy6PmGV/tFzkXmhYc0VaIls/Uw==
   order-generator-base:INTERVAL: "600"
-  order-generator-base:IPFS_GATEWAY_URL: https://dweb.link
+  order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "5000000000000000000"
   order-generator-base:LOCK_TIMEOUT: "900"
   order-generator-base:LOG_LEVEL: "info,boundless_market=debug"


### PR DESCRIPTION
Should improve performance and reliability over `dweb.link` 