### PR TITLE
BM-2475: Fix order-generator staging deployment failure

### DIFF
--- a/infra/order-generator/Pulumi.l-staging-84532.yaml
+++ b/infra/order-generator/Pulumi.l-staging-84532.yaml
@@ -2,7 +2,7 @@ secretsprovider: awskms:///arn:aws:kms:us-west-2:968153779208:alias/pulumi-secre
 encryptedkey: AQICAHhnm/1/W7/xeF2uxmXOGjFzOf6jjMX+KgbMb0K+LSCbsAFtDEwEd4DokgsE4MVOHUtcAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM4WRMKe/RTs500zvZAgEQgDtQ2eCBkl8/LjExNPf2ur+A7uLQFZMgejzs37yMD2GEIGfTCVCGbyxZf8BzxD9trpiDrGN++LO+f9/AyA==
 config:
   aws:region: us-west-2
-  order-generator-base:BASE_STACK: organization/bootstrap/services-dev
+  order-generator-base:BASE_STACK: organization/bootstrap/services-staging
   order-generator-base:BOUNDLESS_MARKET_ADDR: 0x7abb16522f4599481361d318b765af988bfcca8e
   order-generator-base:COLLATERAL_TOKEN_ADDRESS: 0xCBA5Fd30105984125395c18B6E6b1bf603408629
   order-generator-base:CHAIN_ID: "84532"


### PR DESCRIPTION
Reverts the `BASE_STACK` reference in the order-generator staging config from services-dev back to services-staging. The incorrect value was introduced in #1622  (likely from local dev), causing pulumi preview to fail with unknown stack "organization/bootstrap/services-dev".