### PR TITLE
BM-2829: Add Signal (Eth Sepolia) requestor to standard priority list

### DIFF
--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -25,20 +25,6 @@
       }
     },
     {
-      "address": "0xd60c3875952e2eEc0D04e3BC74eA9dDcdeaa902c",
-      "chainId": 11155111,
-      "name": "Signal (Eth Sepolia)",
-      "description": "ZKasper Signal - finality proofs of Ethereum Sepolia, that require substantial compute resources",
-      "tags": [],
-      "extensions": {
-        "requestEstimates": {
-          "estimatedMcycleCountMin": 50000,
-          "estimatedMcycleCountMax": 55000,
-          "estimatedMaxInputSizeMB": 1000
-        }
-      }
-    },
-    {
       "address": "0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e",
       "chainId": 8453,
       "name": "Mango",

--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -25,6 +25,20 @@
       }
     },
     {
+      "address": "0xd60c3875952e2eEc0D04e3BC74eA9dDcdeaa902c",
+      "chainId": 11155111,
+      "name": "Signal (Eth Sepolia)",
+      "description": "ZKasper Signal - finality proofs of Ethereum Sepolia, that require substantial compute resources",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 50000,
+          "estimatedMcycleCountMax": 55000,
+          "estimatedMaxInputSizeMB": 1000
+        }
+      }
+    },
+    {
       "address": "0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e",
       "chainId": 8453,
       "name": "Mango",

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -174,7 +174,7 @@
         "requestEstimates": {
           "estimatedMcycleCountMin": 400,
           "estimatedMcycleCountMax": 600,
-          "estimatedMaxInputSizeMB": 1000
+          "estimatedMaxInputSizeMB": 1
         }
       }
     },

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -165,6 +165,20 @@
       }
     },
     {
+      "address": "0xd60c3875952e2eEc0D04e3BC74eA9dDcdeaa902c",
+      "chainId": 8453,
+      "name": "Signal (Eth Sepolia)",
+      "description": "ZKasper Signal - finality proofs of Ethereum Sepolia",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 400,
+          "estimatedMcycleCountMax": 600,
+          "estimatedMaxInputSizeMB": 1000
+        }
+      }
+    },
+    {
       "address": "0x31DEf5d13d2521ADA03c47E064204692c4e351ec",
       "chainId": 8453,
       "name": "KailuaTestFP",

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -165,7 +165,7 @@
       }
     },
     {
-      "address": "0xd60c3875952e2eEc0D04e3BC74eA9dDcdeaa902c",
+      "address": "0xE30260d1Dc14E70B17951e97719a9D81e768d2C1",
       "chainId": 8453,
       "name": "Signal (Eth Sepolia)",
       "description": "ZKasper Signal - finality proofs of Ethereum Sepolia",


### PR DESCRIPTION
Add the Signal Eth Sepolia requestor (0xE30260d1Dc14E70B17951e97719a9D81e768d2C1, chain 11155111) to the standard prover priority list.

Changes
* New entry in boundless-priority-list.standard.json for Signal on Eth Sepolia with matching cycle/input estimates
