### PR TITLE
BM-2462: Fix `AddressMismatch` error format string

### DIFF
--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -141,7 +141,7 @@ pub enum MarketError {
     RequestError(#[from] RequestError),
 
     /// Request address does not match with signer.
-    #[error("Request address does not match with signer {0} - {0}")]
+    #[error("Request address does not match with signer {0} - {1}")]
     AddressMismatch(Address, Address),
 
     /// Proof not found.


### PR DESCRIPTION
The second {0} should be {1}. This causes the same address to be printed twice, making the error useless for debugging.