### PR TITLE
BM-2873: prover: updated resolved receipt path

### DIFF
--- a/prover/crates/workflow-common/src/lib.rs
+++ b/prover/crates/workflow-common/src/lib.rs
@@ -122,13 +122,6 @@ pub struct ResolveReq {
     pub union_max_idx: Option<usize>,
 }
 
-/// Input request
-#[derive(Debug, Deserialize, Serialize)]
-pub struct FinalizeReq {
-    /// Index of the final joined receipt
-    pub max_idx: usize,
-}
-
 /// Snark task definition
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SnarkReq {
@@ -168,7 +161,7 @@ pub enum TaskType {
     /// Resolve task
     Resolve(ResolveReq),
     /// Finalize task
-    Finalize(FinalizeReq),
+    Finalize,
     /// Stark 2 Snark task
     Snark(SnarkReq),
     /// Keccak coproc callback req
@@ -186,7 +179,7 @@ impl TaskType {
             Self::Prove(_) => "prove-lift".into(),
             Self::Join(_) => "join".into(),
             Self::Resolve(_) => "resolve".into(),
-            Self::Finalize(_) => "finalize".into(),
+            Self::Finalize => "finalize".into(),
             Self::Snark(_) => "snark".into(),
             Self::Keccak(_) => "keccak".into(),
             Self::Union(_) => "union".into(),

--- a/prover/crates/workflow/src/lib.rs
+++ b/prover/crates/workflow/src/lib.rs
@@ -727,8 +727,8 @@ impl Agent {
                     .context("[BENTO-WF-124] Failed to serialize resolve response")?
                 }
             }
-            TaskType::Finalize(req) => serde_json::to_value(
-                tasks::finalize::finalize(self, &task.job_id, &req)
+            TaskType::Finalize => serde_json::to_value(
+                tasks::finalize::finalize(self, &task.job_id)
                     .await
                     .context("[BENTO-WF-125] Finalize failed")?,
             )

--- a/prover/crates/workflow/src/tasks/executor.rs
+++ b/prover/crates/workflow/src/tasks/executor.rs
@@ -24,7 +24,7 @@ use taskdb::planner::{
 };
 use tempfile::NamedTempFile;
 use workflow_common::{
-    AUX_WORK_TYPE, COPROC_WORK_TYPE, CompressType, ExecutorReq, ExecutorResp, FinalizeReq,
+    AUX_WORK_TYPE, COPROC_WORK_TYPE, CompressType, ExecutorReq, ExecutorResp,
     JOIN_WORK_TYPE, JoinReq, KeccakReq, PROVE_WORK_TYPE, ProveReq, ResolveReq, SNARK_WORK_TYPE,
     SnarkReq, UnionReq,
     metrics::{
@@ -210,10 +210,8 @@ async fn process_task(
                     "[BENTO-EXEC-013] create_task (resolve) failure during resolve creation",
                 )?;
 
-            let task_def = serde_json::to_value(TaskType::Finalize(FinalizeReq {
-                max_idx: tree_task.depends_on[0],
-            }))
-            .context("[BENTO-EXEC-014] Failed to serialize finalize task-type")?;
+            let task_def = serde_json::to_value(TaskType::Finalize)
+                .context("[BENTO-EXEC-014] Failed to serialize finalize task-type")?;
             let prereqs = serde_json::json!([task_id]);
 
             let finalize_name = "finalize";

--- a/prover/crates/workflow/src/tasks/executor.rs
+++ b/prover/crates/workflow/src/tasks/executor.rs
@@ -24,9 +24,8 @@ use taskdb::planner::{
 };
 use tempfile::NamedTempFile;
 use workflow_common::{
-    AUX_WORK_TYPE, COPROC_WORK_TYPE, CompressType, ExecutorReq, ExecutorResp,
-    JOIN_WORK_TYPE, JoinReq, KeccakReq, PROVE_WORK_TYPE, ProveReq, ResolveReq, SNARK_WORK_TYPE,
-    SnarkReq, UnionReq,
+    AUX_WORK_TYPE, COPROC_WORK_TYPE, CompressType, ExecutorReq, ExecutorResp, JOIN_WORK_TYPE,
+    JoinReq, KeccakReq, PROVE_WORK_TYPE, ProveReq, ResolveReq, SNARK_WORK_TYPE, SnarkReq, UnionReq,
     metrics::{
         ASSUMPTION_COUNT, EXECUTION_ERRORS, GUEST_FAULTS, S3_OPERATIONS, SEGMENT_COUNT,
         TASKS_CREATED, TOTAL_CYCLES, USER_CYCLES, helpers,

--- a/prover/crates/workflow/src/tasks/finalize.rs
+++ b/prover/crates/workflow/src/tasks/finalize.rs
@@ -12,13 +12,12 @@ use risc0_zkvm::{InnerReceipt, Receipt, ReceiptClaim, SuccinctReceipt};
 use std::time::Instant;
 use uuid::Uuid;
 use workflow_common::storage::{RECEIPT_BUCKET_DIR, STARK_BUCKET_DIR};
-use workflow_common::{FinalizeReq, metrics::helpers};
+use workflow_common::metrics::helpers;
 
 /// Run finalize tasks / cleanup
 ///
 /// Creates the final rollup receipt and uploads it to shared storage.
-/// job path
-pub async fn finalize(agent: &Agent, job_id: &Uuid, _request: &FinalizeReq) -> Result<()> {
+pub async fn finalize(agent: &Agent, job_id: &Uuid) -> Result<()> {
     let start_time = Instant::now();
 
     let job_prefix = format!("job:{job_id}");

--- a/prover/crates/workflow/src/tasks/finalize.rs
+++ b/prover/crates/workflow/src/tasks/finalize.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Agent,
-    tasks::{RECUR_RECEIPT_PATH, deserialize_obj, read_image_id},
+    tasks::{RESOLVED_RECEIPT_PATH, deserialize_obj, read_image_id},
 };
 use anyhow::{Context, Result, bail};
 use risc0_zkvm::{InnerReceipt, Receipt, ReceiptClaim, SuccinctReceipt};
@@ -18,11 +18,11 @@ use workflow_common::{FinalizeReq, metrics::helpers};
 ///
 /// Creates the final rollup receipt and uploads it to shared storage.
 /// job path
-pub async fn finalize(agent: &Agent, job_id: &Uuid, request: &FinalizeReq) -> Result<()> {
+pub async fn finalize(agent: &Agent, job_id: &Uuid, _request: &FinalizeReq) -> Result<()> {
     let start_time = Instant::now();
 
     let job_prefix = format!("job:{job_id}");
-    let root_receipt_key = format!("{job_prefix}:{RECUR_RECEIPT_PATH}:{}", request.max_idx);
+    let root_receipt_key = format!("{job_prefix}:{RESOLVED_RECEIPT_PATH}");
 
     // Get root receipt using Redis helper
     let root_receipt: Vec<u8> = agent

--- a/prover/crates/workflow/src/tasks/finalize.rs
+++ b/prover/crates/workflow/src/tasks/finalize.rs
@@ -11,8 +11,8 @@ use anyhow::{Context, Result, bail};
 use risc0_zkvm::{InnerReceipt, Receipt, ReceiptClaim, SuccinctReceipt};
 use std::time::Instant;
 use uuid::Uuid;
-use workflow_common::storage::{RECEIPT_BUCKET_DIR, STARK_BUCKET_DIR};
 use workflow_common::metrics::helpers;
+use workflow_common::storage::{RECEIPT_BUCKET_DIR, STARK_BUCKET_DIR};
 
 /// Run finalize tasks / cleanup
 ///

--- a/prover/crates/workflow/src/tasks/mod.rs
+++ b/prover/crates/workflow/src/tasks/mod.rs
@@ -22,6 +22,9 @@ pub(crate) mod union;
 /// Recursion receipts key prefix
 pub(crate) const RECUR_RECEIPT_PATH: &str = "recursion_receipts";
 
+/// Resolved receipt key prefix — written by resolve/resolve_povw, read by finalize.
+pub(crate) const RESOLVED_RECEIPT_PATH: &str = "resolved_receipt";
+
 /// Segments key prefix for redis
 pub(crate) const SEGMENTS_PATH: &str = "segments";
 

--- a/prover/crates/workflow/src/tasks/resolve.rs
+++ b/prover/crates/workflow/src/tasks/resolve.rs
@@ -5,7 +5,9 @@
 
 use crate::{
     Agent,
-    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj},
+    tasks::{
+        RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj,
+    },
 };
 use anyhow::{Context, Result};
 use risc0_zkvm::sha::Digestible;

--- a/prover/crates/workflow/src/tasks/resolve.rs
+++ b/prover/crates/workflow/src/tasks/resolve.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Agent,
-    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, deserialize_obj, serialize_obj},
+    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj},
 };
 use anyhow::{Context, Result};
 use risc0_zkvm::sha::Digestible;
@@ -157,12 +157,12 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
     let serialized_asset = serialize_obj(&conditional_receipt)
         .context("[BENTO-RESOLVE-011] Failed to serialize resolved receipt")?;
 
-    // Store resolved receipt using Redis helper
-    tracing::debug!("Writing resolved receipt to Redis key: {root_receipt_key}");
+    let resolved_key = format!("{job_prefix}:{RESOLVED_RECEIPT_PATH}");
+    tracing::debug!("Writing resolved receipt to Redis key: {resolved_key}");
     agent
-        .hot_set_bytes(&root_receipt_key, serialized_asset)
+        .hot_set_bytes(&resolved_key, serialized_asset)
         .await
-        .context("Failed to set root receipt key with expiry")?;
+        .context("Failed to set resolved receipt key with expiry")?;
 
     // Record total task duration and success
     helpers::record_task_operation(

--- a/prover/crates/workflow/src/tasks/resolve_povw.rs
+++ b/prover/crates/workflow/src/tasks/resolve_povw.rs
@@ -5,7 +5,9 @@
 
 use crate::{
     Agent,
-    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj},
+    tasks::{
+        RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj,
+    },
 };
 use anyhow::{Context, Result};
 use futures::{StreamExt, stream};

--- a/prover/crates/workflow/src/tasks/resolve_povw.rs
+++ b/prover/crates/workflow/src/tasks/resolve_povw.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Agent,
-    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, deserialize_obj, serialize_obj},
+    tasks::{RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj},
 };
 use anyhow::{Context, Result};
 use futures::{StreamExt, stream};
@@ -219,12 +219,12 @@ pub async fn resolve_povw(
     let serialized_asset =
         serialize_obj(&conditional_receipt).context("Failed to serialize resolved receipt")?;
 
-    // Store resolved receipt using Redis helper
-    tracing::debug!("Writing resolved receipt to Redis key: {root_receipt_key}");
+    let resolved_key = format!("{job_prefix}:{RESOLVED_RECEIPT_PATH}");
+    tracing::debug!("Writing resolved receipt to Redis key: {resolved_key}");
     agent
-        .hot_set_bytes(&root_receipt_key, serialized_asset)
+        .hot_set_bytes(&resolved_key, serialized_asset)
         .await
-        .context("Failed to set root receipt key with expiry")?;
+        .context("Failed to set resolved receipt key with expiry")?;
 
     // Save the resolved receipt to work receipts bucket for later consumption
     let work_receipt_key = format!("{WORK_RECEIPTS_BUCKET_DIR}/{job_id}.bincode");


### PR DESCRIPTION
This inconsistency exists in bento also, and unclear if we have hit this case, but figured I'd PR what seems to be the fix for this as there doesn't seem to be a downside here other than storing a little extra data temporarily. This could also be made backwards compatible, but didn't seem worth it to do so (unlikely it's upgraded with a task in-between these steps)

The resolve step used to read the receipt from a Redis key, transform it (unwrap POVW + resolve assumptions), then write the result back to the same key it read from. The issue is if the process crashed after the write but before the task got marked as "done", the retry would try to read the original receipt — but it's been overwritten with the transformed version. For the POVW path this is an issue because the types are different (the original is a WorkClaim-wrapped receipt, the output is a plain ReceiptClaim), so deserialization just blows up and the job is permanently stuck.

The fix is to write the output to a different key (resolved_receipt) instead of clobbering the input (recursion_receipts:{idx}). Now retries always find the original untouched input and can redo the work cleanly. Finalize was updated to read from the new key since that's where the resolved receipt lives now.