### PR TITLE
BM-2492: Use RequestLocked event data directly, simplify market monitor

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -783,7 +783,6 @@ where
             self.db.clone(),
             chain_monitor.clone(),
             self.args.private_key.as_ref().expect("Private key must be set").address(),
-            client.clone(),
             new_order_tx.clone(),
             order_state_tx.clone(),
         ));

--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -25,11 +25,8 @@ use alloy::{
 
 use anyhow::{Context, Result};
 use async_stream::stream;
-use boundless_market::{
-    contracts::{
-        boundless_market::BoundlessMarketService, IBoundlessMarket, RequestId, RequestStatus,
-    },
-    order_stream_client::OrderStreamClient,
+use boundless_market::contracts::{
+    boundless_market::BoundlessMarketService, IBoundlessMarket, RequestId, RequestStatus,
 };
 use futures_util::StreamExt;
 use tokio::sync::{
@@ -86,7 +83,6 @@ pub struct MarketMonitor<P> {
     db: DbObj,
     chain_monitor: Arc<ChainMonitorService<P>>,
     prover_addr: Address,
-    order_stream: Option<OrderStreamClient>,
     new_order_tx: mpsc::Sender<Box<OrderRequest>>,
     order_state_tx: broadcast::Sender<OrderStateChange>,
 }
@@ -122,7 +118,6 @@ where
         db: DbObj,
         chain_monitor: Arc<ChainMonitorService<P>>,
         prover_addr: Address,
-        order_stream: Option<OrderStreamClient>,
         new_order_tx: mpsc::Sender<Box<OrderRequest>>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
     ) -> Self {
@@ -135,7 +130,6 @@ where
             db,
             chain_monitor,
             prover_addr,
-            order_stream,
             new_order_tx,
             order_state_tx,
         }
@@ -255,10 +249,11 @@ where
     /// Creates a stream that polls for market events in chunks
     /// Handles all the polling logic: intervals, block tracking, chunking, and querying
     ///
-    /// The `filter_fn` closure receives (market, from_block, to_block) and returns a future that queries the logs
+    /// The `filter_fn` closure receives (provider, market_addr, from_block, to_block) and returns a future that queries the logs
     fn poll_market_events<T, FilterFn, FilterFut>(
         chain_monitor: Arc<ChainMonitorService<P>>,
-        market: BoundlessMarketService<Arc<P>>,
+        provider: Arc<P>,
+        market_addr: Address,
         lookback_blocks: u64,
         events_poll_blocks: u64,
         poll_interval_ms: u64,
@@ -266,7 +261,7 @@ where
     ) -> impl futures_util::Stream<Item = Result<(T, alloy::rpc::types::Log), MarketMonitorErr>>
     where
         T: Send + 'static,
-        FilterFn: Fn(BoundlessMarketService<Arc<P>>, u64, u64) -> FilterFut + Send + 'static,
+        FilterFn: Fn(Arc<P>, Address, u64, u64) -> FilterFut + Send + 'static,
         FilterFut: std::future::Future<Output = Result<Vec<(T, alloy::rpc::types::Log)>, anyhow::Error>>
             + Send,
     {
@@ -301,7 +296,7 @@ where
                         to_block
                     );
 
-                    let logs = filter_fn(market.clone(), from_block, chunk_end)
+                    let logs = filter_fn(provider.clone(), market_addr, from_block, chunk_end)
                         .await
                         .map_err(MarketMonitorErr::EventPollingErr)?;
 
@@ -326,85 +321,78 @@ where
         events_poll_blocks: u64,
         poll_interval_ms: u64,
         new_order_tx: mpsc::Sender<Box<OrderRequest>>,
-        order_stream: Option<OrderStreamClient>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
         cancel_token: CancellationToken,
     ) -> Result<(), MarketMonitorErr> {
-        let market =
-            BoundlessMarketService::new_for_broker(market_addr, provider.clone(), Address::ZERO);
         let chain_id = provider.get_chain_id().await.context("Failed to get chain id")?;
 
         let stream = Self::poll_market_events(
             chain_monitor,
-            market.clone(),
+            provider.clone(),
+            market_addr,
             lookback_blocks,
             events_poll_blocks,
             poll_interval_ms,
-            move |market, from_block, to_block| {
-                let provider = market.instance().provider().clone();
-                async move {
-                    let filter = Filter::new()
-                        .address(*market.instance().address())
-                        .from_block(from_block)
-                        .to_block(to_block)
-                        .event_signature(vec![
-                            IBoundlessMarket::RequestSubmitted::SIGNATURE_HASH,
-                            IBoundlessMarket::RequestLocked::SIGNATURE_HASH,
-                            IBoundlessMarket::RequestFulfilled::SIGNATURE_HASH,
-                        ]);
+            move |provider, market_addr, from_block, to_block| async move {
+                let filter = Filter::new()
+                    .address(market_addr)
+                    .from_block(from_block)
+                    .to_block(to_block)
+                    .event_signature(vec![
+                        IBoundlessMarket::RequestSubmitted::SIGNATURE_HASH,
+                        IBoundlessMarket::RequestLocked::SIGNATURE_HASH,
+                        IBoundlessMarket::RequestFulfilled::SIGNATURE_HASH,
+                    ]);
 
-                    let logs = provider.get_logs(&filter).await.context("Failed to get logs")?;
+                let logs = provider.get_logs(&filter).await.context("Failed to get logs")?;
 
-                    let mut out: Vec<(MarketEvent, alloy::rpc::types::Log)> =
-                        Vec::with_capacity(logs.len());
-                    for log in logs.into_iter() {
-                        match log.topic0() {
-                            Some(t) if t == &IBoundlessMarket::RequestSubmitted::SIGNATURE_HASH => {
-                                match log.log_decode::<IBoundlessMarket::RequestSubmitted>() {
-                                    Ok(res) => out.push((
-                                        MarketEvent::Submitted(res.inner.data),
-                                        log.clone(),
-                                    )),
-                                    Err(err) => tracing::error!(
-                                        "Failed to decode RequestSubmitted log: {err:?}"
-                                    ),
+                let mut out: Vec<(MarketEvent, alloy::rpc::types::Log)> =
+                    Vec::with_capacity(logs.len());
+                for log in logs.into_iter() {
+                    match log.topic0() {
+                        Some(t) if t == &IBoundlessMarket::RequestSubmitted::SIGNATURE_HASH => {
+                            match log.log_decode::<IBoundlessMarket::RequestSubmitted>() {
+                                Ok(res) => {
+                                    out.push((MarketEvent::Submitted(res.inner.data), log.clone()))
                                 }
-                            }
-                            Some(t) if t == &IBoundlessMarket::RequestLocked::SIGNATURE_HASH => {
-                                match log.log_decode::<IBoundlessMarket::RequestLocked>() {
-                                    Ok(res) => {
-                                        out.push((MarketEvent::Locked(res.inner.data), log.clone()))
-                                    }
-                                    Err(err) => tracing::error!(
-                                        "Failed to decode RequestLocked log: {err:?}"
-                                    ),
-                                }
-                            }
-                            Some(t) if t == &IBoundlessMarket::RequestFulfilled::SIGNATURE_HASH => {
-                                match log.log_decode::<IBoundlessMarket::RequestFulfilled>() {
-                                    Ok(res) => out.push((
-                                        MarketEvent::Fulfilled(res.inner.data),
-                                        log.clone(),
-                                    )),
-                                    Err(err) => tracing::error!(
-                                        "Failed to decode RequestFulfilled log: {err:?}"
-                                    ),
-                                }
-                            }
-                            _ => {
-                                tracing::debug!("Skipping unknown topic0 log: {:?}", log.topic0());
+                                Err(err) => tracing::error!(
+                                    "Failed to decode RequestSubmitted log: {err:?}"
+                                ),
                             }
                         }
+                        Some(t) if t == &IBoundlessMarket::RequestLocked::SIGNATURE_HASH => {
+                            match log.log_decode::<IBoundlessMarket::RequestLocked>() {
+                                Ok(res) => {
+                                    out.push((MarketEvent::Locked(res.inner.data), log.clone()))
+                                }
+                                Err(err) => {
+                                    tracing::error!("Failed to decode RequestLocked log: {err:?}")
+                                }
+                            }
+                        }
+                        Some(t) if t == &IBoundlessMarket::RequestFulfilled::SIGNATURE_HASH => {
+                            match log.log_decode::<IBoundlessMarket::RequestFulfilled>() {
+                                Ok(res) => {
+                                    out.push((MarketEvent::Fulfilled(res.inner.data), log.clone()))
+                                }
+                                Err(err) => tracing::error!(
+                                    "Failed to decode RequestFulfilled log: {err:?}"
+                                ),
+                            }
+                        }
+                        _ => {
+                            tracing::debug!("Skipping unknown topic0 log: {:?}", log.topic0());
+                        }
                     }
-
-                    tracing::trace!(
-                        "Processed from block {} to block {} [found {} events]",
-                        from_block,
-                        to_block,
-                        out.len()
-                    );
-                    Ok(out)
                 }
+
+                tracing::trace!(
+                    "Processed from block {} to block {} [found {} events]",
+                    from_block,
+                    to_block,
+                    out.len()
+                );
+                Ok(out)
             },
         );
         tokio::pin!(stream);
@@ -470,45 +458,16 @@ where
                                     // If the request was not locked by the prover, we create an order to evaluate the request
                                     // for fulfilling after the lock expires.
                                     if event.prover != prover_addr {
-                                        // Try the order stream first (single HTTP call). If the request was submitted
-                                        // on-chain rather than via the order stream (off-chain), fall back to an on-chain log search.
-                                        // This order matters: on-chain search can cost up to 100 eth_getLogs calls for
-                                        // requests that were submitted off-chain and have no on-chain RequestSubmitted event.
-                                        let mut order: Option<OrderRequest> = None;
-                                        if let Some(order_stream) = &order_stream {
-                                            if let Ok(order_stream_order) = order_stream.fetch_order(event.requestId, None).await {
-                                                let proof_request = order_stream_order.request;
-                                                let signature = order_stream_order.signature;
-                                                order = Some(OrderRequest::new(
-                                                    proof_request,
-                                                    signature.as_bytes().into(),
-                                                    FulfillmentType::FulfillAfterLockExpire,
-                                                    market_addr,
-                                                    chain_id,
-                                                ));
-                                            }
-                                        }
-                                        if order.is_none() {
-                                            // TODO: we should try to get rid of using get_submitted_request here
-                                            //  1. it is blocking and thus stalls progress of the market monitor overall
-                                            //  2. it incurs RPC calls for every locked order which can be avoided if we indexed the request data in the db when we see the RequestSubmitted event
-                                            if let Ok((proof_request, signature)) = market.get_submitted_request(event.requestId, None, None, log.block_number).await {
-                                                order = Some(OrderRequest::new(
-                                                    proof_request,
-                                                    signature,
-                                                    FulfillmentType::FulfillAfterLockExpire,
-                                                    market_addr,
-                                                    chain_id,
-                                                ));
-                                            }
-                                        }
+                                        let order = OrderRequest::new(
+                                            event.request.clone(),
+                                            event.clientSignature,
+                                            FulfillmentType::FulfillAfterLockExpire,
+                                            market_addr,
+                                            chain_id,
+                                        );
 
-                                        if let Some(order) = order {
-                                            if let Err(e) = new_order_tx.send(Box::new(order)).await {
-                                                tracing::error!("Failed to send order locked by another prover, {:x}: {e} {e:?}", event.requestId);
-                                            }
-                                        } else {
-                                            tracing::warn!("Failed to get order from market or order stream for locked request {:x}. Unable to evaluate for fulfillment after lock expires.", event.requestId);
+                                        if let Err(e) = new_order_tx.send(Box::new(order)).await {
+                                            tracing::error!("Failed to send order locked by another prover, {:x}: {e} {e:?}", event.requestId);
                                         }
                                     }
                                 }
@@ -646,7 +605,6 @@ where
         let chain_monitor = self.chain_monitor.clone();
         let new_order_tx = self.new_order_tx.clone();
         let db = self.db.clone();
-        let order_stream = self.order_stream.clone();
         let order_state_tx = self.order_state_tx.clone();
 
         Box::pin(async move {
@@ -675,7 +633,6 @@ where
                 events_poll_blocks,
                 poll_interval_ms,
                 new_order_tx,
-                order_stream,
                 order_state_tx,
                 cancel_token,
             )
@@ -818,7 +775,6 @@ mod tests {
             db,
             chain_monitor,
             Address::ZERO,
-            None,
             order_tx,
             order_state_tx,
         );
@@ -931,17 +887,15 @@ mod tests {
         // Ensure chain_monitor has its first cached value.
         let _ = chain_monitor.current_block_number().await.unwrap();
 
-        let market =
-            BoundlessMarketService::new_for_broker(Address::ZERO, provider.clone(), Address::ZERO);
-
         // Create a stream with a filter_fn that always fails.
         let stream = MarketMonitor::poll_market_events(
             chain_monitor,
-            market,
+            provider.clone(),
+            Address::ZERO,
             0,
             5,
             50,
-            |_market: BoundlessMarketService<_>, _from: u64, _to: u64| async move {
+            |_provider: Arc<_>, _market_addr: Address, _from: u64, _to: u64| async move {
                 Err::<Vec<((), alloy::rpc::types::Log)>, _>(anyhow::anyhow!(
                     "simulated get_logs failure"
                 ))


### PR DESCRIPTION
## Summary

Follow up for https://github.com/boundless-xyz/boundless/pull/1673. The `RequestLocked` event emitted by `BoundlessMarket.sol` carries the full `ProofRequest` and `clientSignature` as non-indexed fields. This PR eliminates all backward on-chain log searches and order-stream HTTP calls that were previously done to reconstruct a locked order, and follows up by removing the now-dead code.

### What changed

**`crates/broker/src/market_monitor.rs`**
- `RequestLocked` handler now constructs `OrderRequest` directly from `event.request` / `event.clientSignature` with `FulfillmentType::FulfillAfterLockExpire` — no RPC calls needed
- Removed `order_stream: Option<OrderStreamClient>` field, constructor param, and import
- Refactored `poll_market_events` to accept `provider: Arc<P>` + `market_addr: Address` instead of a `BoundlessMarketService` wrapper, eliminating the `BoundlessMarketService` construction in `monitor_market`

**`crates/broker/src/lib.rs`**
- Removed the `client.clone()` argument from `MarketMonitor::new()` (the `OrderStreamClient` is still passed to `OffchainMarketMonitor` as before)

### Why this is safe

The `ProofRequest` and `clientSignature` in the `RequestLocked` event are emitted directly from contract storage — they are identical to what `get_submitted_request` / the order-stream would have returned. 

### Impact

| Metric | Before | After |
|---|---|---|
| `eth_getLogs` per foreign lock event | up to 100 | 0 |
| Order-stream HTTP calls per foreign lock event | 1 (main) / 0 (branch) | 0 |
| Market monitor blocking per foreign lock event | up to ~26s | 0 |