### PR TITLE
BM-2461: [slasher] use confirmed block for range queries

### DIFF
--- a/crates/slasher/src/main.rs
+++ b/crates/slasher/src/main.rs
@@ -72,6 +72,9 @@ struct MainArgs {
     /// Maximum block range to query in a single request.
     #[clap(long, default_value = "500")]
     max_block_range: u64,
+    /// Blocks to subtract from latest when "safe" block is unavailable (0 = use latest; use 0 for tests).
+    #[clap(long, default_value = "2")]
+    block_confirmation_delay: u64,
 }
 
 fn parse_address(s: &str) -> Result<Address, String> {
@@ -111,6 +114,7 @@ async fn main() -> Result<()> {
             skip_addresses: args.skip_addresses,
             tx_timeout: Duration::from_secs(args.tx_timeout),
             max_block_range: args.max_block_range,
+            block_confirmation_delay: args.block_confirmation_delay,
         },
     )
     .await?;

--- a/crates/slasher/tests/basic.rs
+++ b/crates/slasher/tests/basic.rs
@@ -141,6 +141,8 @@ async fn test_basic_usage(pool: sqlx::PgPool) {
         "1",
         "--retries",
         "1",
+        "--block-confirmation-delay",
+        "0",
     ];
 
     println!("{exe_path} {args:?}");
@@ -222,6 +224,8 @@ async fn test_slash_fulfilled(pool: sqlx::PgPool) {
         "1",
         "--retries",
         "1",
+        "--block-confirmation-delay",
+        "0",
     ];
 
     println!("{exe_path} {args:?}");


### PR DESCRIPTION
Use a confirmed block as the upper bound for block range queries instead of the chain tip.

**Problem**: Using the latest block as `to_block` caused “invalid block range params” when querying logs on Base mainnet, where the RPC rejects ranges that include the unstable tip.

**Change**: `current_block()` now prefers the safe block (`BlockNumberOrTag::Safe`). If the RPC doesn’t support it or the call fails, it falls back to latest 2 blocks.