### PR TITLE
BM-2870: Enable cert for Taiko prod order stream

### DIFF
--- a/infra/order-stream/Pulumi.l-prod-167000.yaml
+++ b/infra/order-stream/Pulumi.l-prod-167000.yaml
@@ -9,7 +9,7 @@ config:
   order-stream:CHAIN_ID: "167000"
   order-stream:CI_CACHE_SECRET:
     secure: v1:wV4ZiIGW7+4Z7AHB:upLiSX2V2sLgUKrPz/DiPpNV9kM4oreA684lnX3IiYcq4vGOkfUS4hn+ySjc8OcPz5nP+f3/BB+Yer9RPPKOSC0sk17y+ElvM+d0NZNii9jWhyitCMdxnuPnFTxCfkzpzEOaLQ8DJ8DSu368XlXdClpaSVgcfRqkalSo+Oe3HA==
-  order-stream:DISABLE_CERT: "true"
+  order-stream:DISABLE_CERT: "false"
   order-stream:DOCKER_DIR: ../../
   order-stream:DOCKER_TAG: latest
   order-stream:GH_TOKEN_SECRET:


### PR DESCRIPTION
Route53 records are in place — flip `DISABLE_CERT` back to `false` so the validated cert gets attached to the ALB HTTPS listener.

Changes
* `DISABLE_CERT` set to `"false"` in `Pulumi.l-prod-167000.yaml`