### PR TITLE
BM-2859: Deduplicate request support

### DIFF
--- a/crates/boundless-market/src/indexer_client.rs
+++ b/crates/boundless-market/src/indexer_client.rs
@@ -461,16 +461,14 @@ impl IndexerClient {
             .join(&format!("v1/market/requestors/{}/requests", address))
             .context("Failed to build URL")?;
 
-        let mut query_parts = Vec::new();
-        if let Some(c) = cursor {
-            let encoded: String = url::form_urlencoded::byte_serialize(c.as_bytes()).collect();
-            query_parts.push(format!("cursor={}", encoded));
-        }
-        if deduplicate {
-            query_parts.push("deduplicate=true".to_string());
-        }
-        if !query_parts.is_empty() {
-            url.set_query(Some(&query_parts.join("&")));
+        if cursor.is_some() || deduplicate {
+            let mut pairs = url.query_pairs_mut();
+            if let Some(c) = cursor {
+                pairs.append_pair("cursor", c);
+            }
+            if deduplicate {
+                pairs.append_pair("deduplicate", "true");
+            }
         }
 
         let url_str = url.to_string();

--- a/crates/boundless-market/src/indexer_client.rs
+++ b/crates/boundless-market/src/indexer_client.rs
@@ -113,6 +113,7 @@ impl std::fmt::Display for RequestStatus {
 
 /// Parameters for fetching requests by requestor
 #[derive(Debug, Default, Clone)]
+#[non_exhaustive]
 pub struct GetRequestsByRequestorParams {
     /// Only return requests created after this timestamp (Unix seconds).
     /// TODO: Update to use API parameter once supported server-side.
@@ -120,6 +121,8 @@ pub struct GetRequestsByRequestorParams {
     /// Only return requests with this status.
     /// TODO: Update to use API parameter once supported server-side.
     pub status: Option<RequestStatus>,
+    /// When true, will deduplicate requests such that there is only one per request ID.
+    pub deduplicate: bool,
 }
 
 impl GetRequestsByRequestorParams {
@@ -134,6 +137,7 @@ impl GetRequestsByRequestorParams {
 pub struct GetRequestsByRequestorParamsBuilder {
     after: Option<i64>,
     status: Option<RequestStatus>,
+    deduplicate: bool,
 }
 
 impl GetRequestsByRequestorParamsBuilder {
@@ -149,9 +153,19 @@ impl GetRequestsByRequestorParamsBuilder {
         self
     }
 
+    /// When true, deduplicate requests by request_id keeping only the most advanced status
+    pub fn deduplicate(mut self, deduplicate: bool) -> Self {
+        self.deduplicate = deduplicate;
+        self
+    }
+
     /// Build the GetRequestsByRequestorParams
     pub fn build(self) -> GetRequestsByRequestorParams {
-        GetRequestsByRequestorParams { after: self.after, status: self.status }
+        GetRequestsByRequestorParams {
+            after: self.after,
+            status: self.status,
+            deduplicate: self.deduplicate,
+        }
     }
 }
 
@@ -393,7 +407,9 @@ impl IndexerClient {
         let mut cursor: Option<String> = None;
 
         loop {
-            let response = self.get_requests_by_requestor_page(address, cursor.as_deref()).await?;
+            let response = self
+                .get_requests_by_requestor_page(address, cursor.as_deref(), params.deduplicate)
+                .await?;
 
             // TODO: Update to use API-side filtering once supported
             // Check if we've gone past the 'after' timestamp (client-side filter)
@@ -438,15 +454,23 @@ impl IndexerClient {
         &self,
         address: Address,
         cursor: Option<&str>,
+        deduplicate: bool,
     ) -> Result<RequestListResponse> {
         let mut url = self
             .base_url
             .join(&format!("v1/market/requestors/{}/requests", address))
             .context("Failed to build URL")?;
 
+        let mut query_parts = Vec::new();
         if let Some(c) = cursor {
             let encoded: String = url::form_urlencoded::byte_serialize(c.as_bytes()).collect();
-            url.set_query(Some(&format!("cursor={}", encoded)));
+            query_parts.push(format!("cursor={}", encoded));
+        }
+        if deduplicate {
+            query_parts.push("deduplicate=true".to_string());
+        }
+        if !query_parts.is_empty() {
+            url.set_query(Some(&query_parts.join("&")));
         }
 
         let url_str = url.to_string();
@@ -574,6 +598,35 @@ mod tests {
         assert_eq!(result.p90, price_percentiles.p90);
         assert_eq!(result.p95, price_percentiles.p95);
         assert_eq!(result.p99, price_percentiles.p99);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_requests_by_requestor_deduplicate() {
+        let (server, client) = create_test_indexer_client();
+        let address: Address = "0x1234567890abcdef1234567890abcdef12345678".parse().unwrap();
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path(format!("/v1/market/requestors/{}/requests", address))
+                .query_param("deduplicate", "true");
+            then.status(200).json_body(json!({
+                "chain_id": 1,
+                "data": [{
+                    "request_status": "submitted",
+                    "created_at": 1000,
+                    "request_id": "0x01",
+                    "request_digest": "0xaa"
+                }],
+                "next_cursor": null,
+                "has_more": false
+            }));
+        });
+
+        let params = GetRequestsByRequestorParams::builder().deduplicate(true).build();
+        let result = client.get_all_requests_by_requestor(address, params).await.unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].request_status, "submitted");
+        mock.assert();
     }
 
     #[tokio::test]

--- a/crates/order-generator/src/main.rs
+++ b/crates/order-generator/src/main.rs
@@ -275,6 +275,7 @@ async fn run(args: &MainArgs) -> Result<()> {
             let params = GetRequestsByRequestorParams::builder()
                 .status(RequestStatus::Submitted)
                 .after(one_day_ago)
+                .deduplicate(true)
                 .build();
             match indexer.get_all_requests_by_requestor(client.caller(), params).await {
                 Ok(submitted_requests) => {


### PR DESCRIPTION
Client side change for https://github.com/boundless-xyz/boundless/pull/1889 such that our OGs use the deduplicated endpoint to avoid throttling for duplicate requests sent. Also updates our order generator to set this deduplicate flag.

<details>
<summary>Test used to verify simplification of query params against actual indexer</summary>

```
    /// Run with:
    ///   RISC0_DEV_MODE=1 cargo test -p boundless-market --lib -- test_live_cursor_pagination --ignored --nocapture
    #[tokio::test]
    #[ignore]
    async fn test_live_cursor_pagination_with_deduplicate() {
        let base_url = Url::parse("<Staging URL here>").unwrap();
        let indexer = IndexerClient::new(base_url).expect("Failed to create IndexerClient");
        let address: Address = "0x2b0e9678b8db1dd44980802754beffd89ed3c495".parse().unwrap();

        // Page 1: deduplicate=true, no cursor
        let page1 = indexer
            .get_requests_by_requestor_page(address, None, true)
            .await
            .expect("Page 1 failed");
        println!("Page 1: {} items, has_more={}", page1.data.len(), page1.has_more);
        assert!(!page1.data.is_empty(), "Page 1 should have data");
        assert!(page1.has_more, "Need has_more=true to test cursor pagination");

        let cursor = page1.next_cursor.as_deref().expect("Expected next_cursor");
        println!("Cursor: {}", cursor);

        // Page 2: deduplicate=true + cursor (tests query_pairs_mut combining both)
        let page2 = indexer
            .get_requests_by_requestor_page(address, Some(cursor), true)
            .await
            .expect("Page 2 failed — cursor + deduplicate combination broken");
        println!("Page 2: {} items, has_more={}", page2.data.len(), page2.has_more);
        assert!(!page2.data.is_empty(), "Page 2 should have data");

        // Verify no overlap between pages
        let page1_digests: Vec<&str> =
            page1.data.iter().map(|r| r.request_digest.as_str()).collect();
        let page2_digests: Vec<&str> =
            page2.data.iter().map(|r| r.request_digest.as_str()).collect();
        for d in &page2_digests {
            assert!(
                !page1_digests.contains(d),
                "Overlap detected: digest {} appears in both pages",
                d
            );
        }
        println!("No overlap — cursor + deduplicate pagination works correctly");
    }
```
</details>

