### PR TITLE
BM-2852: Reduce Taiko order generator volume, max price, and distributor ETH thresholds

### DIFF
--- a/infra/distributor/Pulumi.l-prod-167000.yaml
+++ b/infra/distributor/Pulumi.l-prod-167000.yaml
@@ -14,8 +14,8 @@ config:
   distributor:DOCKER_DIR: ../../
   distributor:DOCKER_TAG: latest
   distributor:ENABLE_EXTERNAL_TOPUP: "false"
-  distributor:ETH_THRESHOLD: "0.015"
-  distributor:ETH_TOP_UP_AMOUNT: "0.04"
+  distributor:ETH_THRESHOLD: "0.008"
+  distributor:ETH_TOP_UP_AMOUNT: "0.02"
   distributor:EXTERNAL_COLLATERAL_THRESHOLD: "50"
   distributor:EXTERNAL_LIFETIME_ALLOWANCE: "100"
   distributor:EXTERNAL_PER_TOP_UP_AMOUNT: "50"

--- a/infra/distributor/Pulumi.l-staging-167000.yaml
+++ b/infra/distributor/Pulumi.l-staging-167000.yaml
@@ -16,8 +16,8 @@ config:
   distributor:DOCKER_DIR: ../../
   distributor:DOCKER_TAG: latest
   distributor:ENABLE_EXTERNAL_TOPUP: "false"
-  distributor:ETH_THRESHOLD: "0.015"
-  distributor:ETH_TOP_UP_AMOUNT: "0.04"
+  distributor:ETH_THRESHOLD: "0.008"
+  distributor:ETH_TOP_UP_AMOUNT: "0.02"
   distributor:EXTERNAL_COLLATERAL_THRESHOLD: "50"
   distributor:EXTERNAL_LIFETIME_ALLOWANCE: "100"
   distributor:EXTERNAL_PER_TOP_UP_AMOUNT: "50"

--- a/infra/order-generator/Pulumi.l-prod-167000.yaml
+++ b/infra/order-generator/Pulumi.l-prod-167000.yaml
@@ -31,8 +31,8 @@ config:
   order-generator-evm-requestor:INPUT_MAX_MCYCLES: "3000"
   order-generator-evm-requestor:INTERVAL: "600"
   order-generator-evm-requestor:LOCK_TIMEOUT: "2100"
-  order-generator-evm-requestor:MAX_OUTSTANDING_REQUESTS: "30"
-  order-generator-evm-requestor:MAX_PRICE_CAP: "0.01"
+  order-generator-evm-requestor:MAX_OUTSTANDING_REQUESTS: "15"
+  order-generator-evm-requestor:MAX_PRICE_CAP: "0.0075"
   order-generator-evm-requestor:PRIVATE_KEY:
     secure: v1:UUCFZ16SpRnEHGqY:F5Mwja/OuOUCzSv5E6rkQvHz3SDNQ2f6UWdZpxH1I1+8dO993ucbxqucRsJA+qDuS0fZpj6jiOd6lin1Bbmmr4fnkNE6w16MnK2FeWgW1yQtUQ==
   order-generator-evm-requestor:RAMP_UP: "900"
@@ -49,8 +49,8 @@ config:
   order-generator-offchain:INPUT_MIN_MCYCLES: "1000"
   order-generator-offchain:INTERVAL: "900"
   order-generator-offchain:LOCK_TIMEOUT: "1500"
-  order-generator-offchain:MAX_OUTSTANDING_REQUESTS: "30"
-  order-generator-offchain:MAX_PRICE_CAP: "0.0001"
+  order-generator-offchain:MAX_OUTSTANDING_REQUESTS: "15"
+  order-generator-offchain:MAX_PRICE_CAP: "0.000075"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:C85e3ABgTk030Eup:+LMVZDHLUea4fPhn42jIsQnGIFhZpTnwlv6eyOVik+NqgCUPY78wVTlNaIBQazwDgK0MigKQ+UAoj6klFCygto5+0gM3RFmzMQUuW10ATmc=
   order-generator-offchain:RAMP_UP: "600"
@@ -65,8 +65,8 @@ config:
   order-generator-onchain:INPUT_MIN_MCYCLES: "1000"
   order-generator-onchain:INTERVAL: "900"
   order-generator-onchain:LOCK_TIMEOUT: "2100"
-  order-generator-onchain:MAX_OUTSTANDING_REQUESTS: "30"
-  order-generator-onchain:MAX_PRICE_CAP: "0.0001"
+  order-generator-onchain:MAX_OUTSTANDING_REQUESTS: "15"
+  order-generator-onchain:MAX_PRICE_CAP: "0.000075"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:Wfonliegz8oHLnNJ:VSCTMdfxEzzufPw4NWLsQOfRSE5VDR6MQ+9Byo39aOP9B6r7zVazzNyTWbhttjyD6y0vbF12vsl+4iX8w8HTOewJftwOCoSPsrct3+YLE5w=
   order-generator-onchain:RAMP_UP: "900"
@@ -74,13 +74,13 @@ config:
   order-generator-onchain:SECONDS_PER_MCYCLE: "7"
   order-generator-onchain:TIMEOUT: "1800"
   order-generator-onchain:WARN_BALANCE_BELOW: "0.01"
-  order-generator-random-requestor:COUNT: "10"
+  order-generator-random-requestor:COUNT: "5"
   order-generator-random-requestor:ERROR_BALANCE_BELOW: "0.005"
   order-generator-random-requestor:INPUT_MAX_MCYCLES: "200"
   order-generator-random-requestor:INTERVAL: "600"
   order-generator-random-requestor:LOCK_TIMEOUT: "1800"
-  order-generator-random-requestor:MAX_OUTSTANDING_REQUESTS: "30"
-  order-generator-random-requestor:MAX_PRICE_CAP: "0.01"
+  order-generator-random-requestor:MAX_OUTSTANDING_REQUESTS: "15"
+  order-generator-random-requestor:MAX_PRICE_CAP: "0.0075"
   order-generator-random-requestor:PRIVATE_KEY:
     secure: v1:L6X2rqDXhNLyGChG:RADX+x5yqxbM4835BuSyslAHqs7s2Sx2JNJU50FKliMqJgnzNBKrE/Byodp2LuI+XTLoF8AIjBvCyeIF+Qj0pvGSTN6u0PtGPTqckXmDHnk=
   order-generator-random-requestor:RAMP_UP_SECONDS_PER_MCYCLE: "2"

--- a/infra/order-generator/Pulumi.l-staging-167000.yaml
+++ b/infra/order-generator/Pulumi.l-staging-167000.yaml
@@ -30,7 +30,7 @@ config:
   order-generator-evm-requestor:ERROR_BALANCE_BELOW: "0.01"
   order-generator-evm-requestor:EXEC_RATE_KHZ: "1000"
   order-generator-evm-requestor:INPUT_MAX_MCYCLES: "1000"
-  order-generator-evm-requestor:INTERVAL: "3600"
+  order-generator-evm-requestor:INTERVAL: "7200"
   order-generator-evm-requestor:LOCK_TIMEOUT: "2100"
   order-generator-evm-requestor:PRIVATE_KEY:
     secure: v1:mPdS7f/y5Hd+cmqM:ei/VZ87c4PqENiaWNgTX0rdeOwWysBcJD9aLImzhNB+MbtSSf+d9fSaAT5QPSbppemkz/1UzwQczwTQWT4wIVlEOvG03LlpXA1Kb08KBIllBrw==
@@ -45,7 +45,7 @@ config:
   order-generator-offchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-offchain:EXEC_RATE_KHZ: "500"
   order-generator-offchain:INPUT_MAX_MCYCLES: "10"
-  order-generator-offchain:INTERVAL: "900"
+  order-generator-offchain:INTERVAL: "1800"
   order-generator-offchain:LOCK_TIMEOUT: "900"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:p4IhT/U8smWcYeRL:roi/EfqIqgP1UZmtGLNaA4LMkoa1WzW8vnmCVAcsz9WD2IgBmM40Q2KryQ1VVmkyBHE4d2/AMaMq+HWh+GR3Y/vW5qxksExOTDjrBXOO6jo=
@@ -57,7 +57,7 @@ config:
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "500"
   order-generator-onchain:INPUT_MAX_MCYCLES: "10"
-  order-generator-onchain:INTERVAL: "900"
+  order-generator-onchain:INTERVAL: "1800"
   order-generator-onchain:LOCK_TIMEOUT: "900"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:pQMFkeTtuUKffOsy:uMi6cYMUnzxqi7ErlSWki49wLRhhKBAjwcHvBUqxHwiZoepNZCgZHZmPRqiZnl7ZqNhALvU6CTNH84xTEQc2CN4+SM36xzdaM40fSmH9b8A=
@@ -69,7 +69,7 @@ config:
   order-generator-random-requestor:INPUT_MAX_MCYCLES: "100"
   order-generator-random-requestor:PRIVATE_KEY:
     secure: v1:AAAVxQWIxbmfO0Z2:nVh+b/2hnSIA7txnkTva6kNNflotcqdSBBP2DyI1QPCp5Qcq0E7wmnd250ioO8BLh+TbkYzlpIoUav8i/R0cezcTUsh1qvdSvyFMev0hKRk=
-  order-generator-random-requestor:SCHEDULE_EXPRESSION: rate(2 hours)
+  order-generator-random-requestor:SCHEDULE_EXPRESSION: rate(4 hours)
   order-generator:CI_CACHE_SECRET:
     secure: v1:E8q2Dlw+CaL5J4yF:OeTsiMNliITIEykUETaxMb7iQUOmdiTi0K5TZ4s8huAcIBPtys6HN4s/ujHC039wD2K3LNq9BD6qpETRAj1z0Etz/XcRP+YkFcC/GXhs+qJJv1e60pHHS7QEiV7t+wUVtMkBm/4uydEulU7qvpOV9nLihW5iAfl9wKbp3jrchw==
   order-generator-base:ETH_RPC_URL:


### PR DESCRIPTION
Cuts Taiko order generator request volume and lowers max price caps by 25%. Also reduces distributor ETH top-up amounts and trigger thresholds.

Changes
* Prod: MAX_OUTSTANDING_REQUESTS 30 → 15, random COUNT 10 → 5, MAX_PRICE_CAP reduced 25% across all requestors (evm, offchain, onchain, random)
* Staging: doubled all requestor intervals (evm 3600→7200, offchain/onchain 900→1800, random schedule 2h→4h)
* Distributor (both staging + prod): ETH_THRESHOLD 0.015 → 0.008, ETH_TOP_UP_AMOUNT 0.04 → 0.02