### PR TITLE
BM-2833: [next] Per-chain gas presets for low/medium/high priority modes

### DIFF
--- a/crates/boundless-market/src/deployments.rs
+++ b/crates/boundless-market/src/deployments.rs
@@ -215,40 +215,135 @@ pub fn collateral_token_supports_permit(chain_id: u64) -> bool {
     chain_id == 1 || chain_id == 11155111 || chain_id == 31337 || chain_id == 1337
 }
 
-/// Per-chain gas estimation defaults.
-///
-/// Chains with volatile gas markets (Base, Ethereum) use the generic defaults.
-/// Chains with stable low gas (Taiko) use conservative settings to avoid overestimating.
-#[derive(Debug)]
-pub struct GasConfig {
-    /// Gas estimation mode for profitability calculations (should reflect actual expected cost).
-    pub estimation_priority_mode: PriorityMode,
-    /// Gas priority mode for sending transactions (can include safety buffers).
-    pub gas_priority_mode: PriorityMode,
+/// Low/medium/high gas presets for a single context (priority or estimation).
+#[derive(Debug, Clone)]
+pub struct TierPresets {
+    /// Low priority preset.
+    pub low: PriorityMode,
+    /// Medium priority preset.
+    pub medium: PriorityMode,
+    /// High priority preset.
+    pub high: PriorityMode,
 }
 
-/// Returns chain-specific gas estimation defaults, if any.
-///
-/// Returns `None` for chains where the generic defaults are appropriate (Base, Ethereum, etc.).
-/// Returns tuned values for chains with different gas market characteristics (e.g. Taiko).
-pub fn gas_config_for_chain(chain_id: u64) -> Option<GasConfig> {
+impl TierPresets {
+    /// Resolve a PriorityMode using these presets.
+    /// Low/Medium/High are replaced with the preset values.
+    /// Custom is returned as-is.
+    pub fn resolve(&self, mode: &PriorityMode) -> PriorityMode {
+        match mode {
+            PriorityMode::Low => self.low.clone(),
+            PriorityMode::Medium => self.medium.clone(),
+            PriorityMode::High => self.high.clone(),
+            PriorityMode::Custom { .. } => mode.clone(),
+        }
+    }
+}
+
+/// Per-chain gas presets for both sending (priority) and profitability estimation.
+#[derive(Debug, Clone)]
+pub struct ChainGasPresets {
+    /// Presets for `gas_priority_mode` (sending transactions).
+    pub priority: TierPresets,
+    /// Presets for `gas_estimation_priority_mode` (profitability calculations).
+    pub estimation: TierPresets,
+}
+
+/// Generic gas presets used by chains that don't define their own.
+fn default_presets() -> ChainGasPresets {
+    ChainGasPresets {
+        priority: TierPresets {
+            low: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 200,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 20.0,
+                dynamic_multiplier_percentage: 3,
+            },
+            medium: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 200,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 30.0,
+                dynamic_multiplier_percentage: 5,
+            },
+            high: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 250,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 50.0,
+                dynamic_multiplier_percentage: 7,
+            },
+        },
+        // Conservative settings for profitability estimation: 1x base fee, no
+        // dynamic multiplier, lower percentiles than priority. Overestimating
+        // here causes the broker to skip profitable orders.
+        estimation: TierPresets {
+            low: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 100,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 10.0,
+                dynamic_multiplier_percentage: 0,
+            },
+            medium: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 100,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 20.0,
+                dynamic_multiplier_percentage: 0,
+            },
+            high: PriorityMode::Custom {
+                base_fee_multiplier_percentage: 100,
+                priority_fee_multiplier_percentage: 100,
+                priority_fee_percentile: 30.0,
+                dynamic_multiplier_percentage: 0,
+            },
+        },
+    }
+}
+
+/// Returns gas presets for a chain. Falls back to generic defaults.
+pub fn gas_presets_for_chain(chain_id: u64) -> ChainGasPresets {
     match chain_id {
         // Taiko: very stable gas at ~0.01 gwei, essentially zero priority fee.
-        // Default estimation mode (20th percentile + 1x multiplier) overshoots.
-        167000 => Some(GasConfig {
-            estimation_priority_mode: PriorityMode::Custom {
-                base_fee_multiplier_percentage: 100,
-                priority_fee_multiplier_percentage: 100,
-                priority_fee_percentile: 5.0,
-                dynamic_multiplier_percentage: 0,
+        167000 => ChainGasPresets {
+            priority: TierPresets {
+                low: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 100,
+                    priority_fee_multiplier_percentage: 100,
+                    priority_fee_percentile: 1.0,
+                    dynamic_multiplier_percentage: 2,
+                },
+                medium: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 100,
+                    priority_fee_multiplier_percentage: 100,
+                    priority_fee_percentile: 5.0,
+                    dynamic_multiplier_percentage: 3,
+                },
+                high: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 150,
+                    priority_fee_multiplier_percentage: 150,
+                    priority_fee_percentile: 20.0,
+                    dynamic_multiplier_percentage: 4,
+                },
             },
-            gas_priority_mode: PriorityMode::Custom {
-                base_fee_multiplier_percentage: 100,
-                priority_fee_multiplier_percentage: 100,
-                priority_fee_percentile: 5.0,
-                dynamic_multiplier_percentage: 0,
+            estimation: TierPresets {
+                low: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 100,
+                    priority_fee_multiplier_percentage: 100,
+                    priority_fee_percentile: 10.0,
+                    dynamic_multiplier_percentage: 2,
+                },
+                medium: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 100,
+                    priority_fee_multiplier_percentage: 100,
+                    priority_fee_percentile: 20.0,
+                    dynamic_multiplier_percentage: 3,
+                },
+                high: PriorityMode::Custom {
+                    base_fee_multiplier_percentage: 150,
+                    priority_fee_multiplier_percentage: 150,
+                    priority_fee_percentile: 30.0,
+                    dynamic_multiplier_percentage: 4,
+                },
             },
-        }),
-        _ => None,
+        },
+        _ => default_presets(),
     }
 }

--- a/crates/boundless-market/src/prover_utils/config.rs
+++ b/crates/boundless-market/src/prover_utils/config.rs
@@ -82,16 +82,7 @@ pub mod defaults {
     }
 
     pub fn estimation_priority_mode() -> PriorityMode {
-        // 1× raw base fee (no multiplier) + 20th percentile priority fee.
-        // Reflects what the broker actually expects to pay, without the safety buffers
-        // used for tx sending. Overestimating here causes the broker to inflate prices, lock later
-        // and potentially skip profitable orders.
-        PriorityMode::Custom {
-            base_fee_multiplier_percentage: 100,
-            priority_fee_multiplier_percentage: 100,
-            priority_fee_percentile: 20.0,
-            dynamic_multiplier_percentage: 0,
-        }
+        PriorityMode::Medium
     }
 
     pub const fn max_submission_attempts() -> u32 {
@@ -887,25 +878,14 @@ impl Config {
 }
 
 impl MarketConfig {
-    /// Apply chain-specific gas estimation defaults for fields the user hasn't overridden.
-    ///
-    /// Compares current values against the generic defaults — if they match (i.e. the user
-    /// didn't set them in TOML), replaces them with chain-tuned values from `deployments.rs`.
+    /// Resolve Low/Medium/High gas modes to chain-specific preset values.
+    /// Each context (priority and estimation) has its own set of presets.
+    /// Custom modes are left as-is.
     pub fn apply_chain_defaults(&mut self, chain_id: u64) {
-        if let Some(gas_config) = crate::deployments::gas_config_for_chain(chain_id) {
-            if self.gas_estimation_priority_mode == defaults::estimation_priority_mode() {
-                tracing::debug!(
-                    "Applying chain-specific gas estimation defaults for chain {chain_id}"
-                );
-                self.gas_estimation_priority_mode = gas_config.estimation_priority_mode;
-            }
-            if self.gas_priority_mode == defaults::priority_mode() {
-                tracing::debug!(
-                    "Applying chain-specific gas priority defaults for chain {chain_id}"
-                );
-                self.gas_priority_mode = gas_config.gas_priority_mode;
-            }
-        }
+        let presets = crate::deployments::gas_presets_for_chain(chain_id);
+        self.gas_priority_mode = presets.priority.resolve(&self.gas_priority_mode);
+        self.gas_estimation_priority_mode =
+            presets.estimation.resolve(&self.gas_estimation_priority_mode);
     }
 }
 

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -606,7 +606,6 @@ peak_prove_khz = 999
     #[traced_test]
     async fn config_watcher_chain_defaults_applied_and_survive_reload() {
         use boundless_market::dynamic_gas_filler::PriorityMode;
-        use boundless_market::prover_utils::config_defaults;
         use std::io::{Seek, Write};
 
         let dir = tempfile::tempdir().unwrap();
@@ -626,15 +625,15 @@ max_collateral = "10 USD"
 
         {
             let config = watcher.config.lock_all().unwrap();
-            // Should NOT be the generic defaults
-            assert_ne!(
-                config.market.gas_estimation_priority_mode,
-                config_defaults::estimation_priority_mode(),
-                "Chain defaults should have been applied"
-            );
-            // Should be the Taiko-specific values (5th percentile)
+            // Estimation resolves to Taiko's estimation medium (20th percentile)
             assert!(matches!(
                 config.market.gas_estimation_priority_mode,
+                PriorityMode::Custom { priority_fee_percentile, .. }
+                if (priority_fee_percentile - 20.0).abs() < f64::EPSILON
+            ));
+            // Priority resolves to Taiko's priority medium (5th percentile)
+            assert!(matches!(
+                config.market.gas_priority_mode,
                 PriorityMode::Custom { priority_fee_percentile, .. }
                 if (priority_fee_percentile - 5.0).abs() < f64::EPSILON
             ));
@@ -663,9 +662,12 @@ max_collateral = "10 USD"
             // Config value should be updated
             assert_eq!(config.market.min_mcycle_price, Amount::parse("0.2 ETH", None).unwrap());
             // Chain defaults should survive the reload
-            assert_ne!(
-                config.market.gas_estimation_priority_mode,
-                config_defaults::estimation_priority_mode(),
+            assert!(
+                matches!(
+                    config.market.gas_estimation_priority_mode,
+                    PriorityMode::Custom { priority_fee_percentile, .. }
+                    if (priority_fee_percentile - 20.0).abs() < f64::EPSILON
+                ),
                 "Chain defaults should survive config reload"
             );
         }


### PR DESCRIPTION
Refactor to how we resolve priority modes for estimation and tx submission, and some preliminary modifications to how we parameterize Taiko gas (pending additional guidance from their eng team on values for this)

Separate per-chain gas presets for priority and estimation modes. Previously there was one global set of Low/Medium/High configs, plus special-casing for the estimation default. Now each known chain defines separate presets for sending (priority) and profitability estimation.                                           
                             
Custom values are still passed through as-is.
                                                                                                          
  Changes                    
  * `TierPresets` struct with `resolve()` that maps Low/Medium/High to chain-specific Custom values
  * `ChainGasPresets` has separate `priority` and `estimation` tier presets                               
  * `gas_presets_for_chain()` always returns presets — chain-specific or generic fallback, no more        
  `Option`                                                                                                
  * `apply_chain_defaults()` is two lines, no special-casing or default-comparison hacks                  
  * `estimation_priority_mode` serde default changed from a hardcoded Custom to Medium (resolved through  
  presets like everything else)                                                                           
  * Preliminary Taiko presets: conservative percentiles (1/5/20 for priority, 10/20/30 for estimation),   
  low dynamic multipliers (2/3/4 vs generic 3/5/7)             