### PR TITLE
BM-2853: Lower Taiko broker balance alert thresholds

### DIFF
--- a/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.167000.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.167000.toml
@@ -3,3 +3,5 @@
 min_mcycle_price = "0.000001 USD"
 max_collateral = "100 USD"
 expected_probability_win_secondary_fulfillment = 50
+balance_warn_threshold = "0.005"
+balance_error_threshold = "0.002"

--- a/ansible/roles/prover/configs/broker/prod-mainnet-release/broker.167000.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-release/broker.167000.toml
@@ -3,3 +3,5 @@
 min_mcycle_price = "0.000001 USD"
 max_collateral = "100 USD"
 expected_probability_win_secondary_fulfillment = 50
+balance_warn_threshold = "0.005"
+balance_error_threshold = "0.002"

--- a/ansible/roles/prover/configs/broker/staging-nightly/broker.167000.toml
+++ b/ansible/roles/prover/configs/broker/staging-nightly/broker.167000.toml
@@ -8,3 +8,5 @@
 min_mcycle_price = "0.000001 USD"
 max_collateral = "100 USD"
 expected_probability_win_secondary_fulfillment = 50
+balance_warn_threshold = "0.005"
+balance_error_threshold = "0.002"


### PR DESCRIPTION
Sets Taiko-specific balance_warn_threshold (0.005) and balance_error_threshold (0.002) in all three broker.167000.toml files, overriding the shared base values. These need to be lower than the distributor ETH_THRESHOLD (0.008) we're setting in the companion PR against main.

Changes
* Added balance_warn_threshold and balance_error_threshold overrides to prod-mainnet-release, prod-mainnet-nightly, and staging-nightly broker.167000.toml files