### PR TITLE
bump release-1.2 to 1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives 1.4.1",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-bench"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-cli"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-node-bindings",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-distributor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-indexer"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2849,7 +2849,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2898,7 +2898,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-order-generator"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2916,7 +2916,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-povw"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-rewards"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-slasher"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives 1.4.1",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "broker-stress"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5814,7 +5814,7 @@ checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
 name = "indexer-api"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-monitor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -7291,7 +7291,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "order-stream"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8260,7 +8260,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.2"
 edition = "2021"
 homepage = "https://boundless.network/"
 repository = "https://github.com/boundless-xyz/boundless/"

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2100,6 +2100,7 @@ dependencies = [
  "num-traits",
  "risc0-groth16",
  "risc0-groth16-sys",
+ "risc0-zkp",
  "risc0-zkvm",
  "serde",
  "serde_json",
@@ -2200,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2240,7 +2241,6 @@ dependencies = [
  "tokio-tungstenite",
  "tower",
  "tracing",
- "tracing-subscriber 0.3.20",
  "url",
  "utoipa",
 ]

--- a/examples/blake3-groth16/Cargo.lock
+++ b/examples/blake3-groth16/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6378,7 +6378,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",

--- a/examples/composition/Cargo.lock
+++ b/examples/composition/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6390,7 +6390,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",

--- a/examples/counter-with-callback/Cargo.lock
+++ b/examples/counter-with-callback/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6388,7 +6388,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6388,7 +6388,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",

--- a/examples/smart-contract-requestor/Cargo.lock
+++ b/examples/smart-contract-requestor/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6387,7 +6387,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "reqwest",


### PR DESCRIPTION
version wasn't bumped for 1.2.1 build, and to avoid yanking previous built artifacts, just going to release as 1.2.2