### PR TITLE
ci: skip Linear issue workflow on forks

### DIFF
--- a/.github/workflows/linear.yml
+++ b/.github/workflows/linear.yml
@@ -16,6 +16,9 @@ concurrency:
 
 jobs:
   create-linear-issue-pr:
+    # Only run on the canonical repo; forks don't have LINEAR_API_KEY and the
+    # action hard-errors when the secret is absent.
+    if: github.repository == 'boundless-xyz/boundless'
     runs-on: ubuntu-latest
     steps:
       - name: checkout code


### PR DESCRIPTION
## Problem

The `create-linear-issue-pr` job in `.github/workflows/linear.yml` requires `LINEAR_API_KEY`, which only exists as a secret on the canonical `boundless-xyz/boundless` repo. Any PR opened from a fork triggers the workflow, which then hard-errors:

```
Error: Input required and not supplied: linear-api-key
Error: No accessToken or apiKey provided to the LinearClient
```

This creates noise on every fork PR and makes CI appear broken when it isn't.

## Fix

Add an `if: github.repository == 'boundless-xyz/boundless'` guard on the job. The workflow is skipped (not failed) on forks — no secret needed, no noise.

```yaml
jobs:
  create-linear-issue-pr:
    if: github.repository == 'boundless-xyz/boundless'
```

## Impact

- Canonical repo: behaviour unchanged — job runs on every PR to `main` as before.
- Forks: job is skipped cleanly; CI goes green without needing `LINEAR_API_KEY`.
- 3-line change, no logic altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a simple GitHub Actions job-level `if` guard that only changes when the workflow runs, not application behavior or data handling.
> 
> **Overview**
> Prevents the `create-linear-issue-pr` GitHub Actions job from running on forks by adding a job-level `if: github.repository == 'boundless-xyz/boundless'` guard, avoiding failures when `LINEAR_API_KEY` isn’t available.
> 
> Behavior on the canonical repo is unchanged; fork PRs now skip the job cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7e16d36c4c380f4294ed742481ae620af0cf618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->