### PR TITLE
BM-2824: Fix Docker tag conflict for `next` branch

### DIFF
--- a/.github/workflows/docker-services.yml
+++ b/.github/workflows/docker-services.yml
@@ -201,7 +201,8 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.service.name }}
           tags: |
             type=sha,prefix=nightly-
-            type=raw,value=nightly-latest
+            type=raw,value=nightly-latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=next-latest,enable=${{ github.ref == 'refs/heads/next' }}
             type=match,pattern=infra-v(.*),group=1
             type=ref,event=pr
             type=raw,value=${{ inputs.custom_tag }},enable=${{ inputs.custom_tag != '' }}


### PR DESCRIPTION
  - Prevent `next` branch pushes from overwriting the `nightly-latest` Docker tag used by `main`
  - `main` pushes continue to tag images as `nightly-latest`
  - `next` pushes now tag images as `next-latest` instead
  - Both branches still produce `nightly-<sha>` tags for traceability

  ### Why

  The `docker-services.yml` workflow triggers on both `main` and `next`, and both were writing the same `nightly-latest` rolling tag. Whichever branch merged last would silently overwrite the other's images. This is especially problematic because `retag-image.yml` defaults to promoting `nightly-latest` to `latest`, meaning `next` code could accidentally be promoted to production.