### PR TITLE
chore: add `market_collateral` to prover cumulatives endpoint

### DIFF
--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -4008,8 +4008,9 @@ impl MarketDb {
         .fetch_one(&self.pool)
         .await?;
 
-        let value = U256::from_str_radix(&net_collateral, 10)
-            .map_err(|e| DbError::Error(anyhow::anyhow!("Failed to parse collateral U256: {}", e)))?;
+        let value = U256::from_str_radix(&net_collateral, 10).map_err(|e| {
+            DbError::Error(anyhow::anyhow!("Failed to parse collateral U256: {}", e))
+        })?;
         Ok(value)
     }
 

--- a/crates/lambdas/indexer-api/src/routes/market.rs
+++ b/crates/lambdas/indexer-api/src/routes/market.rs
@@ -2351,10 +2351,7 @@ async fn get_prover_cumulatives_impl(
         })
         .collect();
 
-    let market_collateral = state
-        .market_db
-        .get_prover_market_collateral(prover_address)
-        .await?;
+    let market_collateral = state.market_db.get_prover_market_collateral(prover_address).await?;
     let market_collateral_str = market_collateral.to_string();
 
     Ok(ProverCumulativesResponse {


### PR DESCRIPTION
## Description
- Add `market_collateral` and `market_collateral_formatted` fields to the `/v1/market/provers/:address/cumulatives` endpoint
- Compute prover's current deposited collateral balance from indexed events: `deposits - withdrawals - slashed - locked`
- Add `get_prover_market_collateral` method to `MarketDb`
- Add tests for the new DB method