### PR TITLE
BM-2508: chore: deduplicate requests by `request_id` in requestor list endpoint

### DIFF
--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -3838,7 +3838,7 @@ mod tests {
         assert_eq!(page1.len(), 2);
         assert!(cursor.is_some(), "should have a next page cursor");
 
-        let (page2, cursor2) = db
+        let (page2, _cursor2) = db
             .list_requests_by_requestor(addr, cursor, 2, RequestSortField::CreatedAt)
             .await
             .unwrap();


### PR DESCRIPTION
## Description
The `/v1/market/requestors/:address/requests` endpoint currently returns duplicate rows when a single `request_id` has multiple records (e.g due to different ramp-up times)

To fix this the query should be wrapped in a CTE (Common Table Expression) that uses:
```sql
ROW_NUMBER() OVER (PARTITION BY request_id ORDER BY status_priority)
```

This will select exactly one row per `request_id` prioritizing the most relevant state in the following order:
**fulfilled → expired → locked → submitted**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SQL used by the requestor requests listing to return one row per `request_id`, which could subtly affect ordering/pagination and query performance in production.
> 
> **Overview**
> Updates `list_requests_by_requestor` to **deduplicate** the requestor request listing by wrapping the query in a CTE that ranks rows per `request_id` (prioritizing `fulfilled → expired → locked → submitted`) and selecting only the top-ranked row.
> 
> Adds a new DB test (`test_list_requests_by_requestor_dedup`) covering status-priority selection, multiple unique request IDs, and non-overlapping cursor pagination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec54d10539d022f4a6c359d18aa44b8f6e3bb469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->