### PR TITLE
BM-2841: Increase memory limit from 1G to 4G

### DIFF
--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -220,7 +220,7 @@ services:
       dockerfile: ${PROVER_REST_API_DOCKERFILE:-dockerfiles/prover/rest_api.dockerfile}
     restart: always
 
-    mem_limit: 1G
+    mem_limit: 4G
     cpus: 1
 
     environment:


### PR DESCRIPTION
addresses the below error in the prover 2.0:
gpu_prove_agent-1  |     4: tcp connect error
gpu_prove_agent-1  |     5: Connection refused (os error 111)
gpu_prove_agent-1  |
gpu_prove_agent-1  | Stack backtrace:
gpu_prove_agent-1  |    0: <E as anyhow::context::ext::StdError>::ext_context
gpu_prove_agent-1  |              at ./usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.99/src/backtrace.rs:27:14
gpu_prove_agent-1  |    1: anyhow::context::<impl anyhow::Context<T,E> for core::result::Result<T,E>>::with_context