### PR TITLE
BM-2818: Add docker system prune after prover deployment

### DIFF
--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -88,3 +88,8 @@
     name: bento
     enabled: true
     daemon_reload: true
+
+- name: Prune unused Docker resources
+  ansible.builtin.command:
+    cmd: docker system prune -af
+  changed_when: true


### PR DESCRIPTION
Runs `docker system prune -af` at the end of the prover Ansible role to clean up unused images, containers, networks, and build cache after each deploy. Over time old images pile up on prover hosts — this keeps disk usage in check.

Changes
* New task "Prune unused Docker resources" appended to `ansible/roles/prover/tasks/main.yml`, runs after bento service enablement