### PR TITLE
BM-2842: reduce redis load on the backend

### DIFF
--- a/prover/crates/taskdb/src/redis_backend.rs
+++ b/prover/crates/taskdb/src/redis_backend.rs
@@ -69,18 +69,24 @@ local function adjust_task_state_count(p, worker_type, priority, state, delta)
   end
 end
 
-local function adjust_task_state_count_for_task(p, task_key, old_state, new_state)
+local function adjust_task_state_count_for_meta(p, worker_type, priority, old_state, new_state)
   if redis.call('EXISTS', task_counts_init_key(p)) == 0 then
     return
   end
-  local worker_type = redis.call('HGET', task_key, 'worker_type')
-  local priority = redis.call('HGET', task_key, 'priority')
   if old_state and is_counted_task_state(old_state) then
     adjust_task_state_count(p, worker_type, priority, old_state, -1)
   end
   if new_state and is_counted_task_state(new_state) then
     adjust_task_state_count(p, worker_type, priority, new_state, 1)
   end
+end
+
+local function adjust_task_state_count_for_task(p, task_key, old_state, new_state)
+  if redis.call('EXISTS', task_counts_init_key(p)) == 0 then
+    return
+  end
+  local meta = redis.call('HMGET', task_key, 'worker_type', 'priority')
+  adjust_task_state_count_for_meta(p, meta[1], meta[2], old_state, new_state)
 end
 
 local function bootstrap_task_state_counts(p)
@@ -205,7 +211,7 @@ redis.register_function('create_job', function(keys, args)
     'output', '',
     'error', '')
   redis.call('SADD', p .. ':tasks:by_job:' .. job_id, 'init')
-  adjust_task_state_count_for_task(p, task_key, nil, 'ready')
+  adjust_task_state_count_for_meta(p, worker_type, priority, nil, 'ready')
   enqueue_task(p, task_key, job_id .. '|init')
   return job_id
 end)
@@ -272,7 +278,7 @@ redis.register_function('create_task', function(keys, args)
     'output', '',
     'error', '')
   redis.call('SADD', p .. ':tasks:by_job:' .. job_id, task_id)
-  adjust_task_state_count_for_task(p, task_key, nil, state)
+  adjust_task_state_count_for_meta(p, worker_type, priority, nil, state)
   if state == 'ready' then
     enqueue_task(p, task_key, job_id .. '|' .. task_id)
   end
@@ -304,14 +310,14 @@ redis.register_function('request_work', function(keys, args)
       else
         local job_state = redis.call('HGET', p .. ':job:' .. job_id .. ':meta', 'state')
         if job_state == 'failed' then
-          adjust_task_state_count_for_task(p, task_key, 'ready', 'cancelled')
           redis.call('HSET', task_key, 'state', 'cancelled', 'updated_at', tostring(now))
+          adjust_task_state_count_for_meta(p, worker_type, tostring(priority), 'ready', 'cancelled')
         else
-          adjust_task_state_count_for_task(p, task_key, 'ready', 'running')
           redis.call('HSET', task_key,
             'state', 'running',
             'started_at', tostring(now),
             'updated_at', tostring(now))
+          adjust_task_state_count_for_meta(p, worker_type, tostring(priority), 'ready', 'running')
           local timeout = tonumber(redis.call('HGET', task_key, 'timeout_secs') or '0')
           if timeout < 0 then
             timeout = 0
@@ -343,12 +349,12 @@ redis.register_function('update_task_done', function(keys, args)
     return 0
   end
   local compound = job_id .. '|' .. task_id
-  adjust_task_state_count_for_task(p, task_key, state, 'done')
   redis.call('HSET', task_key,
     'state', 'done',
     'output', output,
     'progress', '1.0',
     'updated_at', tostring(now))
+  adjust_task_state_count_for_task(p, task_key, state, 'done')
   redis.call('ZREM', p .. ':tasks:running', compound)
   if state == 'ready' then
     remove_task_from_ready(p, task_key, compound)
@@ -360,8 +366,8 @@ redis.register_function('update_task_done', function(keys, args)
     if dep_state and dep_state ~= 'failed' and dep_state ~= 'done' then
       local remaining = redis.call('HINCRBY', dep_key, 'waiting_on', -1)
       if remaining <= 0 then
-        adjust_task_state_count_for_task(p, dep_key, dep_state, 'ready')
         redis.call('HSET', dep_key, 'waiting_on', '0', 'state', 'ready', 'updated_at', tostring(now))
+        adjust_task_state_count_for_task(p, dep_key, dep_state, 'ready')
         local dep_compound = job_id .. '|' .. dep_tid
         enqueue_task(p, dep_key, dep_compound)
       end
@@ -398,12 +404,12 @@ redis.register_function('update_task_failed', function(keys, args)
   if state ~= 'ready' and state ~= 'running' and state ~= 'pending' then
     return 0
   end
-  adjust_task_state_count_for_task(p, task_key, state, 'failed')
   redis.call('HSET', task_key,
     'state', 'failed',
     'error', err,
     'progress', '1.0',
     'updated_at', tostring(now))
+  adjust_task_state_count_for_task(p, task_key, state, 'failed')
   local compound = job_id .. '|' .. task_id
   if state == 'running' then
     redis.call('ZREM', p .. ':tasks:running', compound)
@@ -427,8 +433,8 @@ redis.register_function('update_task_failed', function(keys, args)
         if sib_state == 'ready' then
           remove_task_from_ready(p, sib_key, sib_compound)
         end
-        adjust_task_state_count_for_task(p, sib_key, sib_state, 'cancelled')
         redis.call('HSET', sib_key, 'state', 'cancelled', 'updated_at', tostring(now))
+        adjust_task_state_count_for_task(p, sib_key, sib_state, 'cancelled')
       end
     end
   end
@@ -469,13 +475,13 @@ redis.register_function('update_task_retry', function(keys, args)
   local compound = job_id .. '|' .. task_id
   redis.call('ZREM', p .. ':tasks:running', compound)
   if retries > max_retries then
-    adjust_task_state_count_for_task(p, task_key, 'running', 'failed')
     redis.call('HSET',
       task_key,
       'state', 'failed',
       'error', 'retry max hit',
       'progress', '1.0',
       'updated_at', tostring(now))
+    adjust_task_state_count_for_task(p, task_key, 'running', 'failed')
     local job_key = p .. ':job:' .. job_id .. ':meta'
     redis.call('HSET', job_key, 'state', 'failed', 'error', 'retry max hit')
     local job_user = redis.call('HGET', job_key, 'user_id')
@@ -484,13 +490,13 @@ redis.register_function('update_task_retry', function(keys, args)
     end
     return 0
   end
-  adjust_task_state_count_for_task(p, task_key, 'running', 'ready')
   redis.call('HSET',
     task_key,
     'state', 'ready',
     'error', '',
     'progress', '0.0',
     'updated_at', tostring(now))
+  adjust_task_state_count_for_task(p, task_key, 'running', 'ready')
   enqueue_task(p, task_key, compound)
   return 1
 end)

--- a/prover/crates/taskdb/src/redis_backend.rs
+++ b/prover/crates/taskdb/src/redis_backend.rs
@@ -38,6 +38,81 @@ local function task_ready_queue_key(p, task_key)
   return ready_queue_key(p, worker_type, priority)
 end
 
+local function task_counts_key(p)
+  return p .. ':task_counts'
+end
+
+local function task_counts_init_key(p)
+  return p .. ':task_counts_initialized'
+end
+
+local function is_counted_task_state(state)
+  return state == 'ready' or state == 'running' or state == 'pending'
+end
+
+local function task_count_compound(worker_type, priority, state)
+  return worker_type .. '|' .. priority .. '|' .. state
+end
+
+local function adjust_task_state_count(p, worker_type, priority, state, delta)
+  if redis.call('EXISTS', task_counts_init_key(p)) == 0 then
+    return
+  end
+  if not worker_type or not priority or not is_counted_task_state(state) or delta == 0 then
+    return
+  end
+  local counts_key = task_counts_key(p)
+  local field = task_count_compound(worker_type, priority, state)
+  local count = redis.call('HINCRBY', counts_key, field, delta)
+  if count <= 0 then
+    redis.call('HDEL', counts_key, field)
+  end
+end
+
+local function adjust_task_state_count_for_task(p, task_key, old_state, new_state)
+  if redis.call('EXISTS', task_counts_init_key(p)) == 0 then
+    return
+  end
+  local worker_type = redis.call('HGET', task_key, 'worker_type')
+  local priority = redis.call('HGET', task_key, 'priority')
+  if old_state and is_counted_task_state(old_state) then
+    adjust_task_state_count(p, worker_type, priority, old_state, -1)
+  end
+  if new_state and is_counted_task_state(new_state) then
+    adjust_task_state_count(p, worker_type, priority, new_state, 1)
+  end
+end
+
+local function bootstrap_task_state_counts(p)
+  local init_key = task_counts_init_key(p)
+  if redis.call('EXISTS', init_key) == 1 then
+    return
+  end
+
+  local counts = {}
+  local cursor = '0'
+  repeat
+    local res = redis.call('SCAN', cursor, 'MATCH', p .. ':task:*', 'COUNT', 500)
+    cursor = res[1]
+    for _, task_key in ipairs(res[2]) do
+      local state = redis.call('HGET', task_key, 'state')
+      if is_counted_task_state(state) then
+        local worker_type = redis.call('HGET', task_key, 'worker_type') or 'unknown'
+        local priority = redis.call('HGET', task_key, 'priority') or '1'
+        local compound = task_count_compound(worker_type, priority, state)
+        counts[compound] = (counts[compound] or 0) + 1
+      end
+    end
+  until cursor == '0'
+
+  local counts_key = task_counts_key(p)
+  redis.call('DEL', counts_key)
+  for compound, count in pairs(counts) do
+    redis.call('HSET', counts_key, compound, tostring(count))
+  end
+  redis.call('SET', init_key, '1')
+end
+
 local function enqueue_task(p, task_key, compound)
   local ready_key = task_ready_queue_key(p, task_key)
   local worker_type = redis.call('HGET', task_key, 'worker_type')
@@ -130,6 +205,7 @@ redis.register_function('create_job', function(keys, args)
     'output', '',
     'error', '')
   redis.call('SADD', p .. ':tasks:by_job:' .. job_id, 'init')
+  adjust_task_state_count_for_task(p, task_key, nil, 'ready')
   enqueue_task(p, task_key, job_id .. '|init')
   return job_id
 end)
@@ -196,6 +272,7 @@ redis.register_function('create_task', function(keys, args)
     'output', '',
     'error', '')
   redis.call('SADD', p .. ':tasks:by_job:' .. job_id, task_id)
+  adjust_task_state_count_for_task(p, task_key, nil, state)
   if state == 'ready' then
     enqueue_task(p, task_key, job_id .. '|' .. task_id)
   end
@@ -227,8 +304,10 @@ redis.register_function('request_work', function(keys, args)
       else
         local job_state = redis.call('HGET', p .. ':job:' .. job_id .. ':meta', 'state')
         if job_state == 'failed' then
+          adjust_task_state_count_for_task(p, task_key, 'ready', 'cancelled')
           redis.call('HSET', task_key, 'state', 'cancelled', 'updated_at', tostring(now))
         else
+          adjust_task_state_count_for_task(p, task_key, 'ready', 'running')
           redis.call('HSET', task_key,
             'state', 'running',
             'started_at', tostring(now),
@@ -264,6 +343,7 @@ redis.register_function('update_task_done', function(keys, args)
     return 0
   end
   local compound = job_id .. '|' .. task_id
+  adjust_task_state_count_for_task(p, task_key, state, 'done')
   redis.call('HSET', task_key,
     'state', 'done',
     'output', output,
@@ -280,6 +360,7 @@ redis.register_function('update_task_done', function(keys, args)
     if dep_state and dep_state ~= 'failed' and dep_state ~= 'done' then
       local remaining = redis.call('HINCRBY', dep_key, 'waiting_on', -1)
       if remaining <= 0 then
+        adjust_task_state_count_for_task(p, dep_key, dep_state, 'ready')
         redis.call('HSET', dep_key, 'waiting_on', '0', 'state', 'ready', 'updated_at', tostring(now))
         local dep_compound = job_id .. '|' .. dep_tid
         enqueue_task(p, dep_key, dep_compound)
@@ -317,6 +398,7 @@ redis.register_function('update_task_failed', function(keys, args)
   if state ~= 'ready' and state ~= 'running' and state ~= 'pending' then
     return 0
   end
+  adjust_task_state_count_for_task(p, task_key, state, 'failed')
   redis.call('HSET', task_key,
     'state', 'failed',
     'error', err,
@@ -345,6 +427,7 @@ redis.register_function('update_task_failed', function(keys, args)
         if sib_state == 'ready' then
           remove_task_from_ready(p, sib_key, sib_compound)
         end
+        adjust_task_state_count_for_task(p, sib_key, sib_state, 'cancelled')
         redis.call('HSET', sib_key, 'state', 'cancelled', 'updated_at', tostring(now))
       end
     end
@@ -386,6 +469,7 @@ redis.register_function('update_task_retry', function(keys, args)
   local compound = job_id .. '|' .. task_id
   redis.call('ZREM', p .. ':tasks:running', compound)
   if retries > max_retries then
+    adjust_task_state_count_for_task(p, task_key, 'running', 'failed')
     redis.call('HSET',
       task_key,
       'state', 'failed',
@@ -400,6 +484,7 @@ redis.register_function('update_task_retry', function(keys, args)
     end
     return 0
   end
+  adjust_task_state_count_for_task(p, task_key, 'running', 'ready')
   redis.call('HSET',
     task_key,
     'state', 'ready',
@@ -428,6 +513,7 @@ redis.register_function('delete_job', function(keys, args)
     elseif state == 'running' then
       redis.call('ZREM', p .. ':tasks:running', compound)
     end
+    adjust_task_state_count_for_task(p, tkey, state, nil)
     local prereqs_json = redis.call('HGET', tkey, 'prerequisites') or '[]'
     local prereqs = cjson.decode(prereqs_json)
     for _, pre in ipairs(prereqs) do
@@ -511,28 +597,8 @@ end)
 
 redis.register_function('count_task_states', function(keys, args)
   local p = args[1]
-  local counts = {}
-  local cursor = '0'
-  repeat
-    local res = redis.call('SCAN', cursor, 'MATCH', p .. ':task:*', 'COUNT', 500)
-    cursor = res[1]
-    for _, task_key in ipairs(res[2]) do
-      local state = redis.call('HGET', task_key, 'state')
-      if state == 'ready' or state == 'running' or state == 'pending' then
-        local worker_type = redis.call('HGET', task_key, 'worker_type') or 'unknown'
-        local priority = redis.call('HGET', task_key, 'priority') or '1'
-        local compound = worker_type .. '|' .. priority .. '|' .. state
-        counts[compound] = (counts[compound] or 0) + 1
-      end
-    end
-  until cursor == '0'
-
-  local results = {}
-  for compound, count in pairs(counts) do
-    table.insert(results, compound)
-    table.insert(results, tostring(count))
-  end
-  return results
+  bootstrap_task_state_counts(p)
+  return redis.call('HGETALL', task_counts_key(p))
 end)
 
 "#;

--- a/prover/crates/taskdb/tests/redis_backend.rs
+++ b/prover/crates/taskdb/tests/redis_backend.rs
@@ -219,6 +219,107 @@ async fn task_state_counts_bootstrap_and_follow_transitions() -> Result<(), Task
 }
 
 #[tokio::test]
+async fn task_state_counts_drop_when_failure_cancels_siblings() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-cancel").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "cancel"}), 2, 30, "user-cancel")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    db.update_task_done(&job_id, &init.task_id, serde_json::json!({"ok": true})).await?;
+
+    db.create_task(
+        &job_id,
+        "a",
+        &stream_id,
+        &serde_json::json!({"task": "a"}),
+        &serde_json::json!([]),
+        2,
+        30,
+    )
+    .await?;
+    db.create_task(
+        &job_id,
+        "b",
+        &stream_id,
+        &serde_json::json!({"task": "b"}),
+        &serde_json::json!([]),
+        2,
+        30,
+    )
+    .await?;
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 2);
+
+    assert!(db.update_task_failed(&job_id, "a", "boom").await?);
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn task_state_counts_drop_to_zero_after_delete_job() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-delete").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "delete"}), 2, 30, "user-delete")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    db.update_task_done(&job_id, &init.task_id, serde_json::json!({"ok": true})).await?;
+
+    db.create_task(
+        &job_id,
+        "a",
+        &stream_id,
+        &serde_json::json!({"task": "a"}),
+        &serde_json::json!([]),
+        2,
+        30,
+    )
+    .await?;
+    db.create_task(
+        &job_id,
+        "join",
+        &stream_id,
+        &serde_json::json!({"task": "join"}),
+        &serde_json::json!(["a"]),
+        2,
+        30,
+    )
+    .await?;
+
+    let a_task = db.request_work("CPU").await?.expect("expected child task");
+    assert_eq!(a_task.task_id, "a");
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 1);
+
+    db.delete_job(&job_id).await?;
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn request_work_prefers_priority_over_stream_ordering() -> Result<(), TaskDbErr> {
     let Some(db) = test_db().await else {
         return Ok(());

--- a/prover/crates/taskdb/tests/redis_backend.rs
+++ b/prover/crates/taskdb/tests/redis_backend.rs
@@ -19,6 +19,21 @@ async fn test_db() -> Option<RedisTaskDb> {
     Some(db)
 }
 
+fn count_for(
+    counts: &[taskdb::TaskStateCount],
+    worker_type: &str,
+    priority: Priority,
+    state: &str,
+) -> u64 {
+    counts
+        .iter()
+        .find(|count| {
+            count.worker_type == worker_type && count.priority == priority && count.state == state
+        })
+        .map(|count| count.count)
+        .unwrap_or(0)
+}
+
 #[tokio::test]
 async fn request_work_and_dependency_unblock() -> Result<(), TaskDbErr> {
     let Some(db) = test_db().await else {
@@ -114,6 +129,91 @@ async fn timeout_requeue_and_retry_cap() -> Result<(), TaskDbErr> {
 
     let state = db.get_job_state(&job_id, "user-b").await?;
     assert_eq!(state, JobState::Failed);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn task_state_counts_bootstrap_and_follow_transitions() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-counts").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "counts"}), 2, 30, "user-counts")
+        .await?;
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    assert_eq!(init.task_id, INIT_TASK);
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 1);
+
+    db.update_task_done(&job_id, INIT_TASK, serde_json::json!({"ok": true})).await?;
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
+
+    db.create_task(
+        &job_id,
+        "a",
+        &stream_id,
+        &serde_json::json!({"task": "a"}),
+        &serde_json::json!([]),
+        2,
+        30,
+    )
+    .await?;
+    db.create_task(
+        &job_id,
+        "join",
+        &stream_id,
+        &serde_json::json!({"task": "join"}),
+        &serde_json::json!(["a"]),
+        2,
+        30,
+    )
+    .await?;
+
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 1);
+
+    let a_task = db.request_work("CPU").await?.expect("expected child task");
+    assert_eq!(a_task.task_id, "a");
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 1);
+
+    assert!(db.update_task_retry(&job_id, "a").await?);
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 1);
+
+    let a_task = db.request_work("CPU").await?.expect("expected retried child task");
+    assert_eq!(a_task.task_id, "a");
+    db.update_task_done(&job_id, "a", serde_json::json!({"done": true})).await?;
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 1);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
+
+    let join = db.request_work("CPU").await?.expect("expected unblocked join task");
+    assert_eq!(join.task_id, "join");
+    db.update_task_done(&job_id, "join", serde_json::json!({"joined": true})).await?;
+    let counts = db.get_task_state_counts().await?;
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 0);
+    assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 0);
 
     Ok(())
 }


### PR DESCRIPTION
## reduce redis load on the backend
Identified via Grafana Redis dashboard 04/11/2026
### Problem
count_task_states was performing a full keyspace SCAN on every call, iterating all {prefix}:task:* keys with two individual HGET calls per key to read worker_type and priority. At 406K keys and continuous polling cadence this was generating 65M+ scan operations and consistent 185-192ms slow query log hits — visible as the dominant load driver on the Redis instance.
### Solution
Replaced the on-read scan with an on-write incremental counter maintained in a Redis hash at {prefix}:task_counts. Task state transitions now call adjust_task_state_count atomically at each transition point, keeping the counts hash current. count_task_states becomes a single HGETALL — O(1) regardless of keyspace size.
A one-time bootstrap scan runs lazily on the first count_task_states call, populating the counts hash from current state and setting an initialized flag. All subsequent calls skip bootstrap entirely.
### Expected impact
Eliminates the recurring slow query log entries for FCALL count_task_states. Scan call volume drops from 65M+ to near zero after bootstrap. count_task_states latency drops from ~185ms to sub-millisecond.