### PR TITLE
BM-2837: Fix sccache S3 bucket config in prover Dockerfiles

### DIFF
--- a/dockerfiles/prover/agent.cpu.dockerfile
+++ b/dockerfiles/prover/agent.cpu.dockerfile
@@ -28,6 +28,8 @@ RUN curl -L https://risczero.com/install | bash && \
 FROM rust-builder AS builder
 
 ARG S3_CACHE_PREFIX
+ARG S3_CACHE_BUCKET="boundless-sccache"
+ENV SCCACHE_BUCKET=${S3_CACHE_BUCKET}
 # Prevent collisions with concurrent compose builds of the GPU agent image.
 ENV SCCACHE_SERVER_PORT=4228
 

--- a/dockerfiles/prover/agent.dockerfile
+++ b/dockerfiles/prover/agent.dockerfile
@@ -45,6 +45,8 @@ ARG NVCC_APPEND_FLAGS="\
   --generate-code arch=compute_120,code=sm_120"
 ARG CUDA_OPT_LEVEL=1
 ARG S3_CACHE_PREFIX
+ARG S3_CACHE_BUCKET="boundless-sccache"
+ENV SCCACHE_BUCKET=${S3_CACHE_BUCKET}
 ENV NVCC_APPEND_FLAGS=${NVCC_APPEND_FLAGS}
 ENV RISC0_CUDA_OPT=${CUDA_OPT_LEVEL}
 # Prevent collisions with concurrent compose builds of the CPU agent image.

--- a/dockerfiles/prover/prover_cli.dockerfile
+++ b/dockerfiles/prover/prover_cli.dockerfile
@@ -28,6 +28,8 @@ RUN curl -L https://risczero.com/install | bash && \
 FROM rust-builder AS builder
 
 ARG S3_CACHE_PREFIX
+ARG S3_CACHE_BUCKET="boundless-sccache"
+ENV SCCACHE_BUCKET=${S3_CACHE_BUCKET}
 ENV SCCACHE_SERVER_PORT=4227
 
 WORKDIR /src/

--- a/dockerfiles/prover/rest_api.dockerfile
+++ b/dockerfiles/prover/rest_api.dockerfile
@@ -7,6 +7,8 @@ RUN apt-get -qq update && apt-get install -y -q clang mold
 FROM builder AS rust-builder
 
 ARG S3_CACHE_PREFIX
+ARG S3_CACHE_BUCKET="boundless-sccache"
+ENV SCCACHE_BUCKET=${S3_CACHE_BUCKET}
 
 WORKDIR /src/
 COPY . .


### PR DESCRIPTION
All 4 prover Dockerfiles (`prover-agent`, `prover-agent-cpu`, `prover-rest-api`, `prover-cli`) were missing the `S3_CACHE_BUCKET` build arg and `SCCACHE_BUCKET` env var that the bento Dockerfiles have. This caused CI builds to ignore the `S3_CACHE_BUCKET=boundless-ci-prod-cache` override passed by the docker-services workflow, falling back to the `boundless-sccache` bucket — which the CI role doesn't have access to, resulting in a 403 PermissionDenied from S3 and a build failure (exit code 101)