### PR TITLE
BM-2823: Add `deposit-to` and `deposit-collateral-to` CLI commands

### DIFF
--- a/crates/boundless-cli/src/commands/prover/deposit_collateral_to.rs
+++ b/crates/boundless-cli/src/commands/prover/deposit_collateral_to.rs
@@ -1,0 +1,191 @@
+// Copyright 2026 Boundless Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloy::primitives::{utils::parse_units, Address, U256};
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+
+use crate::config::{GlobalConfig, ProverConfig};
+use crate::config_ext::ProverConfigExt;
+use crate::contracts::{get_token_balance, get_token_info};
+use crate::display::{format_token, network_name_from_chain_id, DisplayManager};
+
+/// Deposit collateral funds into the market on behalf of another address
+#[derive(Args, Clone, Debug)]
+pub struct ProverDepositCollateralTo {
+    /// Amount to deposit in HP or USDC based on the chain ID.
+    pub amount: String,
+
+    /// Address to credit with the collateral deposit
+    #[clap(long)]
+    pub to: Address,
+
+    /// Prover configuration options
+    #[clap(flatten, next_help_heading = "Prover")]
+    pub prover_config: ProverConfig,
+}
+
+impl ProverDepositCollateralTo {
+    /// Run the deposit-collateral-to command
+    pub async fn run(&self, global_config: &GlobalConfig) -> Result<()> {
+        let prover_config = self.prover_config.clone().load_and_validate()?;
+        prover_config.require_private_key_with_help()?;
+
+        let client = prover_config
+            .client_builder_with_signer(global_config.tx_timeout)?
+            .build()
+            .await
+            .context("Failed to build Boundless Client with signer")?;
+
+        let network_name = network_name_from_chain_id(client.deployment.market_chain_id);
+        let display = DisplayManager::with_network(network_name);
+
+        // Get collateral token information
+        let collateral_token_address = client.boundless_market.collateral_token_address().await?;
+        let token_info = get_token_info(client.provider(), collateral_token_address).await?;
+        let collateral_label = format!("collateral ({})", token_info.symbol);
+
+        // Parse and validate amount
+        let parsed_amount = parse_units(&self.amount, token_info.decimals)
+            .map_err(|e| anyhow!("Failed to parse amount: {}", e))?
+            .into();
+
+        if parsed_amount == U256::from(0) {
+            bail!("Amount is below the denomination minimum: {}", self.amount);
+        }
+
+        let formatted_amount = format_token(parsed_amount, token_info.decimals)?;
+
+        display.header(&format!("Depositing {} to Boundless Market", collateral_label));
+        display.warning(
+            "Collateral will be credited to the recipient address. \
+             Only the holder of the recipient's private key can withdraw it.",
+        );
+        display.balance("Amount", &formatted_amount, &token_info.symbol, "cyan");
+        display.address("Recipient", self.to);
+
+        // Check if collateral token supports permit (EIP-2612)
+        if !client.deployment.collateral_token_supports_permit() {
+            display.status("Step 1", "Approving token", "yellow");
+            client.boundless_market.approve_deposit_collateral(parsed_amount).await?;
+
+            display.status("Step 2", &format!("Depositing {}", collateral_label), "yellow");
+            match client.boundless_market.deposit_collateral_to(self.to, parsed_amount).await {
+                Ok(_) => {
+                    self.display_success(
+                        &display,
+                        &client,
+                        &token_info,
+                        &formatted_amount,
+                        &collateral_label,
+                    )
+                    .await?;
+                    Ok(())
+                }
+                Err(e) => {
+                    if e.to_string().contains("TRANSFER_FROM_FAILED") {
+                        let addr = client.boundless_market.caller();
+                        Err(anyhow!(
+                            "Failed to deposit {collateral_label}: Ensure your address ({addr}) has funds on the {} contract",
+                            token_info.symbol
+                        ))
+                    } else {
+                        Err(anyhow!("Failed to deposit {collateral_label}: {e}"))
+                    }
+                }
+            }
+        } else {
+            display.status(
+                "Status",
+                &format!("Depositing {} with permit", collateral_label),
+                "yellow",
+            );
+            let signer = client.signer.as_ref().unwrap();
+            match client
+                .boundless_market
+                .deposit_collateral_with_permit_to(self.to, parsed_amount, signer)
+                .await
+            {
+                Ok(_) => {
+                    self.display_success(
+                        &display,
+                        &client,
+                        &token_info,
+                        &formatted_amount,
+                        &collateral_label,
+                    )
+                    .await?;
+                    Ok(())
+                }
+                Err(e) => {
+                    if e.to_string().contains("TRANSFER_FROM_FAILED") {
+                        let addr = client.boundless_market.caller();
+                        Err(anyhow!(
+                            "Failed to deposit {collateral_label}: Ensure your address ({addr}) has funds on the {} contract",
+                            token_info.symbol
+                        ))
+                    } else {
+                        Err(anyhow!("Failed to deposit {collateral_label}: {e}"))
+                    }
+                }
+            }
+        }
+    }
+
+    async fn display_success<P, St, D, Rb, Si>(
+        &self,
+        display: &DisplayManager,
+        client: &boundless_market::Client<P, St, D, Rb, Si>,
+        token_info: &crate::contracts::TokenInfo,
+        formatted_amount: &str,
+        collateral_label: &str,
+    ) -> Result<()>
+    where
+        P: alloy::providers::Provider<alloy::network::Ethereum> + Clone + 'static,
+    {
+        display.success(&format!(
+            "Successfully deposited {}: {} {} to {:?}",
+            collateral_label, formatted_amount, token_info.symbol, self.to
+        ));
+
+        // Display updated balance for the recipient
+        let deposited = client.boundless_market.balance_of_collateral(self.to).await?;
+        let available = get_token_balance(client.provider(), token_info.address, self.to).await?;
+
+        let deposited_formatted = format_token(deposited, token_info.decimals)?;
+        let available_formatted = format_token(available, token_info.decimals)?;
+
+        display.address("Recipient", self.to);
+        display.balance("Deposited", &deposited_formatted, &token_info.symbol, "green");
+        display.balance("Available", &available_formatted, &token_info.symbol, "cyan");
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_common;
+    use predicates::str::contains;
+
+    #[tokio::test]
+    async fn test_deposit_collateral_to_help() {
+        test_common::BoundlessCmd::new("prover", "deposit-collateral-to")
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(contains("Usage:"))
+            .stdout(contains("deposit-collateral-to"));
+    }
+}

--- a/crates/boundless-cli/src/commands/prover/mod.rs
+++ b/crates/boundless-cli/src/commands/prover/mod.rs
@@ -18,6 +18,7 @@ mod balance_collateral;
 mod benchmark;
 mod config;
 mod deposit_collateral;
+mod deposit_collateral_to;
 mod execute;
 mod fulfill;
 mod generate_config;
@@ -29,6 +30,7 @@ pub use balance_collateral::ProverBalanceCollateral;
 pub use benchmark::ProverBenchmark;
 pub use config::ProverConfigCmd;
 pub use deposit_collateral::ProverDepositCollateral;
+pub use deposit_collateral_to::ProverDepositCollateralTo;
 pub use execute::ProverExecute;
 pub use fulfill::ProverFulfill;
 pub use generate_config::ProverGenerateConfig;
@@ -59,6 +61,9 @@ pub enum ProverCommands {
     /// Deposit collateral funds into the market
     #[command(name = "deposit-collateral")]
     DepositCollateral(ProverDepositCollateral),
+    /// Deposit collateral funds into the market on behalf of another address
+    #[command(name = "deposit-collateral-to")]
+    DepositCollateralTo(ProverDepositCollateralTo),
     /// Withdraw collateral funds from the market
     #[command(name = "withdraw-collateral")]
     WithdrawCollateral(ProverWithdrawCollateral),
@@ -88,6 +93,7 @@ impl ProverCommands {
         match self {
             Self::Config(cmd) => cmd.run(global_config).await,
             Self::DepositCollateral(cmd) => cmd.run(global_config).await,
+            Self::DepositCollateralTo(cmd) => cmd.run(global_config).await,
             Self::WithdrawCollateral(cmd) => cmd.run(global_config).await,
             Self::BalanceCollateral(cmd) => cmd.run(global_config).await,
             Self::Lock(cmd) => cmd.run(global_config).await,

--- a/crates/boundless-cli/src/commands/requestor/deposit_to.rs
+++ b/crates/boundless-cli/src/commands/requestor/deposit_to.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 Boundless Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloy::primitives::{utils::parse_ether, Address, U256};
+use anyhow::Result;
+use clap::Args;
+
+use crate::config::{GlobalConfig, RequestorConfig};
+use crate::config_ext::RequestorConfigExt;
+use crate::display::{format_eth, network_name_from_chain_id, DisplayManager};
+
+/// Command to deposit funds into the market on behalf of another address
+#[derive(Args, Clone, Debug)]
+pub struct RequestorDepositTo {
+    /// Amount in ether to deposit
+    #[clap(value_parser = parse_ether)]
+    pub amount: U256,
+
+    /// Address to credit with the deposit
+    #[clap(long)]
+    pub to: Address,
+
+    /// Requestor configuration (RPC URL, private key, deployment)
+    #[clap(flatten)]
+    pub requestor_config: RequestorConfig,
+}
+
+impl RequestorDepositTo {
+    /// Run the deposit-to command
+    pub async fn run(&self, global_config: &GlobalConfig) -> Result<()> {
+        let requestor_config = self.requestor_config.clone().load_and_validate()?;
+        requestor_config.require_private_key_with_help()?;
+
+        let client =
+            requestor_config.client_builder_with_signer(global_config.tx_timeout)?.build().await?;
+        let network_name = network_name_from_chain_id(client.deployment.market_chain_id);
+
+        let display = DisplayManager::with_network(network_name);
+        let formatted = format_eth(self.amount);
+
+        display.header("Depositing funds (ETH) to Boundless Market");
+        display.warning(
+            "Funds will be credited to the recipient address. \
+             Only the holder of the recipient's private key can withdraw them.",
+        );
+        display.balance("Amount", &formatted, "ETH", "cyan");
+        display.address("Recipient", self.to);
+
+        client.boundless_market.deposit_to(self.to, self.amount).await?;
+
+        display.success(&format!("Successfully deposited {} ETH to {:?}", formatted, self.to));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_common::TestContext;
+    use predicates::str::contains;
+
+    #[tokio::test]
+    async fn test_deposit_to_help() {
+        crate::test_common::BoundlessCmd::new("requestor", "deposit-to")
+            .arg("--help")
+            .assert()
+            .success()
+            .stdout(contains("Usage:"))
+            .stdout(contains("deposit-to"));
+    }
+
+    #[tokio::test]
+    async fn test_deposit_to_without_amount() {
+        let ctx = TestContext::base().await;
+        let account = ctx.account(0);
+
+        ctx.cmd("requestor", "deposit-to").with_account(&account).assert().failure();
+    }
+
+    #[tokio::test]
+    async fn test_deposit_to_executes() {
+        let ctx = TestContext::base().await;
+        let account0 = ctx.account(0);
+        let account1 = ctx.account(1);
+
+        ctx.cmd("requestor", "deposit-to")
+            .arg("0.01")
+            .arg("--to")
+            .arg(&format!("{:?}", account1.address))
+            .with_account(&account0)
+            .assert()
+            .success()
+            .stdout(contains("Depositing"))
+            .stdout(contains("ETH"));
+    }
+}

--- a/crates/boundless-cli/src/commands/requestor/deposit_to.rs
+++ b/crates/boundless-cli/src/commands/requestor/deposit_to.rs
@@ -96,7 +96,7 @@ mod tests {
         ctx.cmd("requestor", "deposit-to")
             .arg("0.01")
             .arg("--to")
-            .arg(&format!("{:?}", account1.address))
+            .arg(&account1.address)
             .with_account(&account0)
             .assert()
             .success()

--- a/crates/boundless-cli/src/commands/requestor/mod.rs
+++ b/crates/boundless-cli/src/commands/requestor/mod.rs
@@ -17,6 +17,7 @@
 mod balance;
 mod config;
 mod deposit;
+mod deposit_to;
 mod get_proof;
 mod status;
 mod submit;
@@ -27,6 +28,7 @@ mod withdraw;
 pub use balance::RequestorBalance;
 pub use config::RequestorConfigCmd;
 pub use deposit::RequestorDeposit;
+pub use deposit_to::RequestorDepositTo;
 pub use get_proof::RequestorGetProof;
 pub use status::RequestorStatus;
 pub use submit::RequestorSubmit;
@@ -56,6 +58,9 @@ pub enum RequestorCommands {
     Config(RequestorConfigCmd),
     /// Deposit funds into the market
     Deposit(RequestorDeposit),
+    /// Deposit funds into the market on behalf of another address
+    #[command(name = "deposit-to")]
+    DepositTo(RequestorDepositTo),
     /// Withdraw funds from the market
     Withdraw(RequestorWithdraw),
     /// Check the balance of an account in the market
@@ -87,6 +92,7 @@ impl RequestorCommands {
         match self {
             Self::Config(cmd) => cmd.run(global_config).await,
             Self::Deposit(cmd) => cmd.run(global_config).await,
+            Self::DepositTo(cmd) => cmd.run(global_config).await,
             Self::Withdraw(cmd) => cmd.run(global_config).await,
             Self::DepositedBalance(cmd) | Self::Balance(cmd) => cmd.run(global_config).await,
             Self::Submit(cmd) => cmd.run(global_config).await,

--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -482,6 +482,22 @@ impl<P: Provider> BoundlessMarketService<P> {
         Ok(())
     }
 
+    /// Deposit Ether into the market credited to another address's balance.
+    pub async fn deposit_to(&self, to: Address, value: U256) -> Result<(), MarketError> {
+        tracing::trace!("Calling depositTo({:?}) value: {value}", to);
+        let call = self.instance.depositTo(to).value(value);
+        let pending_tx = call.send().await?;
+        tracing::debug!("Broadcasting depositTo tx {}", pending_tx.tx_hash());
+        let tx_hash = pending_tx
+            .with_timeout(Some(self.timeout))
+            .watch()
+            .await
+            .context("failed to confirm depositTo tx")?;
+        tracing::debug!("Submitted depositTo {}", tx_hash);
+
+        Ok(())
+    }
+
     /// Withdraw Ether from the market.
     pub async fn withdraw(&self, amount: U256) -> Result<(), MarketError> {
         tracing::trace!("Calling withdraw({amount})");


### PR DESCRIPTION
  - Add `deposit-to` CLI command for requestors to deposit ETH into the market credited to another address
  - Add `deposit-collateral-to` CLI command for provers to deposit collateral tokens on behalf of another address, with full approve/permit support
  - Add `deposit_to` Rust SDK binding on `BoundlessMarket` for the existing `depositTo(address)` contract method (the `deposit_collateral_to` / `deposit_collateral_with_permit_to`
  bindings already existed)
  - Both new commands display a warning banner reminding users that only the recipient's private key holder can withdraw the deposited funds