### PR TITLE
BM-2857: Fix Ansible chain-overrides deployment to use delegate_to localhost

### DIFF
--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -55,40 +55,23 @@
 ## 2. prover_broker_toml_local + prover_chain_overrides: individual file paths
 ## 3. prover_broker_toml_url (default): download broker.toml from URL
 
-- name: Deploy base broker config from directory
+- name: Deploy broker config from directory
   ansible.builtin.copy:
-    src: "{{ prover_broker_config_dir }}/broker.toml"
-    dest: "{{ prover_dir }}/broker.toml"
+    src: "{{ prover_broker_config_dir }}/"
+    dest: "{{ prover_dir }}/chain-overrides/"
     owner: root
     group: root
     mode: "0644"
   when: prover_broker_config_dir | string | length > 0
   notify: Restart Bento
 
-- name: Ensure chain-overrides directory exists
-  ansible.builtin.file:
-    path: "{{ prover_dir }}/chain-overrides"
-    state: directory
-    owner: root
-    group: root
-    mode: "0755"
-  when: prover_broker_config_dir | string | length > 0
-
-- name: Find chain override files
-  ansible.builtin.find:
-    paths: "{{ role_path }}/{{ prover_broker_config_dir }}"
-    patterns: "broker.*.toml"
-  register: chain_override_files
-  when: prover_broker_config_dir | string | length > 0
-
-- name: Deploy chain override files
+- name: Copy base broker.toml to prover root
   ansible.builtin.copy:
-    src: "{{ item.path }}"
-    dest: "{{ prover_dir }}/chain-overrides/"
+    src: "{{ prover_broker_config_dir }}/broker.toml"
+    dest: "{{ prover_dir }}/broker.toml"
     owner: root
     group: root
     mode: "0644"
-  loop: "{{ chain_override_files.files | default([]) }}"
   when: prover_broker_config_dir | string | length > 0
   notify: Restart Bento
 


### PR DESCRIPTION
  Follow-up fix to PR #1904. The `ansible.builtin.find` task was searching for `broker.*.toml` chain override files on the **remote host** instead of the Ansible controller where the role files live. This meant the `chain-overrides/` directory on the prover servers was empty — no override files were copied.

  ### Fix
  Replaced the find+copy approach with two simple `ansible.builtin.copy` calls:
  1. Copy the entire config directory contents to `chain-overrides/` on the host
  2. Copy `broker.toml` separately to the prover root