### PR TITLE
chore(BM-2407): add `orders_fulfilled`, `orders_expired` and `not_locked_and_expired` on requestor endpoint

### DIFF
--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -328,6 +328,7 @@ pub struct RequestorLeaderboardEntry {
     pub orders_locked: u64,
     pub orders_fulfilled: u64,
     pub orders_expired: u64,
+    pub orders_not_locked_and_expired: u64,
     pub cycles_requested: U256,
     pub median_lock_price_per_cycle: Option<U256>,
     pub acceptance_rate: f32,

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -1829,6 +1829,7 @@ async fn get_requestor_leaderboard_impl(
             orders_locked: orders_locked as u64,
             orders_fulfilled: fulfilled as u64,
             orders_expired: expired as u64,
+            orders_not_locked_and_expired: not_locked_and_expired as u64,
             cycles_requested,
             median_lock_price_per_cycle: None,
             acceptance_rate,
@@ -4868,10 +4869,13 @@ mod tests {
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].requestor_address, requestor1);
         assert_eq!(results[0].orders_requested, 100);
+        assert_eq!(results[0].orders_not_locked_and_expired, 1); // total_expired(2) - locked_and_expired(1)
         assert_eq!(results[1].requestor_address, requestor2);
         assert_eq!(results[1].orders_requested, 50);
+        assert_eq!(results[1].orders_not_locked_and_expired, 1);
         assert_eq!(results[2].requestor_address, requestor3);
         assert_eq!(results[2].orders_requested, 25);
+        assert_eq!(results[2].orders_not_locked_and_expired, 1);
 
         // Test pagination with cursor
         let results_page1 = db
@@ -4952,6 +4956,7 @@ mod tests {
         summary2.total_requests_locked = 15;
         summary2.total_locked_and_fulfilled = 10;
         summary2.total_locked_and_expired = 2;
+        summary2.total_expired = 3;
         summary2.total_cycles = U256::from(300_000_000u64);
 
         db.upsert_hourly_requestor_summary(summary1).await.unwrap();
@@ -4973,6 +4978,7 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].orders_requested, 50); // 30 + 20
         assert_eq!(results[0].orders_locked, 40); // 25 + 15
+        assert_eq!(results[0].orders_not_locked_and_expired, 1); // (1+3) - (1+2) = 4 - 3 = 1
         assert_eq!(results[0].cycles_requested, U256::from(850_000_000u64)); // 550M + 300M
 
         // Locked order fulfillment rate: (20+10) / ((20+10) + (1+2)) = 30/33 = 90.9%

--- a/crates/lambdas/indexer-api/src/routes/market.rs
+++ b/crates/lambdas/indexer-api/src/routes/market.rs
@@ -316,6 +316,8 @@ pub struct RequestorLeaderboardEntry {
     pub orders_fulfilled: u64,
     /// Total orders expired (locked orders that expired without fulfillment)
     pub orders_expired: u64,
+    /// Total orders that expired without ever being locked
+    pub orders_not_locked_and_expired: u64,
     /// Total cycles requested (as string)
     pub cycles_requested: String,
     /// Total cycles requested (formatted for display)
@@ -2915,6 +2917,7 @@ async fn list_requestors_impl(
                 orders_locked: entry.orders_locked,
                 orders_fulfilled: entry.orders_fulfilled,
                 orders_expired: entry.orders_expired,
+                orders_not_locked_and_expired: entry.orders_not_locked_and_expired,
                 cycles_requested: entry.cycles_requested.to_string(),
                 cycles_requested_formatted: format_cycles(entry.cycles_requested),
                 median_lock_price_per_cycle: median.map(|m| m.to_string()),

--- a/crates/lambdas/indexer-api/tests/local_integration/market.rs
+++ b/crates/lambdas/indexer-api/tests/local_integration/market.rs
@@ -1667,6 +1667,35 @@ async fn test_requestor_leaderboard() {
             first.orders_requested > 0,
             "orders_requested should be positive for active requestors"
         );
+
+        // orders_fulfilled and orders_expired should not exceed orders_locked
+        assert!(
+            first.orders_fulfilled <= first.orders_locked,
+            "orders_fulfilled ({}) should not exceed orders_locked ({})",
+            first.orders_fulfilled,
+            first.orders_locked
+        );
+        assert!(
+            first.orders_expired <= first.orders_locked,
+            "orders_expired ({}) should not exceed orders_locked ({})",
+            first.orders_expired,
+            first.orders_locked
+        );
+        assert!(
+            first.orders_fulfilled + first.orders_expired <= first.orders_locked,
+            "orders_fulfilled ({}) + orders_expired ({}) should not exceed orders_locked ({})",
+            first.orders_fulfilled,
+            first.orders_expired,
+            first.orders_locked
+        );
+        assert!(
+            first.orders_not_locked_and_expired + first.orders_locked <= first.orders_requested,
+            "orders_not_locked_and_expired ({}) + orders_locked ({}) should not exceed orders_requested ({})",
+            first.orders_not_locked_and_expired,
+            first.orders_locked,
+            first.orders_requested
+        );
+
         assert!(
             first.acceptance_rate >= 0.0 && first.acceptance_rate <= 100.0,
             "acceptance_rate should be 0-100: {}",
@@ -1858,9 +1887,11 @@ async fn test_requestor_leaderboard_periods() {
             );
 
             tracing::info!(
-                "Top requestor for 'all': addr={}, orders={}, cycles={}, acceptance={}%, fulfillment={}%",
+                "Top requestor for 'all': addr={}, orders={}, fulfilled={}, expired={}, cycles={}, acceptance={}%, fulfillment={}%",
                 first.requestor_address,
                 first.orders_requested,
+                first.orders_fulfilled,
+                first.orders_expired,
                 first.cycles_requested_formatted,
                 first.acceptance_rate,
                 first.locked_order_fulfillment_rate
@@ -1909,6 +1940,38 @@ async fn test_requestor_leaderboard_periods() {
             entry.requestor_address
         );
 
+        // orders_fulfilled and orders_expired should not exceed orders_locked
+        assert!(
+            entry.orders_fulfilled <= entry.orders_locked,
+            "Requestor {} orders_fulfilled ({}) should not exceed orders_locked ({})",
+            entry.requestor_address,
+            entry.orders_fulfilled,
+            entry.orders_locked
+        );
+        assert!(
+            entry.orders_expired <= entry.orders_locked,
+            "Requestor {} orders_expired ({}) should not exceed orders_locked ({})",
+            entry.requestor_address,
+            entry.orders_expired,
+            entry.orders_locked
+        );
+        assert!(
+            entry.orders_fulfilled + entry.orders_expired <= entry.orders_locked,
+            "Requestor {} orders_fulfilled ({}) + orders_expired ({}) should not exceed orders_locked ({})",
+            entry.requestor_address,
+            entry.orders_fulfilled,
+            entry.orders_expired,
+            entry.orders_locked
+        );
+        assert!(
+            entry.orders_not_locked_and_expired + entry.orders_locked <= entry.orders_requested,
+            "Requestor {} orders_not_locked_and_expired ({}) + orders_locked ({}) should not exceed orders_requested ({})",
+            entry.requestor_address,
+            entry.orders_not_locked_and_expired,
+            entry.orders_locked,
+            entry.orders_requested
+        );
+
         // Cycles may be zero locally, but should be parseable
         let _cycles: u128 = entry.cycles_requested.parse().expect("cycles should be numeric");
 
@@ -1939,9 +2002,11 @@ async fn test_requestor_leaderboard_periods() {
         );
 
         tracing::info!(
-            "Requestor {}: orders={}, cycles={}, acceptance={}%, fulfillment={}%",
+            "Requestor {}: orders={}, fulfilled={}, expired={}, cycles={}, acceptance={}%, fulfillment={}%",
             entry.requestor_address,
             entry.orders_requested,
+            entry.orders_fulfilled,
+            entry.orders_expired,
             entry.cycles_requested_formatted,
             entry.acceptance_rate,
             entry.locked_order_fulfillment_rate


### PR DESCRIPTION
## Description

Add `orders_fulfilled`, `orders_expired` and `orders_not_locked_and_expired` on `/v1/market/requestors` endpoint

This will let the frontend distinguish **N/A** (all orders still in-flight) from a genuine **0%** acceptance/fulfillment rate

## Example

```ts
// Acceptance rate
if (entry.orders_not_locked_and_expired === 0 && entry.orders_locked === 0) {
    return "N/A"; // no outcomes yet and all orders still in-flight
}

return `${entry.acceptance_rate}%`;

// Fulfillment rate
if (entry.orders_fulfilled + entry.orders_expired === 0) {
    return "N/A"; // locked orders still in-flight
}

return `${entry.locked_order_fulfillment_rate}%`;
```
