### PR TITLE
BM-2835: Deduplicate requests by request_id in indexer list queries

### DIFF
--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -3428,27 +3428,28 @@ impl IndexerDb for MarketDb {
         };
 
         // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id, keep the one with the most advanced status
-        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
+        // request_id (e.g. resubmission with modified offer), exclude rows where
+        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
+        // which preserves the original index-driven LIMIT scan.
+        let dedup_clause = "NOT EXISTS (
+                       SELECT 1 FROM request_status rs2
+                       WHERE rs2.request_id = rs.request_id
+                         AND rs2.request_digest != rs.request_digest
+                         AND (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                              <
+                              CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                   )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                WHERE ({} < $1 OR ({} = $1 AND request_digest < $2))
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $3",
-                sort_field, sort_field, sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE ({sort_field} < $1 OR ({sort_field} = $1 AND rs.request_digest < $2))
+                   AND {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $3",
             );
             sqlx::query(&query_str)
                 .bind(c.timestamp as i64)
@@ -3458,22 +3459,10 @@ impl IndexerDb for MarketDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $1",
-                sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $1",
             );
             sqlx::query(&query_str).bind(limit as i64).fetch_all(&self.pool).await?
         };

--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -3427,12 +3427,27 @@ impl IndexerDb for MarketDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
+        // Deduplicate by request_id: when multiple digests exist for the same
+        // request_id, keep the one with the most advanced status
+        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 WHERE {} < $1 OR ({} = $1 AND request_digest < $2)
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $3",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                WHERE ({} < $1 OR ({} = $1 AND request_digest < $2))
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $3",
                 sort_field, sort_field, sort_field
             );
             sqlx::query(&query_str)
@@ -3443,9 +3458,21 @@ impl IndexerDb for MarketDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $1",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $1",
                 sort_field
             );
             sqlx::query(&query_str).bind(limit as i64).fetch_all(&self.pool).await?

--- a/crates/indexer/src/db/provers.rs
+++ b/crates/indexer/src/db/provers.rs
@@ -44,28 +44,29 @@ pub trait ProversDb: IndexerDb {
         };
 
         // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id, keep the one with the most advanced status
-        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
+        // request_id (e.g. resubmission with modified offer), exclude rows where
+        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
+        // which preserves the original index-driven LIMIT scan.
+        let dedup_clause = "NOT EXISTS (
+                       SELECT 1 FROM request_status rs2
+                       WHERE rs2.request_id = rs.request_id
+                         AND rs2.request_digest != rs.request_digest
+                         AND (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                              <
+                              CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                   )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                WHERE ({} < $2 OR ({} = $2 AND request_digest < $3))
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $4",
-                sort_field, sort_field, sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE (rs.lock_prover_address = $1 OR rs.fulfill_prover_address = $1)
+                   AND ({sort_field} < $2 OR ({sort_field} = $2 AND rs.request_digest < $3))
+                   AND {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $4",
             );
             sqlx::query(&query_str)
                 .bind(&prover_str)
@@ -76,23 +77,11 @@ pub trait ProversDb: IndexerDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $2",
-                sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE (rs.lock_prover_address = $1 OR rs.fulfill_prover_address = $1)
+                   AND {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $2",
             );
             sqlx::query(&query_str)
                 .bind(&prover_str)

--- a/crates/indexer/src/db/provers.rs
+++ b/crates/indexer/src/db/provers.rs
@@ -43,13 +43,28 @@ pub trait ProversDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
+        // Deduplicate by request_id: when multiple digests exist for the same
+        // request_id, keep the one with the most advanced status
+        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
-                   AND ({} < $2 OR ({} = $2 AND request_digest < $3))
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $4",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                WHERE ({} < $2 OR ({} = $2 AND request_digest < $3))
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $4",
                 sort_field, sort_field, sort_field
             );
             sqlx::query(&query_str)
@@ -61,10 +76,22 @@ pub trait ProversDb: IndexerDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $2",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    WHERE (lock_prover_address = $1 OR fulfill_prover_address = $1)
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $2",
                 sort_field
             );
             sqlx::query(&query_str)

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -252,28 +252,29 @@ pub trait RequestorDb: IndexerDb {
         };
 
         // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id, keep the one with the most advanced status
-        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
+        // request_id (e.g. resubmission with modified offer), exclude rows where
+        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
+        // which preserves the original index-driven LIMIT scan.
+        let dedup_clause = "NOT EXISTS (
+                       SELECT 1 FROM request_status rs2
+                       WHERE rs2.request_id = rs.request_id
+                         AND rs2.request_digest != rs.request_digest
+                         AND (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                              <
+                              CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                   )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    WHERE client_address = $1
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                WHERE ({} < $2 OR ({} = $2 AND request_digest < $3))
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $4",
-                sort_field, sort_field, sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE rs.client_address = $1
+                   AND ({sort_field} < $2 OR ({sort_field} = $2 AND rs.request_digest < $3))
+                   AND {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $4",
             );
             sqlx::query(&query_str)
                 .bind(&client_str)
@@ -284,23 +285,11 @@ pub trait RequestorDb: IndexerDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM (
-                    SELECT DISTINCT ON (request_id) *
-                    FROM request_status
-                    WHERE client_address = $1
-                    ORDER BY request_id,
-                        CASE request_status
-                            WHEN 'fulfilled' THEN 1
-                            WHEN 'locked'    THEN 2
-                            WHEN 'submitted' THEN 3
-                            WHEN 'expired'   THEN 4
-                            ELSE 5
-                        END,
-                        updated_at DESC
-                ) deduped
-                ORDER BY {} DESC, request_digest DESC
-                LIMIT $2",
-                sort_field
+                "SELECT rs.* FROM request_status rs
+                 WHERE rs.client_address = $1
+                   AND {dedup_clause}
+                 ORDER BY {sort_field} DESC, rs.request_digest DESC
+                 LIMIT $2",
             );
             sqlx::query(&query_str)
                 .bind(&client_str)

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -251,13 +251,28 @@ pub trait RequestorDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
+        // Deduplicate by request_id: when multiple digests exist for the same
+        // request_id, keep the one with the most advanced status
+        // (fulfilled > locked > submitted > expired), breaking ties by updated_at.
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 WHERE client_address = $1
-                   AND ({} < $2 OR ({} = $2 AND request_digest < $3))
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $4",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    WHERE client_address = $1
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                WHERE ({} < $2 OR ({} = $2 AND request_digest < $3))
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $4",
                 sort_field, sort_field, sort_field
             );
             sqlx::query(&query_str)
@@ -269,10 +284,22 @@ pub trait RequestorDb: IndexerDb {
                 .await?
         } else {
             let query_str = format!(
-                "SELECT * FROM request_status
-                 WHERE client_address = $1
-                 ORDER BY {} DESC, request_digest DESC
-                 LIMIT $2",
+                "SELECT * FROM (
+                    SELECT DISTINCT ON (request_id) *
+                    FROM request_status
+                    WHERE client_address = $1
+                    ORDER BY request_id,
+                        CASE request_status
+                            WHEN 'fulfilled' THEN 1
+                            WHEN 'locked'    THEN 2
+                            WHEN 'submitted' THEN 3
+                            WHEN 'expired'   THEN 4
+                            ELSE 5
+                        END,
+                        updated_at DESC
+                ) deduped
+                ORDER BY {} DESC, request_digest DESC
+                LIMIT $2",
                 sort_field
             );
             sqlx::query(&query_str)
@@ -3860,6 +3887,104 @@ mod tests {
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].client_address, addr2);
+    }
+
+    /// Verifies that when two digests exist for the same request_id (e.g. resubmission
+    /// with modified offer), only the one with the most advanced status is returned.
+    #[sqlx::test(migrations = "./migrations")]
+    async fn test_list_requests_by_requestor_dedup(pool: sqlx::PgPool) {
+        let test_db = test_db(pool).await;
+        let db = &test_db.db;
+
+        let addr = Address::from([0xAB; 20]);
+        let base_ts = 1700000000u64;
+        let shared_request_id = U256::from(42);
+
+        // Two digests for the same request_id: one submitted, one fulfilled.
+        let submitted = RequestStatus {
+            request_digest: B256::from([0x01; 32]),
+            request_id: shared_request_id,
+            request_status: RequestStatusType::Submitted,
+            slashed_status: SlashedStatus::NotApplicable,
+            source: "onchain".to_string(),
+            client_address: addr,
+            lock_prover_address: None,
+            fulfill_prover_address: None,
+            created_at: base_ts + 200, // newer created_at
+            updated_at: base_ts + 200,
+            locked_at: None,
+            fulfilled_at: None,
+            slashed_at: None,
+            lock_prover_delivered_proof_at: None,
+            submit_block: Some(101),
+            lock_block: None,
+            fulfill_block: None,
+            slashed_block: None,
+            min_price: "1000".to_string(),
+            max_price: "2000".to_string(),
+            lock_collateral: "0".to_string(),
+            ramp_up_start: base_ts,
+            ramp_up_period: 10,
+            expires_at: base_ts + 10000,
+            lock_end: base_ts + 10000,
+            slash_recipient: None,
+            slash_transferred_amount: None,
+            slash_burned_amount: None,
+            program_cycles: None,
+            total_cycles: None,
+            peak_prove_mhz: None,
+            effective_prove_mhz: None,
+            prover_effective_prove_mhz: None,
+            cycle_status: None,
+            lock_price: None,
+            lock_price_per_cycle: None,
+            fixed_cost: None,
+            variable_cost_per_cycle: None,
+            lock_base_fee: None,
+            fulfill_base_fee: None,
+            submit_tx_hash: Some(B256::ZERO),
+            lock_tx_hash: None,
+            fulfill_tx_hash: None,
+            slash_tx_hash: None,
+            image_id: "test".to_string(),
+            image_url: None,
+            selector: "test".to_string(),
+            predicate_type: "digest_match".to_string(),
+            predicate_data: "0x00".to_string(),
+            input_type: "inline".to_string(),
+            input_data: "0x00".to_string(),
+            fulfill_journal: None,
+            fulfill_seal: None,
+        };
+
+        let fulfilled = RequestStatus {
+            request_digest: B256::from([0x02; 32]),
+            request_status: RequestStatusType::Fulfilled,
+            created_at: base_ts + 100, // older created_at
+            updated_at: base_ts + 300,
+            fulfilled_at: Some(base_ts + 300),
+            fulfill_prover_address: Some(Address::from([0xCC; 20])),
+            ..submitted.clone()
+        };
+
+        db.upsert_request_statuses(&[submitted, fulfilled]).await.unwrap();
+
+        // Should return exactly one row — the fulfilled variant
+        let (results, _) = db
+            .list_requests_by_requestor(addr, None, 10, RequestSortField::CreatedAt)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1, "expected dedup to 1 row, got {}", results.len());
+        assert_eq!(results[0].request_status, RequestStatusType::Fulfilled);
+        assert_eq!(results[0].request_digest, B256::from([0x02; 32]));
+
+        // Same result with UpdatedAt sort
+        let (results, _) = db
+            .list_requests_by_requestor(addr, None, 10, RequestSortField::UpdatedAt)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].request_status, RequestStatusType::Fulfilled);
     }
 
     #[sqlx::test(migrations = "./migrations")]


### PR DESCRIPTION
 ## Summary                                                                                                                                                                        
  - When a requestor resubmits a request with the same `request_id` but different parameters (e.g., modified offer), the indexer stores both as separate rows keyed by`request_digest`                                                                                                                                                                  
  - List endpoints (`/requests`, `/requestors/:addr/requests`, `/provers/:addr/requests`) returned both variants, causing the UI to show unfulfilled duplicates even when a fulfilled version exists                                                                                                                                                          
  - Uses a `NOT EXISTS` anti-join to exclude rows where a digest with a more advanced status exists for the same `request_id` (priority: `fulfilled > locked > submitted > expired`)
  - The anti-join preserves the original index-driven `LIMIT` scan — cost is O(page_size) not O(table_size)                                                                         
  - `GET /requests/:request_id` intentionally still returns all variants for diagnostics                                                                                            
                                                                                                                                                                                    
  ## Benchmarks (617K rows, production snapshot)                                                                                                                                    
                                                                                                                                                                                    
  | Query | Original | NOT EXISTS |                                                                                                                                                 
  |-------|----------|------------|                                    
  | By requestor (44K rows) | 0.4 ms | 0.7 ms |                                                                                                                                     
  | Global list (617K rows) | 0.4 ms | 1.2 ms | 
  | By prover (98K rows) | 142 ms | 134 ms |                                                                                                                                                                                                                                                       
                                                                                                                                                                                    
  An earlier `DISTINCT ON` subquery approach was **329 ms / 2,351 ms** for the same queries — rejected because it forces a full scan before pagination. 
  
  **Note**: The list_requests_by_prover query has a pre-existing performance issue (~142ms) unrelated to this PR — the OR across lock_prover_address and fulfill_prover_address prevents efficient index usage, forcing a full scan with row-level filtering. This should be addressed separately (e.g., rewriting as UNION ALL or adding a composite index).