### PR TITLE
BM-2539: Logging for market price percentiles in SDK

### DIFF
--- a/crates/boundless-market/src/indexer_client.rs
+++ b/crates/boundless-market/src/indexer_client.rs
@@ -322,7 +322,7 @@ impl IndexerClient {
                 && !entry.p95_lock_price_per_cycle.is_empty()
                 && !entry.p99_lock_price_per_cycle.is_empty()
             {
-                return Ok(PricePercentiles {
+                let percentiles = PricePercentiles {
                     p10: U256::from_str(&entry.p10_lock_price_per_cycle)
                         .context("Failed to parse p10 lock price per cycle")?,
                     p25: U256::from_str(&entry.p25_lock_price_per_cycle)
@@ -337,7 +337,18 @@ impl IndexerClient {
                         .context("Failed to parse p95 lock price per cycle")?,
                     p99: U256::from_str(&entry.p99_lock_price_per_cycle)
                         .context("Failed to parse p99 lock price per cycle")?,
-                });
+                };
+                tracing::debug!(
+                    p10 = %percentiles.p10,
+                    p25 = %percentiles.p25,
+                    p50 = %percentiles.p50,
+                    p75 = %percentiles.p75,
+                    p90 = %percentiles.p90,
+                    p95 = %percentiles.p95,
+                    p99 = %percentiles.p99,
+                    "Fetched price percentiles (lock price per cycle in wei) from indexer"
+                );
+                return Ok(percentiles);
             }
         }
 

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -701,13 +701,15 @@ where
                     match price_provider.price_percentiles().await {
                         Ok(percentiles) => {
                             let min = U256::ZERO;
-                            let max = percentiles.p99.min(percentiles.p50 * U256::from(2))
-                                * U256::from(cycle_count);
+                            let max_per_cycle =
+                                percentiles.p99.min(percentiles.p50 * U256::from(2));
+                            let max = max_per_cycle * U256::from(cycle_count);
                             tracing::debug!(
-                                "Using market prices from price provider: min={}, max={} (for {} cycles)",
+                                "Using market prices from price provider to set max price: p50_per_cycle: {} p99_per_cycle: {} min price: {} max price: {}",
+                                percentiles.p50,
+                                percentiles.p99,
                                 format_units(min, "ether")?,
                                 format_units(max, "ether")?,
-                                cycle_count
                             );
                             (Some(min), Some(max))
                         }


### PR DESCRIPTION
Log the price data the indexer returns and how it feeds into order pricing.

Changes
* Log all percentile values (p10–p99) returned by `IndexerClient::get_prices_percentiles()` after parsing
* Log the raw p50/p99 per-cycle values used in the max price computation in `OfferLayer::into_offer()`, alongside the final min/max

Set `RUST_LOG=boundless_market=debug` to see these when running the order generator.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to additional `tracing::debug!` logging and a minor refactor of max-price calculation variables without altering pricing logic.
> 
> **Overview**
> Adds `tracing::debug!` output in `IndexerClient::get_prices_percentiles()` to log all parsed percentile values (`p10`–`p99`) returned by the indexer.
> 
> Improves `OfferLayer` market-pricing diagnostics by logging the raw `p50`/`p99` per-cycle values used to compute the market-based max price, alongside the final min/max values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a675d9abad6ad7f7d0f07622dd73ea06bc5dbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->