### PR TITLE
BM-2856: Mount chain-overrides in prover-compose and fix Ansible config deployment

### DIFF
--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -55,13 +55,40 @@
 ## 2. prover_broker_toml_local + prover_chain_overrides: individual file paths
 ## 3. prover_broker_toml_url (default): download broker.toml from URL
 
-- name: Deploy broker config from directory
+- name: Deploy base broker config from directory
   ansible.builtin.copy:
-    src: "{{ prover_broker_config_dir }}/"
-    dest: "{{ prover_dir }}/"
+    src: "{{ prover_broker_config_dir }}/broker.toml"
+    dest: "{{ prover_dir }}/broker.toml"
     owner: root
     group: root
     mode: "0644"
+  when: prover_broker_config_dir | string | length > 0
+  notify: Restart Bento
+
+- name: Ensure chain-overrides directory exists
+  ansible.builtin.file:
+    path: "{{ prover_dir }}/chain-overrides"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: prover_broker_config_dir | string | length > 0
+
+- name: Find chain override files
+  ansible.builtin.find:
+    paths: "{{ role_path }}/{{ prover_broker_config_dir }}"
+    patterns: "broker.*.toml"
+  register: chain_override_files
+  when: prover_broker_config_dir | string | length > 0
+
+- name: Deploy chain override files
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ prover_dir }}/chain-overrides/"
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ chain_override_files.files | default([]) }}"
   when: prover_broker_config_dir | string | length > 0
   notify: Restart Bento
 

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -243,6 +243,10 @@ services:
       - type: bind
         source: ./broker.toml
         target: /app/broker.toml
+      - type: bind
+        source: ./chain-overrides
+        target: /app/chain-overrides
+        read_only: true
       - broker-data:/db/
     # Uncomment when using locally built set-builder and assessor guest programs
     # - type: bind


### PR DESCRIPTION
The broker on all nightly provers using `prover-compose.yml` (the new prover stack) fails to parse config because chain override files (`broker.{chain_id}.toml`) are not mounted into the container. The `chain-overrides/` bind mount was added to `compose.yml` in PR #1854 but was missed in `prover-compose.yml`.

Without the override mount, `ConfigWatcher::new_with_chain_override` falls back to parsing the base `broker.toml` directly (no merge), which fails because `min_mcycle_price` is only defined in the per-chain override files.

### Changes

**`prover-compose.yml`**: Added `chain-overrides/` read-only bind mount to the broker service, matching `compose.yml`.
**`ansible/roles/prover/tasks/main.yml`**: Split the `prover_broker_config_dir` deployment task to copy files to the correct locations:
- `broker.toml` → `{{ prover_dir }}/broker.toml` (container root)
- `broker.*.toml` → `{{ prover_dir }}/chain-overrides/` (mounted subdirectory)

Previously the task copied all files flat to `{{ prover_dir }}/`, so override files existed on the host but weren't visible inside the container.