### PR TITLE
BM-2838: Make request deduplication opt-in via query parameter

### DIFF
--- a/crates/boundless-market/src/indexer_types.rs
+++ b/crates/boundless-market/src/indexer_types.rs
@@ -289,9 +289,10 @@ pub struct RequestorLeaderboardParams {
 }
 
 /// Parameters for listing requests.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::IntoParams, utoipa::ToSchema))]
 #[cfg_attr(feature = "openapi", into_params(parameter_in = Query))]
+#[non_exhaustive]
 pub struct RequestListParams {
     /// Base64-encoded cursor from previous response for pagination
     #[serde(default)]
@@ -304,6 +305,11 @@ pub struct RequestListParams {
     /// Sort field: "updated_at" or "created_at" (default "created_at")
     #[serde(default)]
     pub sort_by: Option<String>,
+
+    /// When true, deduplicate requests by request_id keeping only the most
+    /// advanced status (default false)
+    #[serde(default)]
+    pub deduplicate: Option<bool>,
 }
 
 // ─── Market Response Types ───────────────────────────────────────────────────

--- a/crates/boundless-market/src/indexer_types.rs
+++ b/crates/boundless-market/src/indexer_types.rs
@@ -309,7 +309,7 @@ pub struct RequestListParams {
     /// When true, deduplicate requests by request_id keeping only the most
     /// advanced status (default false)
     #[serde(default)]
-    pub deduplicate: Option<bool>,
+    pub deduplicate: bool,
 }
 
 // ─── Market Response Types ───────────────────────────────────────────────────

--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -869,6 +869,7 @@ pub trait IndexerDb {
         cursor: Option<RequestCursor>,
         limit: u32,
         sort_by: RequestSortField,
+        deduplicate: bool,
     ) -> Result<(Vec<RequestStatus>, Option<RequestCursor>), DbError>;
 
     async fn get_requests_by_request_id(
@@ -3421,17 +3422,19 @@ impl IndexerDb for MarketDb {
         cursor: Option<RequestCursor>,
         limit: u32,
         sort_by: RequestSortField,
+        deduplicate: bool,
     ) -> Result<(Vec<RequestStatus>, Option<RequestCursor>), DbError> {
         let sort_field = match sort_by {
             RequestSortField::UpdatedAt => "updated_at",
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id (e.g. resubmission with modified offer), exclude rows where
-        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
-        // which preserves the original index-driven LIMIT scan.
-        let dedup_clause = "NOT EXISTS (
+        // When deduplicate is enabled, exclude rows where a digest with a more
+        // advanced status exists for the same request_id (e.g. resubmission with
+        // modified offer). Uses NOT EXISTS anti-join which preserves the original
+        // index-driven LIMIT scan.
+        let dedup_clause = if deduplicate {
+            "AND NOT EXISTS (
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
@@ -3453,12 +3456,15 @@ impl IndexerDb for MarketDb {
                                AND (rs2.updated_at > rs.updated_at
                                     OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
                          )
-                   )";
+                   )"
+        } else {
+            ""
+        };
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
                  WHERE ({sort_field} < $1 OR ({sort_field} = $1 AND rs.request_digest < $2))
-                   AND {dedup_clause}
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $3",
             );
@@ -3471,7 +3477,8 @@ impl IndexerDb for MarketDb {
         } else {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
-                 WHERE {dedup_clause}
+                 WHERE true
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $1",
             );

--- a/crates/indexer/src/db/market.rs
+++ b/crates/indexer/src/db/market.rs
@@ -3429,37 +3429,7 @@ impl IndexerDb for MarketDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // When deduplicate is enabled, exclude rows where a digest with a more
-        // advanced status exists for the same request_id (e.g. resubmission with
-        // modified offer). Uses NOT EXISTS anti-join which preserves the original
-        // index-driven LIMIT scan.
-        let dedup_clause = if deduplicate {
-            "AND NOT EXISTS (
-                       SELECT 1 FROM request_status rs2
-                       WHERE rs2.request_id = rs.request_id
-                         AND rs2.request_digest != rs.request_digest
-                         AND (
-                           (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                            <
-                            CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
-                           OR (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               =
-                               CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               AND (rs2.updated_at > rs.updated_at
-                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
-                         )
-                   )"
-        } else {
-            ""
-        };
+        let dedup_clause = super::dedup_clause(deduplicate);
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs

--- a/crates/indexer/src/db/mod.rs
+++ b/crates/indexer/src/db/mod.rs
@@ -38,6 +38,39 @@ pub use market::{
 pub use provers::{MarketCollateralStats, ProversDb};
 pub use requestors::RequestorDb;
 
+/// Returns a SQL fragment that, when appended to a WHERE clause, filters out
+/// duplicate request_id rows keeping only the one with the most advanced status.
+/// Returns an empty string when deduplication is disabled.
+pub(crate) fn dedup_clause(enabled: bool) -> &'static str {
+    if enabled {
+        "AND NOT EXISTS (
+                       SELECT 1 FROM request_status rs2
+                       WHERE rs2.request_id = rs.request_id
+                         AND rs2.request_digest != rs.request_digest
+                         AND (
+                           (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                            <
+                            CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
+                           OR (CASE rs2.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               =
+                               CASE rs.request_status
+                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
+                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
+                               AND (rs2.updated_at > rs.updated_at
+                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
+                         )
+                   )"
+    } else {
+        ""
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum DbError {
     #[error("SQL error {0:?}")]

--- a/crates/indexer/src/db/provers.rs
+++ b/crates/indexer/src/db/provers.rs
@@ -44,37 +44,7 @@ pub trait ProversDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // When deduplicate is enabled, exclude rows where a digest with a more
-        // advanced status exists for the same request_id (e.g. resubmission with
-        // modified offer). Uses NOT EXISTS anti-join which preserves the original
-        // index-driven LIMIT scan.
-        let dedup_clause = if deduplicate {
-            "AND NOT EXISTS (
-                       SELECT 1 FROM request_status rs2
-                       WHERE rs2.request_id = rs.request_id
-                         AND rs2.request_digest != rs.request_digest
-                         AND (
-                           (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                            <
-                            CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
-                           OR (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               =
-                               CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               AND (rs2.updated_at > rs.updated_at
-                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
-                         )
-                   )"
-        } else {
-            ""
-        };
+        let dedup_clause = super::dedup_clause(deduplicate);
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs

--- a/crates/indexer/src/db/provers.rs
+++ b/crates/indexer/src/db/provers.rs
@@ -36,6 +36,7 @@ pub trait ProversDb: IndexerDb {
         cursor: Option<RequestCursor>,
         limit: u32,
         sort_by: RequestSortField,
+        deduplicate: bool,
     ) -> Result<(Vec<RequestStatus>, Option<RequestCursor>), DbError> {
         let prover_str = format!("{:x}", prover_address);
         let sort_field = match sort_by {
@@ -43,11 +44,12 @@ pub trait ProversDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id (e.g. resubmission with modified offer), exclude rows where
-        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
-        // which preserves the original index-driven LIMIT scan.
-        let dedup_clause = "NOT EXISTS (
+        // When deduplicate is enabled, exclude rows where a digest with a more
+        // advanced status exists for the same request_id (e.g. resubmission with
+        // modified offer). Uses NOT EXISTS anti-join which preserves the original
+        // index-driven LIMIT scan.
+        let dedup_clause = if deduplicate {
+            "AND NOT EXISTS (
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
@@ -69,13 +71,16 @@ pub trait ProversDb: IndexerDb {
                                AND (rs2.updated_at > rs.updated_at
                                     OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
                          )
-                   )";
+                   )"
+        } else {
+            ""
+        };
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
                  WHERE (rs.lock_prover_address = $1 OR rs.fulfill_prover_address = $1)
                    AND ({sort_field} < $2 OR ({sort_field} = $2 AND rs.request_digest < $3))
-                   AND {dedup_clause}
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $4",
             );
@@ -90,7 +95,7 @@ pub trait ProversDb: IndexerDb {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
                  WHERE (rs.lock_prover_address = $1 OR rs.fulfill_prover_address = $1)
-                   AND {dedup_clause}
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $2",
             );
@@ -2150,7 +2155,7 @@ mod tests {
         // This includes: 3 locked-only, 2 locked+fulfilled, 1 fulfilled-only (mixed)
         // Total: 6 requests
         let (results, _cursor) = db
-            .list_requests_by_prover(prover1, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_prover(prover1, None, 10, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(
@@ -2167,7 +2172,7 @@ mod tests {
 
         // List with limit
         let (results, cursor) = db
-            .list_requests_by_prover(prover1, None, 2, RequestSortField::CreatedAt)
+            .list_requests_by_prover(prover1, None, 2, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 2);
@@ -2175,7 +2180,7 @@ mod tests {
 
         // Use cursor for pagination
         let (results2, _) = db
-            .list_requests_by_prover(prover1, cursor, 2, RequestSortField::CreatedAt)
+            .list_requests_by_prover(prover1, cursor, 2, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results2.len(), 2);
@@ -2184,7 +2189,7 @@ mod tests {
 
         // Test sorting by updated_at
         let (results_updated, _) = db
-            .list_requests_by_prover(prover1, None, 10, RequestSortField::UpdatedAt)
+            .list_requests_by_prover(prover1, None, 10, RequestSortField::UpdatedAt, false)
             .await
             .unwrap();
         assert_eq!(results_updated.len(), 6);
@@ -2198,7 +2203,7 @@ mod tests {
 
         // List for prover2 - should only get the one request where prover2 locked
         let (results, _) = db
-            .list_requests_by_prover(prover2, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_prover(prover2, None, 10, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -2207,7 +2212,7 @@ mod tests {
 
         // List for prover3 - should only get the one request where prover3 fulfilled
         let (results, _) = db
-            .list_requests_by_prover(prover3, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_prover(prover3, None, 10, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -2217,7 +2222,13 @@ mod tests {
         // List for a prover with no requests - should return empty
         let prover_no_requests = Address::from([0xFF; 20]);
         let (results, _) = db
-            .list_requests_by_prover(prover_no_requests, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_prover(
+                prover_no_requests,
+                None,
+                10,
+                RequestSortField::CreatedAt,
+                false,
+            )
             .await
             .unwrap();
         assert_eq!(results.len(), 0);

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -252,37 +252,7 @@ pub trait RequestorDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // When deduplicate is enabled, exclude rows where a digest with a more
-        // advanced status exists for the same request_id (e.g. resubmission with
-        // modified offer). Uses NOT EXISTS anti-join which preserves the original
-        // index-driven LIMIT scan.
-        let dedup_clause = if deduplicate {
-            "AND NOT EXISTS (
-                       SELECT 1 FROM request_status rs2
-                       WHERE rs2.request_id = rs.request_id
-                         AND rs2.request_digest != rs.request_digest
-                         AND (
-                           (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                            <
-                            CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END)
-                           OR (CASE rs2.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               =
-                               CASE rs.request_status
-                                WHEN 'fulfilled' THEN 1 WHEN 'locked' THEN 2
-                                WHEN 'submitted' THEN 3 WHEN 'expired' THEN 4 ELSE 5 END
-                               AND (rs2.updated_at > rs.updated_at
-                                    OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
-                         )
-                   )"
-        } else {
-            ""
-        };
+        let dedup_clause = super::dedup_clause(deduplicate);
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs

--- a/crates/indexer/src/db/requestors.rs
+++ b/crates/indexer/src/db/requestors.rs
@@ -244,6 +244,7 @@ pub trait RequestorDb: IndexerDb {
         cursor: Option<RequestCursor>,
         limit: u32,
         sort_by: RequestSortField,
+        deduplicate: bool,
     ) -> Result<(Vec<RequestStatus>, Option<RequestCursor>), DbError> {
         let client_str = format!("{:x}", client_address);
         let sort_field = match sort_by {
@@ -251,11 +252,12 @@ pub trait RequestorDb: IndexerDb {
             RequestSortField::CreatedAt => "created_at",
         };
 
-        // Deduplicate by request_id: when multiple digests exist for the same
-        // request_id (e.g. resubmission with modified offer), exclude rows where
-        // a digest with a more advanced status exists. Uses NOT EXISTS anti-join
-        // which preserves the original index-driven LIMIT scan.
-        let dedup_clause = "NOT EXISTS (
+        // When deduplicate is enabled, exclude rows where a digest with a more
+        // advanced status exists for the same request_id (e.g. resubmission with
+        // modified offer). Uses NOT EXISTS anti-join which preserves the original
+        // index-driven LIMIT scan.
+        let dedup_clause = if deduplicate {
+            "AND NOT EXISTS (
                        SELECT 1 FROM request_status rs2
                        WHERE rs2.request_id = rs.request_id
                          AND rs2.request_digest != rs.request_digest
@@ -277,13 +279,16 @@ pub trait RequestorDb: IndexerDb {
                                AND (rs2.updated_at > rs.updated_at
                                     OR (rs2.updated_at = rs.updated_at AND rs2.request_digest > rs.request_digest)))
                          )
-                   )";
+                   )"
+        } else {
+            ""
+        };
         let rows = if let Some(c) = &cursor {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
                  WHERE rs.client_address = $1
                    AND ({sort_field} < $2 OR ({sort_field} = $2 AND rs.request_digest < $3))
-                   AND {dedup_clause}
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $4",
             );
@@ -298,7 +303,7 @@ pub trait RequestorDb: IndexerDb {
             let query_str = format!(
                 "SELECT rs.* FROM request_status rs
                  WHERE rs.client_address = $1
-                   AND {dedup_clause}
+                   {dedup_clause}
                  ORDER BY {sort_field} DESC, rs.request_digest DESC
                  LIMIT $2",
             );
@@ -3849,28 +3854,28 @@ mod tests {
         db.upsert_request_statuses(&[status_addr2]).await.unwrap();
 
         let (results, _cursor) = db
-            .list_requests_by_requestor(addr1, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_requestor(addr1, None, 10, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 5);
         assert!(results.iter().all(|r| r.client_address == addr1));
 
         let (results, cursor) = db
-            .list_requests_by_requestor(addr1, None, 2, RequestSortField::CreatedAt)
+            .list_requests_by_requestor(addr1, None, 2, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 2);
         assert!(cursor.is_some());
 
         let (results2, _) = db
-            .list_requests_by_requestor(addr1, cursor, 2, RequestSortField::CreatedAt)
+            .list_requests_by_requestor(addr1, cursor, 2, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results2.len(), 2);
         assert_ne!(results[0].request_id, results2[0].request_id);
 
         let (results, _) = db
-            .list_requests_by_requestor(addr2, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_requestor(addr2, None, 10, RequestSortField::CreatedAt, false)
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
@@ -3957,9 +3962,16 @@ mod tests {
 
         db.upsert_request_statuses(&[submitted, fulfilled]).await.unwrap();
 
-        // Should return exactly one row — the fulfilled variant
+        // Without dedup, both rows are returned
         let (results, _) = db
-            .list_requests_by_requestor(addr, None, 10, RequestSortField::CreatedAt)
+            .list_requests_by_requestor(addr, None, 10, RequestSortField::CreatedAt, false)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2, "expected 2 rows without dedup, got {}", results.len());
+
+        // With dedup, should return exactly one row — the fulfilled variant
+        let (results, _) = db
+            .list_requests_by_requestor(addr, None, 10, RequestSortField::CreatedAt, true)
             .await
             .unwrap();
         assert_eq!(results.len(), 1, "expected dedup to 1 row, got {}", results.len());
@@ -3968,7 +3980,7 @@ mod tests {
 
         // Same result with UpdatedAt sort
         let (results, _) = db
-            .list_requests_by_requestor(addr, None, 10, RequestSortField::UpdatedAt)
+            .list_requests_by_requestor(addr, None, 10, RequestSortField::UpdatedAt, true)
             .await
             .unwrap();
         assert_eq!(results.len(), 1);

--- a/crates/lambdas/indexer-api/src/routes/market.rs
+++ b/crates/lambdas/indexer-api/src/routes/market.rs
@@ -1623,7 +1623,10 @@ async fn list_requests_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let (statuses, next_cursor) = state.market_db.list_requests(cursor, limit, sort_by).await?;
+    let deduplicate = params.deduplicate.unwrap_or(false);
+
+    let (statuses, next_cursor) =
+        state.market_db.list_requests(cursor, limit, sort_by, deduplicate).await?;
 
     let data =
         statuses.into_iter().map(|s| convert_request_status(s, state.chain_id)).collect::<Vec<_>>();
@@ -1693,8 +1696,12 @@ async fn list_requests_by_requestor_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let (statuses, next_cursor) =
-        state.market_db.list_requests_by_requestor(client_address, cursor, limit, sort_by).await?;
+    let deduplicate = params.deduplicate.unwrap_or(false);
+
+    let (statuses, next_cursor) = state
+        .market_db
+        .list_requests_by_requestor(client_address, cursor, limit, sort_by, deduplicate)
+        .await?;
 
     let data =
         statuses.into_iter().map(|s| convert_request_status(s, state.chain_id)).collect::<Vec<_>>();
@@ -1764,8 +1771,12 @@ async fn list_requests_by_prover_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let (statuses, next_cursor) =
-        state.market_db.list_requests_by_prover(prover_address, cursor, limit, sort_by).await?;
+    let deduplicate = params.deduplicate.unwrap_or(false);
+
+    let (statuses, next_cursor) = state
+        .market_db
+        .list_requests_by_prover(prover_address, cursor, limit, sort_by, deduplicate)
+        .await?;
 
     let data =
         statuses.into_iter().map(|s| convert_request_status(s, state.chain_id)).collect::<Vec<_>>();

--- a/crates/lambdas/indexer-api/src/routes/market.rs
+++ b/crates/lambdas/indexer-api/src/routes/market.rs
@@ -1623,7 +1623,7 @@ async fn list_requests_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let deduplicate = params.deduplicate.unwrap_or(false);
+    let deduplicate = params.deduplicate;
 
     let (statuses, next_cursor) =
         state.market_db.list_requests(cursor, limit, sort_by, deduplicate).await?;
@@ -1696,7 +1696,7 @@ async fn list_requests_by_requestor_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let deduplicate = params.deduplicate.unwrap_or(false);
+    let deduplicate = params.deduplicate;
 
     let (statuses, next_cursor) = state
         .market_db
@@ -1771,7 +1771,7 @@ async fn list_requests_by_prover_impl(
         _ => anyhow::bail!("Invalid sort_by. Must be 'updated_at' or 'created_at'"),
     };
 
-    let deduplicate = params.deduplicate.unwrap_or(false);
+    let deduplicate = params.deduplicate;
 
     let (statuses, next_cursor) = state
         .market_db


### PR DESCRIPTION
  ## Description
  The deduplication logic added in #1886 and #1887 is now gated behind an optional `deduplicate` query parameter (default `false`), restoring the original unfiltered behavior by default.

  ### Changes
  - Added `deduplicate: bool` to `RequestListParams` (default `false`)
  - Threaded the flag through all 3 list endpoints (`list_requests`, `list_requests_by_requestor`, `list_requests_by_prover`) and their DB trait methods
  - Dedup SQL clause is only applied when `?deduplicate=true`
  - Added `#[non_exhaustive]` + `Default` derive to `RequestListParams` to prevent future field additions from being SDK-breaking
  - Updated existing dedup test to verify both `deduplicate=false` (returns all rows) and `deduplicate=true` (returns only most advanced status)

  ### Usage

  **REST API:**
  GET /v1/market/requests?deduplicate=true
  GET /v1/market/requestors/{address}/requests?deduplicate=true
  GET /v1/market/provers/{address}/requests?deduplicate=true

  **Rust SDK:**
  ```rust
  let params = RequestListParams {
      deduplicate: true,
      ..Default::default()
  };
  ```