### PR TITLE
BM-2836: Fix deduplication tiebreaker for same-status duplicate requests

### DIFF
--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -3435,13 +3435,24 @@ impl IndexerDb for MarketDb {
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
-                         AND (CASE rs2.request_status
+                         AND (
+                           (CASE rs2.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                              <
-                              CASE rs.request_status
+                            <
+                            CASE rs.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                           OR (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               =
+                               CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               AND (rs2.updated_at > rs.updated_at
+                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
+                         )
                    )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(

--- a/crates/indexer/src/db/provers.rs
+++ b/crates/indexer/src/db/provers.rs
@@ -51,13 +51,24 @@ pub trait ProversDb: IndexerDb {
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
-                         AND (CASE rs2.request_status
+                         AND (
+                           (CASE rs2.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                              <
-                              CASE rs.request_status
+                            <
+                            CASE rs.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                           OR (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               =
+                               CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               AND (rs2.updated_at > rs.updated_at
+                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
+                         )
                    )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -259,13 +259,24 @@ pub trait RequestorDb: IndexerDb {
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
-                         AND (CASE rs2.request_status
+                         AND (
+                           (CASE rs2.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                              <
-                              CASE rs.request_status
+                            <
+                            CASE rs.request_status
                                 WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
                                 WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                           OR (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               =
+                               CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               AND (rs2.updated_at > rs.updated_at
+                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
+                         )
                    )";
         let rows = if let Some(c) = &cursor {
             let query_str = format!(


### PR DESCRIPTION
- Fixes incomplete deduplication in indexer list queries when two rows for the same `request_id` have different `request_digest` values but the **same** status priority                                                                   
- The prior logic (#1886) only eliminated duplicates where one row had a strictly better status — when statuses matched, both rows survived the `NOT EXISTS` filter                                                                        
- Adds an `OR` branch to the deduplication subquery: when status priority is equal, prefer the row with the most recent `updated_at`, with `request_digest` as a final deterministic tiebreaker                                            
- Applied consistently across all three list query sites: `market.rs`, `provers.rs`, and `requestors.rs` 