### PR TITLE
BM-2472: Bump pre-built binaries to v1.2.1

### DIFF
--- a/ansible/test-prover.yml
+++ b/ansible/test-prover.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: Download bento CLI bundle
       ansible.builtin.get_url:
-        url: https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.0/bento-bundle-linux-amd64.tar.gz
+        url: https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.1/bento-bundle-linux-amd64.tar.gz
         dest: /tmp/bento-bundle-linux-amd64.tar.gz
         mode: "0644"
 

--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ x-agent-common: &agent-common
     context: .
     dockerfile: ${AGENT_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.0/bento-bundle-linux-amd64.tar.gz}
+      BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.1/bento-bundle-linux-amd64.tar.gz}
       BLAKE3_GROTH16_ARTIFACTS_URL: ${BLAKE3_GROTH16_ARTIFACTS_URL:-https://staging-signal-artifacts.beboundless.xyz/v3/proving/blake3_groth16_artifacts.tar.xz}
       # If set to 1, yes, or true, the agent will expect local mounting of BLAKE3 Groth16 setup files instead of downloading
       USE_LOCAL_BLAKE3_GROTH16_SETUP: ${USE_LOCAL_BLAKE3_GROTH16_SETUP:-0}
@@ -115,7 +115,7 @@ x-broker-common: &broker-common
     context: .
     dockerfile: ${BROKER_DOCKERFILE:-dockerfiles/broker.prebuilt.dockerfile}
     args:
-      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.2.0/broker}
+      BINARY_URL: ${BROKER_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/broker-v1.2.1/broker}
   mem_limit: 2G
   cpus: 2
   stop_grace_period: 3h
@@ -251,7 +251,7 @@ services:
       context: .
       dockerfile: ${REST_API_DOCKERFILE:-dockerfiles/rest_api.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.0/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.1/bento-bundle-linux-amd64.tar.gz}
     restart: always
     depends_on:
       postgres:
@@ -314,7 +314,7 @@ services:
       context: .
       dockerfile: ${BENTO_CLI_DOCKERFILE:-dockerfiles/agent.prebuilt.dockerfile}
       args:
-        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.0/bento-bundle-linux-amd64.tar.gz}
+        BINARY_URL: ${BENTO_BINARY_URL:-https://github.com/boundless-xyz/boundless/releases/download/bento-v1.2.1/bento-bundle-linux-amd64.tar.gz}
         BLAKE3_GROTH16_ARTIFACTS_URL: ${BLAKE3_GROTH16_ARTIFACTS_URL:-https://staging-signal-artifacts.beboundless.xyz/v3/proving/blake3_groth16_artifacts.tar.xz}
         # If set to 1, yes, or true, the agent will expect local mounting of BLAKE3 Groth16 setup files instead of downloading
         USE_LOCAL_BLAKE3_GROTH16_SETUP: ${USE_LOCAL_BLAKE3_GROTH16_SETUP:-0}


### PR DESCRIPTION
Bump `compose.yml` to use the pre-built binaries on version bento-v1.2.1

Fixes BM-2470