### PR TITLE
BM-2479: Fix rewards indexer: `eth_getLogs` block range error

### DIFF
--- a/crates/indexer/src/bin/rewards-indexer.rs
+++ b/crates/indexer/src/bin/rewards-indexer.rs
@@ -79,7 +79,8 @@ struct RewardsIndexerArgs {
     epochs_to_process: Option<u64>,
 
     /// Number of blocks to query in each chunk when fetching event logs.
-    #[clap(long, default_value = "50000")]
+    /// Many RPCs limit eth_getLogs to 10_000 blocks; the rewards crate caps at 10k internally.
+    #[clap(long, default_value = "10000")]
     block_chunk_size: u64,
 }
 


### PR DESCRIPTION
The rewards indexer was failing with:
```
Error running rewards indexer: Failed to get work logsHTTP error 400: "You can make eth_getLogs requests with up to a 10000 block range..."
```
The indexer was requesting up to 50,000 blocks per eth_getLogs call, while many RPC providers (e.g. Alchemy, Infura) allow at most 10,000 blocks per request.

This PR adds:

- Cap in boundless-rewards: In crates/rewards/src/events.rs, added MAX_ETH_GETLOGS_BLOCK_RANGE = 10_000 and use it in query_logs_chunked so each eth_getLogs request is limited to 10k blocks, regardless of the configured chunk size.
- Default in rewards-indexer binary: In crates/indexer/src/bin/rewards-indexer.rs, changed the default for --block-chunk-size from 50000 to 10000 and documented that many RPCs limit eth_getLogs to 10k blocks.