### PR TITLE
BM-2839: Add Signal service to logs query skill

### DIFF
--- a/.claude/skills/ops-logs-query/SKILL.md
+++ b/.claude/skills/ops-logs-query/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-logs-query
-description: Internal — for Boundless team members only. Query AWS CloudWatch logs for Boundless services (provers, slasher, distributor, order stream, order generator, indexer) on prod/staging environments. Use when the user asks to look at service logs, debug service behavior from log output, search logs for a request ID, or investigate errors using CloudWatch. Do NOT use for debugging local code changes, reviewing PRs, or investigating issues in the codebase itself.
+description: Internal — for Boundless team members only. Query AWS CloudWatch logs for Boundless services (provers, slasher, distributor, order stream, order generator, indexer, signal) on prod/staging environments. Use when the user asks to look at service logs, debug service behavior from log output, search logs for a request ID, or investigate errors using CloudWatch. Do NOT use for debugging local code changes, reviewing PRs, or investigating issues in the codebase itself.
 ---
 
 # Logs Query
@@ -104,6 +104,7 @@ Common service name fragments to search for:
 | Order generator | `order-generator`, `og`                                    |
 | Slasher         | `slasher`                                                  |
 | Distributor     | `distributor`                                              |
+| Signal          | `prod-8453-signal` (no `l-` prefix)                        |
 | Prover (bento)  | `/boundless/bento/prover` or `/boundless/bento/*-prover-*` |
 
 ## Querying Logs


### PR DESCRIPTION
Adds Signal to the ops-logs-query skill so log queries can find Signal service log groups.

Changes
* Added `signal` to the service list in the skill frontmatter description
* Added Signal row to the service name patterns table with prefix `prod-8453-signal` (doesn't use the `l-` prefix like other services)