### PR TITLE
BM-2821: Fix CLI release workflow to mark RC tags as prerelease

### DIFF
--- a/.github/workflows/boundless-cli-release.yml
+++ b/.github/workflows/boundless-cli-release.yml
@@ -161,6 +161,11 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "release_name=Boundless CLI Release $VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *"-rc."* ]]; then
+            echo "is_rc=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_rc=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Release
         id: create_release
@@ -174,7 +179,7 @@ jobs:
             ## Boundless CLI Release
 
             This release includes a package of:
-            - **Boundless ClI**
+            - **Boundless CLI**
 
             ### Supported Platforms
             - Linux AMD64
@@ -200,7 +205,7 @@ jobs:
             ### Verification
             Verify the integrity of downloaded packages using the provided SHA256 checksums.
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.get_version.outputs.is_rc == 'true' }}
 
       - name: Upload Boundless CLI Package (Linux AMD64)
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
The `boundless-cli-release.yml` workflow creates a stable (non-prerelease) GitHub Release for every `boundless-v*` tag, including RC tags like `boundless-v1.0.0-rc.1`. This means RC releases are indistinguishable from final releases.

### Fix

Added RC detection logic (matching the pattern already used by `broker-release.yml` and `bento-release.yml`):

- Tags containing `-rc.` (e.g., `boundless-v1.5.0-rc.1`) now create a **prerelease** GitHub Release
- All other tags create a stable release as before

Also fixed a typo in the release body ("ClI" → "CLI").