### PR TITLE
BM-2845: Fix nightly prover deployment configs for next branch

### DIFF
--- a/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.11155111.toml
+++ b/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.11155111.toml
@@ -1,4 +1,4 @@
 # Production Ethereum Sepolia (11155111) chain override
 [market]
-mcycle_price = "0.0000005"
+min_mcycle_price = "0.0000005"
 max_collateral = "7"

--- a/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.84532.toml
+++ b/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.84532.toml
@@ -1,6 +1,6 @@
 # Production Base Sepolia (84532) chain override
 [market]
-mcycle_price = "0.0000005"
+min_mcycle_price = "0.0000005"
 max_collateral = "7"
 deny_requestor_addresses = [
   "0x47c76E56Ad9316A5c1ab17CBa87a1Cc134552183", # Signal contract on Base Sepolia; proofs are too large

--- a/ansible/roles/prover/configs/broker/staging-nightly/broker.84532.toml
+++ b/ansible/roles/prover/configs/broker/staging-nightly/broker.84532.toml
@@ -1,6 +1,6 @@
 # Staging Base Sepolia (84532) chain override
 [market]
-mcycle_price = "0.00000005"
+min_mcycle_price = "0.00000005"
 max_collateral = "5"
 deny_requestor_addresses = [
   "0x5351280f80ffC14B7550638F1d2fa336D7e1d435", # Signal contract on Base Sepolia, connected to the staging market

--- a/ansible/roles/prover/defaults/main.yml
+++ b/ansible/roles/prover/defaults/main.yml
@@ -109,6 +109,22 @@ prover_chain_rpc_urls: {}
 #   or with local files:
 #     167000: "/path/to/broker.167000.toml"
 prover_chain_overrides: {}
+
+# Multichain: per-chain deployment addresses. Dict of chain_id → dict of addresses.
+# Only needed for staging, where the prover connects to a different market contract
+# than the production default hardcoded in the broker. Production provers auto-resolve
+# addresses from the built-in deployment config and do not need this.
+# Supported keys: market_address, set_verifier_address, collateral_token_address, order_stream_url
+# Example:
+#   prover_chain_deployments:
+#     84532:
+#       market_address: "0x..."
+#       set_verifier_address: "0x..."
+#       collateral_token_address: "0x..."
+#     167000:
+#       market_address: "0x..."
+prover_chain_deployments: {}
+
 # MinIO input TTL: 0 disables the lifecycle rule, >0 expires inputs/ objects after N days
 prover_input_ttl_days: 1
 

--- a/ansible/roles/prover/templates/docker-compose.env.j2
+++ b/ansible/roles/prover/templates/docker-compose.env.j2
@@ -164,9 +164,30 @@ PROVER_RPC_URL_{{ chain_id }}={{ rpc_url }}
 {% endfor %}
 {% endif %}
 
-# Broker extra CLI args (e.g. --experimental-rpc when prover_broker_experimental_rpc is true)
-{% if prover_broker_experimental_rpc | default(false) | bool or (prover_broker_extra_args is defined and prover_broker_extra_args | string | length > 0) %}
-BROKER_EXTRA_ARGS={% if prover_broker_experimental_rpc | default(false) | bool %}--experimental-rpc{% endif %}{% if prover_broker_extra_args is defined and prover_broker_extra_args | string | length > 0 %}{% if prover_broker_experimental_rpc | default(false) | bool %} {% endif %}{{ prover_broker_extra_args }}{% endif %}
+# Broker extra CLI args
+{% set broker_args = [] %}
+{% if prover_broker_experimental_rpc | default(false) | bool %}
+{% set _ = broker_args.append('--experimental-rpc') %}
+{% endif %}
+{% if prover_broker_extra_args is defined and prover_broker_extra_args | string | length > 0 %}
+{% set _ = broker_args.append(prover_broker_extra_args) %}
+{% endif %}
+{% for chain_id, addrs in (prover_chain_deployments | default({})).items() %}
+{% if addrs.market_address is defined %}
+{% set _ = broker_args.append('--market-address-' ~ chain_id ~ ' ' ~ addrs.market_address) %}
+{% endif %}
+{% if addrs.set_verifier_address is defined %}
+{% set _ = broker_args.append('--set-verifier-address-' ~ chain_id ~ ' ' ~ addrs.set_verifier_address) %}
+{% endif %}
+{% if addrs.collateral_token_address is defined %}
+{% set _ = broker_args.append('--collateral-token-address-' ~ chain_id ~ ' ' ~ addrs.collateral_token_address) %}
+{% endif %}
+{% if addrs.order_stream_url is defined %}
+{% set _ = broker_args.append('--order-stream-url-' ~ chain_id ~ ' ' ~ addrs.order_stream_url) %}
+{% endif %}
+{% endfor %}
+{% if broker_args | length > 0 %}
+BROKER_EXTRA_ARGS={{ broker_args | join(' ') }}
 {% endif %}
 
 # MinIO Input TTL (0 = disabled, >0 = expire inputs/ objects after N days)


### PR DESCRIPTION
## Description
Fixes multiple configuration issues affecting all nightly provers deploying from the `next` branch. The staging nightly broker has been crash-looping since Apr 11 due to a missing config field, and several other issues would prevent correct multichain (Base + Taiko) operation.

### Changes

**Broker config field rename** (`ansible/roles/prover/configs/broker/`)
- Renamed `mcycle_price` → `min_mcycle_price` in `staging-nightly/broker.84532.toml`, `prod-testnet-nightly/broker.84532.toml`, and `prod-testnet-nightly/broker.11155111.toml`. The `next` branch removed the `serde(alias = "mcycle_price")` backward-compatibility alias, so the old field name causes a parse error: `missing field `min_mcycle_price'`. This was the direct cause of the staging broker crash-loop.

**Per-chain deployment address support** (`ansible/roles/prover/`)
- Added `prover_chain_deployments` variable to `defaults/main.yml` — a dict of `chain_id → {market_address, set_verifier_address, collateral_token_address, order_stream_url}` for overriding hardcoded contract addresses. Only needed for staging, where the prover connects to different market contracts than the production defaults in `deployments.rs`.
- Updated `docker-compose.env.j2` to emit per-chain deployment flags (`--market-address-{chain_id}`, etc.) via `BROKER_EXTRA_ARGS`. Existing behavior is preserved when the variable is empty (default).

### Summary

| # | Issue | Fix | Where |
|---|---|---|---|
| 1 | Staging broker crash-loop (`missing field min_mcycle_price`) | Rename `mcycle_price` → `min_mcycle_price` in broker configs | This PR |
| 2 | No per-chain contract address support for staging | New `prover_chain_deployments` Ansible variable + template | This PR |
| 3 | `prover_broker_toml_url` points to deleted files | Replace with `prover_broker_config_dir` | TODO AWS secret |
| 4 | No Taiko RPC URL configured | Replace `prover_rpc_urls` with `prover_chain_rpc_urls` | TODO AWS secret |
| 5 | Staging uses production Taiko contract addresses | Add `prover_chain_deployments` for staging | TODO  AWS secret |

### Inventory update required (AWS Secrets Manager)
Items 3–5 are TODO and require updating `l-prover-ansible-inventory-file`. The current inventory references broker config files that were deleted in the multichain restructure (#1858) — deployments silently use stale configs cached on the servers.

**All nightly provers:** Replace `prover_broker_toml_url` with `prover_broker_config_dir` and `prover_rpc_urls` with `prover_chain_rpc_urls` to add Taiko RPC.

**Staging nightly only:** Add `prover_chain_deployments` with the staging contract addresses from `contracts/deployment.toml` (`base-sepolia-staging` and `taiko-staging`).