### PR TITLE
BM-2858: Add required base config fields and env_file for multichain broker

### DIFF
--- a/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
@@ -1,6 +1,8 @@
 # Nightly base broker config (shared across all chains)
 # Per-chain fields (min_mcycle_price, max_collateral) are in broker.{chain_id}.toml
 [market]
+min_mcycle_price = "0.000000025"
+max_collateral = "200"
 lookback_blocks = 300
 peak_prove_khz = 8000
 priority_requestor_lists = [

--- a/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.toml
+++ b/ansible/roles/prover/configs/broker/prod-testnet-nightly/broker.toml
@@ -1,6 +1,8 @@
 # Production testnet base broker config (shared across testnet chains)
-# Per-chain fields (mcycle_price, max_collateral, deny lists) are in broker.{chain_id}.toml
+# Per-chain fields (min_mcycle_price, max_collateral, deny lists) are in broker.{chain_id}.toml
 [market]
+min_mcycle_price = "0.0000005"
+max_collateral = "7"
 expected_probability_win_secondary_fulfillment = 100 # no discount on secondary fulfillments -> min_mcycle_price is used to judge whether to accept a request or not
 peak_prove_khz = 80
 min_deadline = 120

--- a/ansible/roles/prover/configs/broker/staging-nightly/broker.toml
+++ b/ansible/roles/prover/configs/broker/staging-nightly/broker.toml
@@ -1,6 +1,8 @@
 # Staging base broker config (shared across all chains)
-# Per-chain fields (mcycle_price, max_collateral, deny lists) are in broker.{chain_id}.toml
+# Per-chain fields (min_mcycle_price, max_collateral, deny lists) are in broker.{chain_id}.toml
 [market]
+min_mcycle_price = "0.00000005"
+max_collateral = "5"
 expected_probability_win_secondary_fulfillment = 100 # no discount on secondary fulfillments -> min_mcycle_price is used to judge whether to accept a request or not
 peak_prove_khz = 80
 min_deadline = 120

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -255,6 +255,9 @@ services:
     # - type: bind
     #   source: ./target/riscv-guest/guest-assessor/assessor-guest/riscv32im-risc0-zkvm-elf/release/assessor-guest.bin
     #   target: /target/riscv-guest/guest-assessor/assessor-guest/riscv32im-risc0-zkvm-elf/release/assessor-guest.bin
+    env_file:
+      - path: .env
+        required: false
     environment:
       <<: *broker-environment
     entrypoint:


### PR DESCRIPTION
  Follow-up to PR #1904 and #1905. The broker parses the base `broker.toml` at startup **before** entering multichain mode and loading chain overrides. Two issues prevented startup:

  1. **Missing required fields in base config**: `min_mcycle_price` and `max_collateral` have no `serde(default)` — they must be present in the base `broker.toml` even though chain overrides redefine them. Added default values to all three nightly base configs.

  2. **Per-chain env vars not reaching the container**: `PROVER_RPC_URL_{chain_id}` vars are in `.env` but `prover-compose.yml` only passes explicitly listed vars via the `environment`  block. The broker's chain discovery (`discover_chain_ids_from_argv`) scans `std::env::vars()` for `PROVER_RPC_URL_*` patterns but never sees them. Added `env_file: .env` to the broker service.

  Both fixes verified on the staging prover (`prover-84532-staging-nightly`) — broker now starts successfully on both chains (84532 + 167000).