### PR TITLE
BM-2874: Fix nightly retry workflow and update signal max cycles

### DIFF
--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -189,21 +189,9 @@ jobs:
       - name: sccache stats
         run: sccache --show-stats
 
-  retry-failed:
-    if: failure() && fromJSON(github.run_attempt) < 3
-    needs: [examples]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Re-run failed jobs (attempt ${{ github.run_attempt }}/3)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run rerun ${{ github.run_id }} --repo ${{ github.repository }} --failed
-
   notify-failure:
-    if: failure() && fromJSON(github.run_attempt) >= 3
-    needs: [examples, retry-failed]
+    if: failure()
+    needs: [examples]
     runs-on: ubuntu-latest
     steps:
       - uses: slackapi/slack-github-action@v2.1.0
@@ -212,5 +200,5 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "Nightly examples CI failed after 3 attempts: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "Nightly examples CI failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/nightly-signal-execute.yml
+++ b/.github/workflows/nightly-signal-execute.yml
@@ -29,7 +29,7 @@ env:
   # NOTE: these are program_cycles from the indexer; the executor reports segment-level
   # total cycles which are close but not identical. The ±5% tolerance covers the difference.
   SIGNAL_REQUESTOR_MIN_CYCLES: "36000000000"
-  SIGNAL_REQUESTOR_MAX_CYCLES: "36400000000"
+  SIGNAL_REQUESTOR_MAX_CYCLES: "37000000000"
   # Tolerance percentage for alerting
   TOLERANCE_PCT: "5"
 

--- a/.github/workflows/retry-nightly.yml
+++ b/.github/workflows/retry-nightly.yml
@@ -1,0 +1,26 @@
+name: Retry Failed Nightly Jobs
+
+on:
+  workflow_run:
+    workflows: ["Nightly Examples", "Nightly Signal Execute"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+jobs:
+  retry:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs (attempt ${{ github.event.workflow_run.run_attempt }}/3)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.reRunWorkflowFailedJobs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });

--- a/crates/boundless-market/src/price_provider.rs
+++ b/crates/boundless-market/src/price_provider.rs
@@ -189,7 +189,7 @@ impl RequestorMap {
 
     fn count_cycles(&self, address: Address, input: RequestInput) -> Option<u64> {
         const SIGNAL_REQUESTOR_MIN_CYCLES: u64 = 36_000_000_000;
-        const SIGNAL_REQUESTOR_MAX_CYCLES: u64 = 36_400_000_000;
+        const SIGNAL_REQUESTOR_MAX_CYCLES: u64 = 37_000_000_000;
 
         let requestor_type = self.requestors.get(&address);
         match requestor_type {

--- a/crates/indexer/src/market/service/cycle_counts.rs
+++ b/crates/indexer/src/market/service/cycle_counts.rs
@@ -31,7 +31,7 @@ const SIGNAL_REQUESTOR: Address =
     alloy::primitives::address!("734df7809c4ef94da037449c287166d114503198");
 
 const SIGNAL_REQUESTOR_MIN_CYCLES: u64 = 36_000_000_000; // 36 billion
-const SIGNAL_REQUESTOR_MAX_CYCLES: u64 = 36_400_000_000; // 36.4 billion
+const SIGNAL_REQUESTOR_MAX_CYCLES: u64 = 37_000_000_000; // 37 billion
 
 /// Try to extract program cycles from inline request input data.
 /// Returns Some(program_cycles) if extraction succeeds, None otherwise.


### PR DESCRIPTION
  ### Nightly retry mechanism
  - Removed the broken `retry-failed` job from `nightly-examples.yml` — it can never work because `gh run rerun` fails with "This workflow is already running" when called from within the same workflow
  - Created `retry-nightly.yml` — a separate workflow that triggers via `workflow_run` when either "Nightly Examples" or "Nightly Signal Execute" completes with failure. Retries only failed jobs, up to 3 attempts
  - Simplified `notify-failure` in `nightly-examples.yml` to always notify on failure

  ### Signal max cycles
  Updated `SIGNAL_REQUESTOR_MAX_CYCLES` from 36.4B to 37B