### PR TITLE
BM-2819: [next] Per-chain logging fixes, ansible deploy skill updates, other log changes

### DIFF
--- a/.claude/skills/setup-prover/SKILL.md
+++ b/.claude/skills/setup-prover/SKILL.md
@@ -60,11 +60,13 @@ Ensure the inventory file is in `.gitignore` (`ansible/inventory-*.yml` pattern)
 
 ### 2. Set environment variables
 
-The user must export secrets before running ansible:
+The inventory uses `{{ lookup('env', 'VAR') }}` for secrets. These resolve on the machine running `ansible-playbook`, not on the remote server. They must be exported in the same shell that runs the playbook.
 
 ```bash
 export PROVER_PRIVATE_KEY="<broker private key>"
-export PROVER_RPC_URLS="<RPC URL>"
+export PROVER_RPC_URL_8453="<Base RPC URL>"
+export PROVER_RPC_URL_167000="<Taiko RPC URL>"
+ansible-playbook -i inventory-<name>.yml prover.yml  # must be in the same shell
 ```
 
 ### 3. Test connectivity
@@ -102,27 +104,65 @@ ssh <user>@<host> "sudo docker compose -f /opt/bento/compose.yml --env-file /opt
 
 ## Image modes
 
-| Mode                   | Config                                | Description                                                                                       |
-| ---------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **Pre-built nightly**  | `prover_image_tag: "nightly-latest"`  | Pull latest CI images from GHCR (recommended)                                                     |
-| **Pinned nightly SHA** | `prover_image_tag: "nightly-abc1234"` | Pin to a specific CI build by commit SHA                                                          |
-| **Custom tag**         | `prover_image_tag: "my-custom-tag"`   | Any tag from GHCR (e.g. from `gh workflow run docker-services.yml -f custom_tag="my-custom-tag"`) |
-| **Pinned release**     | `prover_image_version: "1.3"`         | Use release-tagged images (e.g. `bento-v1.3`, `broker-v1.3`)                                      |
-| **Build from source**  | `prover_boundless_build: "all"`       | Build Docker images on the server (slow, not recommended)                                         |
+Before generating the inventory, ask the user which image mode they want. This matters because building from source is slow (Rust compilation) but required when deploying code from a feature branch that doesn't have CI-built images.
+
+Ask: **"Do you want to use pre-built images or build from source? If building from source, which components?"**
+
+| Mode                      | Config                                | Description                                                                                       |
+| ------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Pre-built nightly**     | `prover_image_tag: "nightly-latest"`  | Pull latest CI images from GHCR (recommended for `main` branch)                                   |
+| **Pinned nightly SHA**    | `prover_image_tag: "nightly-abc1234"` | Pin to a specific CI build by commit SHA                                                          |
+| **Custom tag**            | `prover_image_tag: "my-custom-tag"`   | Any tag from GHCR (e.g. from `gh workflow run docker-services.yml -f custom_tag="my-custom-tag"`) |
+| **Pinned release**        | `prover_image_version: "1.3"`         | Use release-tagged images (e.g. `bento-v1.3`, `broker-v1.3`)                                      |
+| **Build all from source** | `prover_boundless_build: "all"`       | Build all Docker images on the server (slow, not recommended unless needed)                       |
+| **Selective build**       | `prover_boundless_build: "broker"`    | Build specific service(s) from source, pull pre-built images for the rest                         |
 
 `prover_image_tag` takes precedence over `prover_image_version`. When set, ALL images use the exact same tag.
 
-## Broker configuration
+### Selective build + pre-built (hybrid mode)
 
-By default, broker.toml is downloaded from `prover_broker_toml_url`. To use a custom local file instead, set `prover_broker_toml_local` in the inventory:
+You can combine `prover_image_tag` with `prover_boundless_build` to build only specific services from source while pulling pre-built images for everything else. The justfile handles this by clearing the image tag for the built service at runtime (`export BROKER_IMAGE=""`) so docker compose builds it from the local Dockerfile instead of pulling.
+
+Example: deploy a feature branch that only changes the broker:
 
 ```yaml
-# Use a local broker.toml (recommended for custom configs)
-prover_broker_toml_local: "/path/to/my/broker.toml"
-
-# Or download from a URL (default)
-prover_broker_toml_url: "https://raw.githubusercontent.com/boundless-xyz/boundless/refs/heads/main/broker-template.toml"
+prover_image_tag: "nightly-latest"       # pre-built images for agents, rest_api, etc.
+prover_boundless_build: "broker"          # build only the broker from the branch source
 ```
+
+Valid `prover_boundless_build` values: `"all"`, `"broker"`, `"rest_api"`, `"exec_agent"`, `"aux_agent"`, `"gpu_prove_agent"`, `"miner"`, or space-separated combinations (e.g. `"broker rest_api"`).
+
+## Broker configuration
+
+Ask the user: **"Do you want to use an existing broker config from the repo, or specify your own config directory?"**
+
+**Option A: Use an existing config.** List the directories in `ansible/roles/prover/configs/broker/` and let the user pick:
+
+```yaml
+prover_broker_config_dir: "roles/prover/configs/broker/<chosen-config>"
+```
+
+**Option B: Specify a custom directory.** The user provides a path to a directory containing their own config files:
+
+```yaml
+prover_broker_config_dir: "/path/to/my/broker-config"
+```
+
+Ansible copies the entire directory contents to `/opt/bento/` on the remote server.
+
+The config directory should contain:
+
+- `broker.toml` — base config shared across all chains
+- `broker.{chain_id}.toml` — per-chain overrides (e.g. `broker.8453.toml`, `broker.167000.toml`)
+
+Per-chain override files must go in a `chain-overrides/` subdirectory (e.g. `chain-overrides/broker.8453.toml`). This is the directory mounted into the Docker container.
+
+IMPORTANT: `broker.toml` must include `min_mcycle_price` and `max_collateral` even if per-chain overrides replace them. These are required fields — the broker fails to parse the base config without them.
+
+Fallback options (when `prover_broker_config_dir` is not set):
+
+- `prover_broker_toml_local` — copies a single local file to `/opt/bento/broker.toml`
+- `prover_broker_toml_url` — downloads from a URL (default: `broker-template.toml` from main branch)
 
 ### Auto-generating config with the CLI wizard
 
@@ -158,7 +198,7 @@ ansible-playbook -i inventory-<name>.yml prover.yml --skip-tags nvidia
 ansible-playbook -i inventory-<name>.yml prover.yml --skip-tags nvidia,docker
 ```
 
-Note: `--tags prover` does NOT work as expected — the individual tasks inside the role are not tagged. Use `--skip-tags` instead. The NVIDIA/Docker roles are idempotent so running the full playbook on an already-configured host is safe and fast.
+Note: `--tags prover` does NOT work as expected — the individual tasks inside the role are not tagged. Use `--skip-tags` instead. IMPORTANT: `--skip-tags nvidia,docker` will ALSO skip the prover role because it is tagged with both `prover` and `docker`. To skip only the NVIDIA and Docker install roles, use `--skip-tags nvidia-install,docker-install`. The NVIDIA/Docker roles are idempotent so running the full playbook on an already-configured host is safe and fast.
 
 ## Tear down
 

--- a/crates/boundless-market/src/price_oracle/composite_oracle.rs
+++ b/crates/boundless-market/src/price_oracle/composite_oracle.rs
@@ -91,18 +91,16 @@ impl CompositeOracle {
     ) -> Result<ExchangeRate, PriceOracleError> {
         // Collect successful results
         let mut successful: Vec<ExchangeRate> = Vec::new();
+        let mut source_summaries: Vec<String> = Vec::new();
         for (i, result) in results.into_iter() {
             match result {
                 Ok(rate) => {
-                    tracing::debug!(
-                        "Source {} returned rate for {}: {} => {}. Timestamp: {} => {}",
+                    source_summaries.push(format!(
+                        "({}/{}/{})",
                         self.sources[i].name(),
-                        self.pair,
-                        rate.rate,
                         rate.rate_to_f64(),
-                        rate.timestamp,
                         rate.timestamp_to_human_readable()
-                    );
+                    ));
                     successful.push(rate);
                 }
                 Err(e) => {
@@ -144,13 +142,14 @@ impl CompositeOracle {
         };
 
         tracing::debug!(
-            "Aggregated rate for {} using {:?}: {} => {}. Timestamp: {} => {}",
+            "Aggregated rate for {} using {:?}: {} => {}. Timestamp: {} => {}. Sources: {}",
             self.pair,
             self.aggregation_mode,
             aggregated_rate.rate,
             aggregated_rate.rate_to_f64(),
             aggregated_rate.timestamp,
-            aggregated_rate.timestamp_to_human_readable()
+            aggregated_rate.timestamp_to_human_readable(),
+            source_summaries.join(", ")
         );
         Ok(aggregated_rate)
     }

--- a/crates/boundless-market/src/prover_utils/mod.rs
+++ b/crates/boundless-market/src/prover_utils/mod.rs
@@ -1052,7 +1052,7 @@ pub trait OrderPricingContext {
             );
 
             tracing::debug!(
-                "Order price: {} (collateral tokens) - cycles: {} - mcycle price: {} (collateral tokens), config_min_mcycle_price_collateral_tokens: {} (collateral tokens)",
+                "Order {order_id} price: {} (collateral tokens) - cycles: {} - mcycle price: {} (collateral tokens), config_min_mcycle_price_collateral_tokens: {} (collateral tokens)",
                 format_ether(price),
                 cycle_count,
                 self.format_collateral(mcycle_price_in_collateral_tokens),

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -889,7 +889,10 @@ impl Broker {
         // Pricers send preflight completions here; the evaluator reads from pricing_completion_rx to free capacity.
         let (pricing_completion_tx, pricing_completion_rx) =
             mpsc::channel(COMPLETION_CHANNEL_CAPACITY);
-        // Lock/fulfill events broadcast to both the evaluator (removes pending) and pricers (cancels active tasks).
+        // Shared broadcast for on-chain lock/fulfill events. Each chain's MarketMonitor sends into
+        // this channel, and both global singletons (OrderEvaluator, OrderCommitter) and per-chain
+        // components (OrderPricer, ProvingService) subscribe. Per-chain subscribers must filter by
+        // chain_id since they receive events from all chains.
         let (order_state_tx, _) = tokio::sync::broadcast::channel(ORDER_STATE_CHANNEL_CAPACITY);
         let mut chain_dispatchers: std::collections::HashMap<u64, mpsc::Sender<Box<OrderRequest>>> =
             std::collections::HashMap::new();

--- a/crates/broker/src/order_committer.rs
+++ b/crates/broker/src/order_committer.rs
@@ -530,7 +530,7 @@ impl RetryTask for OrderCommitter {
                             OrderStateChange::Locked { request_id, prover, chain_id } => {
                                 tracing::debug!(
                                     chain_id,
-                                    "Order committer: request 0x{:x} on chain {chain_id} locked by {:x}, removing pending LockAndFulfill orders",
+                                    "Order committer: request 0x{:x} on chain {chain_id} locked by 0x{:x}, removing pending LockAndFulfill orders",
                                     request_id, prover,
                                 );
                                 let initial_len = pending_orders.len();

--- a/crates/broker/src/order_pricer.rs
+++ b/crates/broker/src/order_pricer.rs
@@ -49,6 +49,7 @@ use tokio::{
     task::JoinSet,
 };
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
 
 const LOG_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -744,12 +745,15 @@ where
                                 (false, false) => PreflightOutcome::Skipped,
                             };
                             (order_id, request_id, outcome)
-                        });
+                        }.instrument(Span::current()));
                     }
                     Ok(state_change) = order_state_rx.recv() => {
+                        if state_change.chain_id() != pricer.chain_id {
+                            continue;
+                        }
                         match state_change {
                             OrderStateChange::Locked { request_id, prover, .. } => {
-                                tracing::debug!("Received order state change for request 0x{:x}: Locked by prover {:x}",
+                                tracing::debug!("Received order state change for request 0x{:x}: Locked by prover 0x{:x}",
                                     request_id, prover);
                                 active_preflights.cancel_lock_and_fulfill(&request_id);
                             }

--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -36,6 +36,7 @@ use boundless_market::contracts::boundless_market::BoundlessMarketService;
 use boundless_market::telemetry::CompletionOutcome;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
 
 #[derive(Error)]
 pub enum ProvingErr {
@@ -379,6 +380,7 @@ impl ProvingService {
                 // External fulfillment notification
                 recv_res = order_state_rx.recv() => {
                     match recv_res {
+                        Ok(ref sc) if sc.chain_id() != self.chain_id => continue,
                         Ok(OrderStateChange::Fulfilled { request_id: fulfilled_request_id, .. }) if fulfilled_request_id == request_id => {
                             // Determine if this makes the order not actionable based on order type
                             let is_not_actionable = match order.fulfillment_type {
@@ -611,7 +613,10 @@ impl ProvingService {
 
             // Spawn monitoring task - it will handle expiry/cancellation based on config
             let prove_serv = self.clone();
-            tokio::spawn(async move { prove_serv.prove_and_update_db(order).await });
+            let span = Span::current();
+            tokio::spawn(
+                async move { prove_serv.prove_and_update_db(order).await }.instrument(span),
+            );
         }
 
         Ok(())
@@ -654,7 +659,10 @@ impl RetryTask for ProvingService {
 
                 if let Some(order) = order_res {
                     let prov_serv = proving_service_copy.clone();
-                    tokio::spawn(async move { prov_serv.prove_and_update_db(order).await });
+                    let span = Span::current();
+                    tokio::spawn(
+                        async move { prov_serv.prove_and_update_db(order).await }.instrument(span),
+                    );
                 }
 
                 // TODO: configuration

--- a/crates/broker/src/task.rs
+++ b/crates/broker/src/task.rs
@@ -19,6 +19,7 @@ use anyhow::{Context, Result as AnyhowRes};
 use thiserror::Error;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
 
 #[derive(Error, Debug)]
 pub enum SupervisorErr<E: CodedError> {
@@ -121,10 +122,11 @@ where
         let mut retry_count = 0;
         let mut current_delay = self.retry_policy.delay;
         let mut last_spawn_time = std::time::Instant::now();
+        let parent_span = Span::current();
 
         // Spawn initial task
         tracing::debug!("Spawning task");
-        tasks.spawn(self.task.spawn(self.cancel_token.clone()));
+        tasks.spawn(self.task.spawn(self.cancel_token.clone()).instrument(parent_span.clone()));
 
         while let Some(res) = tasks.join_next().await {
             // Check if we should reset the retry counter based on how long the task ran
@@ -176,11 +178,14 @@ where
                             // Instead of sleeping here, wrap the task spawn with a delay
                             let task_clone = self.task.clone();
                             let t = task_clone.spawn(self.cancel_token.clone());
-                            tasks.spawn(async move {
-                                // Apply calculated retry delay before spawning the task
-                                tokio::time::sleep(current_delay).await;
-                                t.await
-                            });
+                            tasks.spawn(
+                                async move {
+                                    // Apply calculated retry delay before spawning the task
+                                    tokio::time::sleep(current_delay).await;
+                                    t.await
+                                }
+                                .instrument(parent_span.clone()),
+                            );
 
                             retry_count += 1;
                             last_spawn_time = std::time::Instant::now() + current_delay;

--- a/crates/order-stream/src/heartbeat.rs
+++ b/crates/order-stream/src/heartbeat.rs
@@ -27,7 +27,7 @@ use axum::{
 use boundless_market::contracts::IBoundlessMarket;
 use moka::future::Cache;
 
-const BALANCE_CACHE_TTL_SECS: u64 = 6000;
+const BALANCE_CACHE_TTL_SECS: u64 = 1200;
 const BALANCE_CACHE_MAX_ENTRIES: u64 = 10_000;
 
 // Per-record size limits (2x the largest reasonable payload).


### PR DESCRIPTION
Various minor fixes + tweaks from running multi-chain broker via Ansible on my dev machine today

Changes
* Broker code updates for multi-chain order processing (order_pricer, order_committer, proving, task)
* Price oracle composite_oracle changes for multi-chain support
* Updated setup-prover skill: added image mode selection (pre-built vs build from source), env var same-shell caveat, broker config dir guidance with chain-overrides docs, skip-tags gotcha for nvidia/docker
