### PR TITLE
BM-2452: Reduce order generator rate

### DIFF
--- a/infra/order-generator/Pulumi.l-prod-8453.yaml
+++ b/infra/order-generator/Pulumi.l-prod-8453.yaml
@@ -29,7 +29,7 @@ config:
     secure: v1:wOJUhapOWpVScxx5:9ws7QAOS62UNKJmhQP9tdl1aQosT+BRovdoYv9HYNLApYkx6dzGguK9o/IdNdjzfd2rspTpVyvHX7MlP4LYoPgOf9j3L048G8vTxNZ5g0MqZDS5Rhx+gdmRqj3SRglfOIkD/AEcpCba3GNBmAi5+9x3QXEQerKAKJ4EpLpnez1sJs9WOdTG40YbM54qZlzwbdU/EOsWxAuWKIFnPKwm7CPlNZ2lzmA0PzEgGbG77mhHrafNnuGXHc16iy/lvhEh6Qe13sXHJg+p4U29KAL8HWR+dkNytQLnU3UsPZQcx6QQLSJRFg0PLLlEZ/DEsAAXuqMbRPzAexF2qX65/52JGiv9ite2+zOL8zhfhjbbpVHVrcwcSVB87vpPEiOLIRPrZD8OjjtKBxw9mcBID6ysPZDjCsgXjjAn/WqilS4/m0aUMUnRcC2z+upAByCrWDXoTz5XrTy2wDFvHhtK5v2j/ETv/dXWZcFBpUK7o/5JhJ5NKuiOgNhPaPVo1/HJqQMY8lYArgyRs/8cDd5jbcQZ+dbI/sBYXkCI3Jdtgghk7ZOr22RxSOQZhiptr4fzgX/C6Mp3V2ln/90uY0+BOZUfC+Dqd4nFjWBeaY8NtAfJacAbI83eC9yH+HL0LphRhtjmWgfE2NXjSRv8g1bSsrVUrKh44RsSUjOSMMGJyd7ydXRT4gOUAt3whc01WtTlVzCgEx9OlUYx1IaLXh9kUdotNGGzE6IdUVk+JBlIzQbHwwPCSQ+2oLTMdbRiz/56HvUNFf0ENysCy+17uIpjlKT1i9yJCrEyRPAcBpIl7MPboTwG3a65/yGiqvoMSZrEhKXl8e/HHRPSNQsEhtphEJVNj7MyI17Q0UuIXsd1jjYUEGWBT2GutmHbActlH4As0cRB4HTcBoaJJhtfCzL0Izs04tsqgcKkCyBHh
   order-generator-base:SET_VERIFIER_ADDR: 0x1Ab08498CfF17b9723ED67143A050c8E8c2e3104
   order-generator-base:TX_TIMEOUT: "90"
-  order-generator-offchain:MAX_PRICE_CAP: "0.01"
+  order-generator-offchain:MAX_PRICE_CAP: "0.0001"
   order-generator-offchain:AUTO_DEPOSIT: "0.015"
   order-generator-offchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-offchain:EXEC_RATE_KHZ: "1000"
@@ -41,7 +41,7 @@ config:
   order-generator-offchain:SECONDS_PER_MCYCLE: "7"
   order-generator-offchain:TIMEOUT: "1500"
   order-generator-offchain:WARN_BALANCE_BELOW: "0.01"
-  order-generator-onchain:MAX_PRICE_CAP: "0.01"
+  order-generator-onchain:MAX_PRICE_CAP: "0.0001"
   order-generator-onchain:AUTO_DEPOSIT: "0.015"
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "1000"


### PR DESCRIPTION
Slow down order generator on Base mainnet and cap the max price.

Changes
* `INTERVAL` doubled for both offchain (22s → 44s) and onchain (32s → 64s) — 50% rate reduction
* `MAX_PRICE_CAP` lowered from 0.01 to 0.0001 ETH on both offchain and onchain orders

## Test plan
- Deploy to l-prod-8453 (Base mainnet)
- Monitor order generation rate and pricing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but it directly affects production order-generation throughput and bidding behavior (lower `MAX_PRICE_CAP`, longer `INTERVAL`).
> 
> **Overview**
> Reduces Base mainnet (`l-prod-8453`) order generation aggressiveness by **tightening price caps** and **slowing generation intervals**.
> 
> Specifically updates `order-generator-offchain` and `order-generator-onchain` to lower `MAX_PRICE_CAP` from `0.01` to `0.0001`, and increases `INTERVAL` from `22→44` (offchain) and `32→64` (onchain).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012da309fc5d88ea614262a0dcceab0a998a9400. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->