### PR TITLE
fix redis handling of nil result

### DIFF
--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -2081,6 +2081,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "toml",
  "tower",
  "tracing",

--- a/bento/crates/workflow/src/redis.rs
+++ b/bento/crates/workflow/src/redis.rs
@@ -47,7 +47,15 @@ where
     T: FromRedisValue + Send + Sync + 'static,
 {
     let redis_start = Instant::now();
-    let result = conn.get::<_, T>(key).await;
+    let result: RedisResult<T> = match conn.get::<_, redis::Value>(key).await {
+        Ok(redis::Value::Nil) => Err(redis::RedisError::from((
+            redis::ErrorKind::TypeError,
+            "Key not found (nil response)",
+            key.to_string(),
+        ))),
+        Ok(val) => T::from_redis_value(&val),
+        Err(e) => Err(e),
+    };
     let elapsed = redis_start.elapsed().as_secs_f64();
     let status = if result.is_ok() { "success" } else { "error" };
     helpers::record_redis_operation("get", status, elapsed);


### PR DESCRIPTION
currently nil/not found gets returned as an empty vec if `T` is `Vec`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b141875ed1d78b93da8164cee5361425cd7d4b14. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->