### PR TITLE
BM-2861: Fall back to `eth_maxPriorityFeePerGas` when fee history returns zero rewards

### DIFF
--- a/crates/boundless-market/src/dynamic_gas_filler.rs
+++ b/crates/boundless-market/src/dynamic_gas_filler.rs
@@ -132,12 +132,7 @@ impl PriorityMode {
         provider: &P,
     ) -> TransportResult<u128> {
         let config = self.config();
-        let fee_provider = FeeEstimatorProvider::new(
-            provider,
-            config.priority_fee_percentile,
-            config.base_fee_multiplier_percentage,
-            config.priority_fee_multiplier_percentage,
-        );
+        let fee_provider = FeeEstimatorProvider::new(provider, &config);
         match fee_provider.estimate_eip1559_fees().await {
             Ok(estimation) => Ok(estimation.max_fee_per_gas),
             Err(err) => {
@@ -283,12 +278,7 @@ impl<N: Network> TxFiller<N> for DynamicGasFiller {
     {
         let priority_config = self.get_priority_mode().await.config();
 
-        let fee_override_provider = FeeEstimatorProvider::new(
-            provider,
-            priority_config.priority_fee_percentile,
-            priority_config.base_fee_multiplier_percentage,
-            priority_config.priority_fee_multiplier_percentage,
-        );
+        let fee_override_provider = FeeEstimatorProvider::new(provider, &priority_config);
 
         let fillable = GasFiller.prepare(&fee_override_provider, tx).await?;
 
@@ -355,17 +345,12 @@ struct FeeEstimatorProvider<'a, P, N> {
 }
 
 impl<'a, P, N> FeeEstimatorProvider<'a, P, N> {
-    fn new(
-        inner: &'a P,
-        priority_fee_percentile: f64,
-        base_fee_multiplier_percentage: u64,
-        priority_fee_multiplier_percentage: u64,
-    ) -> Self {
+    fn new(inner: &'a P, config: &PriorityModeConfig) -> Self {
         Self {
             inner,
-            priority_fee_percentile,
-            base_fee_multiplier_percentage,
-            priority_fee_multiplier_percentage,
+            priority_fee_percentile: config.priority_fee_percentile,
+            base_fee_multiplier_percentage: config.base_fee_multiplier_percentage,
+            priority_fee_multiplier_percentage: config.priority_fee_multiplier_percentage,
             _network: std::marker::PhantomData,
         }
     }
@@ -416,7 +401,34 @@ where
                 .into(),
         };
 
-        Ok(estimator.estimate(base_fee_per_gas, &fee_history.reward.unwrap_or_default()))
+        let mut estimation =
+            estimator.estimate(base_fee_per_gas, &fee_history.reward.unwrap_or_default());
+
+        // When fee history returns near-zero priority fees (common on chains like Taiko
+        // where blocks are mostly empty), fall back to eth_maxPriorityFeePerGas which
+        // returns the node's recommended minimum for inclusion.
+        if estimation.max_priority_fee_per_gas <= 1 {
+            match self.inner.get_max_priority_fee_per_gas().await {
+                Ok(suggested) if suggested > estimation.max_priority_fee_per_gas => {
+                    tracing::debug!(
+                        "Fee history returned near-zero priority fee, using eth_maxPriorityFeePerGas: {} wei",
+                        suggested
+                    );
+                    estimation.max_priority_fee_per_gas = suggested;
+                    // Recalculate max_fee to include the updated priority fee
+                    estimation.max_fee_per_gas = std::cmp::max(
+                        estimation.max_fee_per_gas,
+                        base_fee_per_gas
+                            .saturating_mul(self.base_fee_multiplier_percentage as u128)
+                            / 100
+                            + estimation.max_priority_fee_per_gas,
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        Ok(estimation)
     }
 
     async fn estimate_eip1559_fees(&self) -> TransportResult<Eip1559Estimation> {

--- a/crates/broker/src/order_locker.rs
+++ b/crates/broker/src/order_locker.rs
@@ -1458,7 +1458,7 @@ pub(crate) mod tests {
         let mut ctx = setup_oc_test_context().await;
 
         let balance = ctx.monitor.provider.get_balance(ctx.signer.address()).await.unwrap();
-        let gas_price = ctx.monitor.provider.get_gas_price().await.unwrap();
+        let gas_price = ctx.monitor.chain_monitor.current_gas_price().await.unwrap();
         let gas_remaining: u64 = (balance / U256::from(gas_price)).try_into().unwrap();
         ctx.config.load_write().unwrap().market.fulfill_gas_estimate = gas_remaining / 2;
         ctx.config.load_write().unwrap().market.lockin_gas_estimate = gas_remaining / 3;

--- a/crates/guest/assessor/assessor-guest/Cargo.lock
+++ b/crates/guest/assessor/assessor-guest/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "1.3.2"
+version = "1.5.0-alpha.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.3.2"
+version = "1.5.0-alpha.0"
 dependencies = [
  "alloy",
  "alloy-chains",


### PR DESCRIPTION
  Fixes Taiko transactions getting stuck in the mempool indefinitely. Both staging and prod nightly provers were unable to lock or fulfill any orders on Taiko (chain 167000).

  ### Root Cause
  The `DynamicGasFiller` estimates priority fees using `eth_feeHistory` reward percentiles. On Taiko, blocks are mostly empty so fee history returns **0 wei** for all percentiles. The existing floor (`EIP1559_MIN_PRIORITY_FEE = 1 wei` from alloy) is far too low — Taiko block builders ignore transactions with 1 wei priority fee.

  Confirmed via stuck transactions on-chain:
  - `maxPriorityFeePerGas: 1 wei` (from fee history)
  - `eth_maxPriorityFeePerGas` RPC returns `15,000,000 wei` (0.015 gwei) — the node's recommended minimum

  ### Fix
  When the estimated priority fee from fee history is ≤ 1 wei, fall back to `eth_maxPriorityFeePerGas` from the node. This follows recommendations that the value returned by `eth_maxPriorityFeePerGas` should generally be sufficient for inclusion.

  ### Simulation Results (no funds needed)
  Old: priority fee = 1 wei,        max fee = 0.0175 gwei → STUCK
  New: priority fee = 15000000 wei,  max fee = 0.0325 gwei → INCLUDED

  ### Impact
  - Affects any chain where fee history rewards are near-zero (Taiko, potentially other L2s with low activity)
  - No impact on chains where fee history works normally (Base, Ethereum) — the fallback only triggers when priority fee ≤ 1 wei
  - No config changes needed — works automatically with all PriorityMode variants