### PR TITLE
prover: include cleanup for missing redis keys

### DIFF
--- a/prover/crates/workflow/src/lib.rs
+++ b/prover/crates/workflow/src/lib.rs
@@ -713,32 +713,30 @@ impl Agent {
                 }
             }
             TaskType::Resolve(req) => {
-                cleanup = tasks::CleanupKeys::none();
                 // Route to POVW or regular resolve based on agent POVW setting
                 if self.is_povw_enabled() {
-                    serde_json::to_value(
+                    let (result, keys) =
                         tasks::resolve_povw::resolve_povw(self, &task.job_id, &req)
                             .await
-                            .context("[BENTO-WF-121] POVW resolve failed")?,
-                    )
-                    .context("[BENTO-WF-122] Failed to serialize POVW resolve response")?
+                            .context("[BENTO-WF-121] POVW resolve failed")?;
+                    cleanup = keys;
+                    serde_json::to_value(result)
+                        .context("[BENTO-WF-122] Failed to serialize POVW resolve response")?
                 } else {
-                    serde_json::to_value(
-                        tasks::resolve::resolver(self, &task.job_id, &req)
-                            .await
-                            .context("[BENTO-WF-123] Resolve failed")?,
-                    )
-                    .context("[BENTO-WF-124] Failed to serialize resolve response")?
+                    let (result, keys) = tasks::resolve::resolver(self, &task.job_id, &req)
+                        .await
+                        .context("[BENTO-WF-123] Resolve failed")?;
+                    cleanup = keys;
+                    serde_json::to_value(result)
+                        .context("[BENTO-WF-124] Failed to serialize resolve response")?
                 }
             }
             TaskType::Finalize => {
-                cleanup = tasks::CleanupKeys::none();
-                serde_json::to_value(
-                    tasks::finalize::finalize(self, &task.job_id)
-                        .await
-                        .context("[BENTO-WF-125] Finalize failed")?,
-                )
-                .context("[BENTO-WF-126] Failed to serialize finalize response")?
+                cleanup = tasks::finalize::finalize(self, &task.job_id)
+                    .await
+                    .context("[BENTO-WF-125] Finalize failed")?;
+                serde_json::to_value(())
+                    .context("[BENTO-WF-126] Failed to serialize finalize response")?
             }
             TaskType::Snark(req) => {
                 cleanup = tasks::CleanupKeys::none();

--- a/prover/crates/workflow/src/tasks/finalize.rs
+++ b/prover/crates/workflow/src/tasks/finalize.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     Agent,
-    tasks::{RESOLVED_RECEIPT_PATH, deserialize_obj, read_image_id},
+    tasks::{CleanupKeys, RESOLVED_RECEIPT_PATH, deserialize_obj, read_image_id},
 };
 use anyhow::{Context, Result, bail};
 use risc0_zkvm::{InnerReceipt, Receipt, ReceiptClaim, SuccinctReceipt};
@@ -17,7 +17,7 @@ use workflow_common::storage::{RECEIPT_BUCKET_DIR, STARK_BUCKET_DIR};
 /// Run finalize tasks / cleanup
 ///
 /// Creates the final rollup receipt and uploads it to shared storage.
-pub async fn finalize(agent: &Agent, job_id: &Uuid) -> Result<()> {
+pub async fn finalize(agent: &Agent, job_id: &Uuid) -> Result<CleanupKeys> {
     let start_time = Instant::now();
 
     let job_prefix = format!("job:{job_id}");
@@ -93,5 +93,5 @@ pub async fn finalize(agent: &Agent, job_id: &Uuid) -> Result<()> {
         start_time.elapsed().as_secs_f64(),
     );
 
-    Ok(())
+    Ok(CleanupKeys(vec![root_receipt_key, journal_key, image_key]))
 }

--- a/prover/crates/workflow/src/tasks/mod.rs
+++ b/prover/crates/workflow/src/tasks/mod.rs
@@ -36,6 +36,7 @@ pub(crate) const COPROC_CB_PATH: &str = "coproc";
 
 /// Keys to clean up from Redis after a task is marked done in the DB.
 /// Returned by task functions so cleanup happens only after successful completion.
+#[must_use]
 pub(crate) struct CleanupKeys(pub Vec<String>);
 
 impl CleanupKeys {

--- a/prover/crates/workflow/src/tasks/resolve.rs
+++ b/prover/crates/workflow/src/tasks/resolve.rs
@@ -6,7 +6,8 @@
 use crate::{
     Agent,
     tasks::{
-        RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj,
+        CleanupKeys, RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj,
+        serialize_obj,
     },
 };
 use anyhow::{Context, Result};
@@ -17,12 +18,17 @@ use uuid::Uuid;
 use workflow_common::{KECCAK_RECEIPT_PATH, ResolveReq, metrics::helpers};
 
 /// Run the resolve operation
-pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Result<Option<u64>> {
+pub async fn resolver(
+    agent: &Agent,
+    job_id: &Uuid,
+    request: &ResolveReq,
+) -> Result<(Option<u64>, CleanupKeys)> {
     let start_time = Instant::now();
     let max_idx = &request.max_idx;
     let job_prefix = format!("job:{job_id}");
     let receipts_key = format!("{job_prefix}:{RECEIPT_PATH}");
     let root_receipt_key = format!("{job_prefix}:{RECUR_RECEIPT_PATH}:{max_idx}");
+    let mut keys_to_cleanup = vec![root_receipt_key.clone()];
 
     tracing::debug!("Starting resolve for job_id: {job_id}, max_idx: {max_idx}");
 
@@ -109,6 +115,7 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
                         continue;
                     }
                     let assumption_key = format!("{receipts_key}:{assumption_claim}");
+                    keys_to_cleanup.push(assumption_key.clone());
                     tracing::debug!("Deserializing assumption with key: {assumption_key}");
                     let assumption_bytes: Vec<u8> =
                         agent.hot_get_bytes(&assumption_key).await.context(format!(
@@ -175,5 +182,5 @@ pub async fn resolver(agent: &Agent, job_id: &Uuid, request: &ResolveReq) -> Res
     );
 
     tracing::info!("Resolve operation completed successfully");
-    Ok(assumptions_len)
+    Ok((assumptions_len, CleanupKeys(keys_to_cleanup)))
 }

--- a/prover/crates/workflow/src/tasks/resolve_povw.rs
+++ b/prover/crates/workflow/src/tasks/resolve_povw.rs
@@ -6,7 +6,8 @@
 use crate::{
     Agent,
     tasks::{
-        RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj, serialize_obj,
+        CleanupKeys, RECEIPT_PATH, RECUR_RECEIPT_PATH, RESOLVED_RECEIPT_PATH, deserialize_obj,
+        serialize_obj,
     },
 };
 use anyhow::{Context, Result};
@@ -27,12 +28,13 @@ pub async fn resolve_povw(
     agent: &Agent,
     job_id: &Uuid,
     request: &ResolveReq,
-) -> Result<Option<u64>> {
+) -> Result<(Option<u64>, CleanupKeys)> {
     let start_time = Instant::now();
     let max_idx = &request.max_idx;
     let job_prefix = format!("job:{job_id}");
     let receipts_key = format!("{job_prefix}:{RECEIPT_PATH}");
     let root_receipt_key = format!("{job_prefix}:{RECUR_RECEIPT_PATH}:{max_idx}");
+    let mut keys_to_cleanup = vec![root_receipt_key.clone()];
 
     tracing::debug!("Starting POVW resolve for job_id: {job_id}, max_idx: {max_idx}");
 
@@ -181,6 +183,7 @@ pub async fn resolve_povw(
                         continue;
                     }
                     let assumption_key = format!("{receipts_key}:{assumption_claim}");
+                    keys_to_cleanup.push(assumption_key.clone());
                     tracing::debug!("Deserializing assumption with key: {assumption_key}");
                     let assumption_bytes =
                         assumption_bytes_by_claim.remove(&assumption_claim).with_context(|| {
@@ -279,5 +282,5 @@ pub async fn resolve_povw(
         start_time.elapsed().as_secs_f64(),
     );
 
-    Ok(assumptions_len)
+    Ok((assumptions_len, CleanupKeys(keys_to_cleanup)))
 }


### PR DESCRIPTION
Builds on #1920 except that it adds missing keys that were previously left until TTL or the cleanup script to pick up.