### PR TITLE
BM-2854: Fix broker startup crash when per-chain deployments are configured

### DIFF
--- a/ansible/roles/prover/templates/docker-compose.env.j2
+++ b/ansible/roles/prover/templates/docker-compose.env.j2
@@ -132,8 +132,9 @@ BOUNDLESS_MARKET_ADDRESS={{ prover_boundless_market_address }}
 {% if prover_collateral_token_address is defined and prover_collateral_token_address | string | length > 0 %}
 COLLATERAL_TOKEN_ADDRESS={{ prover_collateral_token_address }}
 {% endif %}
-# Order Stream URL
-{% if prover_order_stream_url is defined and prover_order_stream_url | string | length > 0 %}
+# Order Stream URL (skip when per-chain deployments are configured to avoid
+# triggering clap's Deployment group requires constraint)
+{% if prover_order_stream_url is defined and prover_order_stream_url | string | length > 0 and (prover_chain_deployments | default({}) | length == 0) %}
 ORDER_STREAM_URL={{ prover_order_stream_url }}
 {% endif %}
 


### PR DESCRIPTION
When the staging prover inventory uses `prover_chain_deployments` (for multichain staging contracts), the single-chain `ORDER_STREAM_URL` env var was still being emitted. This triggered clap's `Deployment` group `requires` constraint, which demands `BOUNDLESS_MARKET_ADDRESS` and `SET_VERIFIER_ADDRESS` — fields that were intentionally removed from the staging inventory since they're now passed per-chain via `BROKER_EXTRA_ARGS`.

The broker crashed on startup with:
Usage: broker --boundless-market-address  --set-verifier-address  ...

  ### Fix
  Skip emitting `ORDER_STREAM_URL` in the env template when `prover_chain_deployments` is configured. The order stream URL is already passed per-chain via `--order-stream-url-{chain_id}` in `BROKER_EXTRA_ARGS`.