### PR TITLE
BM-1841: Add functionality to wizard for estimating infra costs and zkc subsidy

### DIFF
--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -670,7 +670,12 @@ impl ProverGenerateConfig {
             // When cost floor is 0 (subsidy >= infra), recommend market 25th percentile instead of 0.
             let recommended_default = if let Some(floor_usd) = cost_floor_usd_per_mcycle {
                 let cost_floor_per_bcycle = floor_usd * MCYCLES_PER_BCYCLE;
-                let market_p25_f64: f64 = market_p25_usd.trim().parse().unwrap_or(0.0);
+                // try_convert_to_usd returns e.g. "0.010409 USD"; parse numeric part only
+                let market_p25_f64: f64 = market_p25_usd
+                    .split_whitespace()
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0.0);
                 let cost_floor_is_zero = cost_floor_per_bcycle <= 0.0;
 
                 display.item_colored(


### PR DESCRIPTION
Extends the prover generate-config wizard with optional infrastructure cost estimation and a cost-based pricing floor. The wizard can now derive a minimum price from the user’s hourly infra cost and ZKC subsidy, compare it to market levels, and recommend a floor that keeps the prover profitable while staying comparable to the market.

Changes:

- Hourly infra cost (Step 7): New prompt for hourly infra cost (USD). Default 0; if 0, cost-based logic is skipped and behavior stays market-percentile only.
- ZKC subsidy: Fetches POVW epochs API, computes average ZKC per Mcycle, converts to USD via price oracle. Used as baseline income and subtracted from infra cost to get cost floor.
- Cost breakdown: shows infra cost, ZKC subsidy, and cost floor per BCycle; cost floor is capped by $0.10/BCycle benchmark.
- Recommendation: If cost >= 0, recommends cost-based floor (or market 25th percentile when cost floor is 0). Shows both floor and market 25th; warns only when floor is above market.
- BCycle UX: Pricing and collateral prompts use “per BCycle”; values are converted to per Mcycle for broker.toml.
- Config: When cost-based, adds a comment to min_mcycle_price explaining how it was derived.

Example:
<img width="1477" height="973" alt="Screenshot 2026-02-19 at 16 47 57" src="https://github.com/user-attachments/assets/49d45a29-4405-43cb-804f-064298d3691b" />
