### PR TITLE
BM-2832: Add concurrency guards to workflows missing them

### DIFF
--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/retag-image.yml
+++ b/.github/workflows/retag-image.yml
@@ -15,6 +15,10 @@ on:
         required: true
         default: 'latest'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.image }}
+  cancel-in-progress: false
+
 permissions:
   packages: write
 


### PR DESCRIPTION
- Adds `concurrency` configuration to 4 workflows that were missing it, preventing resource contention on self-hosted runners
- `nightly-signal-execute.yml`: group per PR branch, cancel-in-progress                                                                                                           
- `nightly-examples.yml`: singleton group, cancel-in-progress (manual dispatch during nightly cancels stale run)                                                                  
- `post-merge.yml`: group per ref, cancel-in-progress (rapid merges to main only keep latest)                                                                                     
- `retag-image.yml`: group per image name, queue instead of cancel (different images retag in parallel, same image serialize