### PR TITLE
BM-2879: improve exec stats expiry/cleanup and broker handling

### DIFF
--- a/crates/boundless-market/src/prover_utils/local_executor.rs
+++ b/crates/boundless-market/src/prover_utils/local_executor.rs
@@ -200,7 +200,11 @@ impl Prover for LocalExecutor {
         if let Some(data) = self.state.executions.get(&exec_id).await {
             if let Some(stats) = data.stats.as_ref() {
                 tracing::debug!("Preflight cache hit for {}", exec_id);
-                return Ok(ProofResult { id: exec_id, stats: Some(stats.clone()), ..Default::default() });
+                return Ok(ProofResult {
+                    id: exec_id,
+                    stats: Some(stats.clone()),
+                    ..Default::default()
+                });
             }
         }
 
@@ -426,7 +430,10 @@ mod tests {
         // Preflight should return cached data without execution
         let result = executor.preflight(&image_id, &input_id, vec![], None, "test").await.unwrap();
 
-        assert_eq!(result.stats.expect("preflight should always return stats").total_cycles, cycles);
+        assert_eq!(
+            result.stats.expect("preflight should always return stats").total_cycles,
+            cycles
+        );
 
         // Journal should also be cached
         let cached_journal = executor.get_preflight_journal(&result.id).await.unwrap();

--- a/crates/boundless-market/src/prover_utils/local_executor.rs
+++ b/crates/boundless-market/src/prover_utils/local_executor.rs
@@ -137,7 +137,10 @@ impl LocalExecutor {
             .await?
             .ok_or_else(|| ProverError::NotFound("journal".to_string()))?;
 
-        Ok((result.stats, journal))
+        let stats = result.stats.ok_or_else(|| {
+            ProverError::ProverInternalError("Local executor preflight missing stats".to_string())
+        })?;
+        Ok((stats, journal))
     }
 
     async fn run_execution(
@@ -197,7 +200,7 @@ impl Prover for LocalExecutor {
         if let Some(data) = self.state.executions.get(&exec_id).await {
             if let Some(stats) = data.stats.as_ref() {
                 tracing::debug!("Preflight cache hit for {}", exec_id);
-                return Ok(ProofResult { id: exec_id, stats: stats.clone(), ..Default::default() });
+                return Ok(ProofResult { id: exec_id, stats: Some(stats.clone()), ..Default::default() });
             }
         }
 
@@ -235,7 +238,7 @@ impl Prover for LocalExecutor {
                     )
                     .await;
 
-                Ok(ProofResult { id: exec_id, stats, ..Default::default() })
+                Ok(ProofResult { id: exec_id, stats: Some(stats), ..Default::default() })
             }
             Err(err) => {
                 self.state.executions.insert(exec_id, ExecutionData::default()).await;
@@ -371,7 +374,8 @@ mod tests {
         let result =
             executor.preflight(&image_id, &input_id, vec![], None, "test_order_id").await.unwrap();
         assert!(!result.id.is_empty());
-        assert!(result.stats.segments > 0 && result.stats.user_cycles > 0);
+        let stats = result.stats.expect("preflight should always return stats");
+        assert!(stats.segments > 0 && stats.user_cycles > 0);
 
         // Fetch the journal
         let journal = executor.get_preflight_journal(&result.id).await.unwrap().unwrap();
@@ -422,7 +426,7 @@ mod tests {
         // Preflight should return cached data without execution
         let result = executor.preflight(&image_id, &input_id, vec![], None, "test").await.unwrap();
 
-        assert_eq!(result.stats.total_cycles, cycles);
+        assert_eq!(result.stats.expect("preflight should always return stats").total_cycles, cycles);
 
         // Journal should also be cached
         let cached_journal = executor.get_preflight_journal(&result.id).await.unwrap();

--- a/crates/boundless-market/src/prover_utils/mod.rs
+++ b/crates/boundless-market/src/prover_utils/mod.rs
@@ -614,14 +614,19 @@ pub trait OrderPricingContext {
                     .await
                 {
                     Ok(res) => {
+                        let stats = res.stats.ok_or_else(|| {
+                            OrderPricingError::UnexpectedErr(Arc::new(anyhow::anyhow!(
+                                "Preflight execution of {order_id_clone} succeeded but stats are missing"
+                            )))
+                        })?;
                         tracing::debug!(
                             "Preflight execution of {order_id_clone} with session id {} and {} mcycles completed",
                             res.id,
-                            res.stats.total_cycles / 1_000_000
+                            stats.total_cycles / 1_000_000
                         );
                         Ok(PreflightCacheValue::Success {
                             exec_session_id: res.id,
-                            cycle_count: res.stats.total_cycles,
+                            cycle_count: stats.total_cycles,
                             image_id,
                             input_id,
                         })

--- a/crates/boundless-market/src/prover_utils/prover.rs
+++ b/crates/boundless-market/src/prover_utils/prover.rs
@@ -41,10 +41,6 @@ pub enum ProverError {
     #[error("Not found: {0}")]
     NotFound(String),
 
-    /// Stark job missing stats data.
-    #[error("Stark job missing stats data")]
-    MissingStatus,
-
     /// Prover failure.
     #[error("Prover failure: {0}")]
     ProvingFailed(String),
@@ -74,8 +70,8 @@ impl From<bincode::Error> for ProverError {
 pub struct ProofResult {
     /// Unique identifier for this proof.
     pub id: String,
-    /// Execution statistics.
-    pub stats: ExecutorResp,
+    /// Execution statistics, if available from the prover backend.
+    pub stats: Option<ExecutorResp>,
     /// Time elapsed during proving.
     #[allow(unused)]
     pub elapsed_time: f64,

--- a/crates/boundless-market/src/request_builder/mod.rs
+++ b/crates/boundless-market/src/request_builder/mod.rs
@@ -1273,7 +1273,7 @@ mod tests {
         let preflight_result =
             executor.preflight(&image_id.to_string(), &input_id, vec![], None, "test").await?;
 
-        assert_eq!(preflight_result.stats.total_cycles, cycles);
+        assert_eq!(preflight_result.stats.unwrap().total_cycles, cycles);
 
         Ok(())
     }

--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -222,10 +222,10 @@ impl AggregatorService {
                     })?;
 
                 tracing::debug!(
-                    "Set-builder proof complete with orders {:?}, proof id: {} cycles: {} time: {}",
+                    "Set-builder proof complete with orders {:?}, proof id: {} cycles: {:?} time: {}",
                     all_orders,
                     proof_res.id,
-                    proof_res.stats.total_cycles,
+                    proof_res.stats.as_ref().map(|s| s.total_cycles),
                     proof_res.elapsed_time
                 );
 
@@ -335,10 +335,10 @@ impl AggregatorService {
             .context("Failed to prove assesor stark")?;
 
         tracing::debug!(
-            "Assessor proof completed, proof id: {} count: {} cycles: {} time: {}",
+            "Assessor proof completed, proof id: {} count: {} cycles: {:?} time: {}",
             proof_res.id,
             order_count,
-            proof_res.stats.total_cycles,
+            proof_res.stats.as_ref().map(|s| s.total_cycles),
             proof_res.elapsed_time
         );
 

--- a/crates/broker/src/provers/bonsai.rs
+++ b/crates/broker/src/provers/bonsai.rs
@@ -233,22 +233,28 @@ impl StatusPoller {
                     continue;
                 }
                 "SUCCEEDED" => {
-                    let Some(stats) = status.stats else {
-                        return Err(ProverError::MissingStatus);
-                    };
-                    tracing::trace!(
-                        "Session {proof_id:?} succeeded with user cycles: {} and total cycles: {}",
-                        stats.cycles,
-                        stats.total_cycles
-                    );
-                    return Ok(ProofResult {
-                        id: proof_id.uuid.clone(),
-                        stats: ExecutorResp {
+                    let stats = status.stats.map(|stats| {
+                        tracing::trace!(
+                            "Session {proof_id:?} succeeded with user cycles: {} and total cycles: {}",
+                            stats.cycles,
+                            stats.total_cycles
+                        );
+                        ExecutorResp {
                             assumption_count: 0,
                             segments: stats.segments as u64,
                             user_cycles: stats.cycles,
                             total_cycles: stats.total_cycles,
-                        },
+                        }
+                    });
+                    if stats.is_none() {
+                        tracing::warn!(
+                            "Session {proof_id:?} succeeded but stats are not available. \
+                            This can happen if the status is cleaned up before this is polled."
+                        );
+                    }
+                    return Ok(ProofResult {
+                        id: proof_id.uuid.clone(),
+                        stats,
                         elapsed_time: status.elapsed_time.unwrap_or(f64::NAN),
                     });
                 }

--- a/crates/broker/src/provers/default.rs
+++ b/crates/broker/src/provers/default.rs
@@ -195,7 +195,7 @@ impl Prover for DefaultProver {
                 proof.stats = Some(stats.clone());
                 proof.preflight_journal = Some(info.journal.bytes);
 
-                Ok(ProofResult { id: proof_id, stats, ..Default::default() })
+                Ok(ProofResult { id: proof_id, stats: Some(stats), ..Default::default() })
             }
             Err(err) => {
                 proof.status = Status::Failed;
@@ -287,12 +287,12 @@ impl Prover for DefaultProver {
                         let stats = proof_data.stats.as_ref().unwrap();
                         return Ok(ProofResult {
                             id: proof_id.to_string(),
-                            stats: ExecutorResp {
+                            stats: Some(ExecutorResp {
                                 segments: stats.segments,
                                 user_cycles: stats.user_cycles,
                                 total_cycles: stats.total_cycles,
                                 ..Default::default()
-                            },
+                            }),
                             ..Default::default()
                         });
                     }
@@ -504,7 +504,8 @@ mod tests {
         let result =
             prover.preflight(&image_id, &input_id, vec![], None, "test_order_id").await.unwrap();
         assert!(!result.id.is_empty());
-        assert!(result.stats.segments > 0 && result.stats.user_cycles > 0);
+        let stats = result.stats.expect("preflight should always return stats");
+        assert!(stats.segments > 0 && stats.user_cycles > 0);
 
         // Fetch the journal
         let journal = prover.get_preflight_journal(&result.id).await.unwrap().unwrap();
@@ -525,11 +526,8 @@ mod tests {
         let result =
             prover.prove_and_monitor_stark(&image_id.to_string(), &input_id, vec![]).await.unwrap();
         assert!(!result.id.is_empty());
-        assert!(
-            result.stats.segments > 0
-                && result.stats.total_cycles > 0
-                && result.stats.user_cycles > 0
-        );
+        let stats = result.stats.expect("DefaultProver should always return stats");
+        assert!(stats.segments > 0 && stats.total_cycles > 0 && stats.user_cycles > 0);
 
         // Fetch the journal
         let journal = prover.get_journal(&result.id).await.unwrap().unwrap();

--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -223,8 +223,8 @@ impl ProvingService {
         };
 
         tracing::info!(
-            "Customer Proof complete for proof_id: {stark_proof_id}, order_id: {order_id} cycles: {} time: {}",
-            proof_res.stats.total_cycles,
+            "Customer Proof complete for proof_id: {stark_proof_id}, order_id: {order_id} cycles: {:?} time: {}",
+            proof_res.stats.as_ref().map(|s| s.total_cycles),
             proof_res.elapsed_time,
         );
 

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -189,6 +189,7 @@ services:
     environment:
       <<: *base-environment
       CLEANUP_POLL_INTERVAL:
+      CLEANUP_STATS_TTL:
       STUCK_TASKS_POLL_INTERVAL:
       BENTO_DISABLE_COMPLETED_CLEANUP: false
       BENTO_DISABLE_STUCK_TASK_CLEANUP:

--- a/prover/crates/api/src/lib.rs
+++ b/prover/crates/api/src/lib.rs
@@ -549,46 +549,28 @@ async fn stark_status(
     Path(job_id): Path<Uuid>,
     ExtractApiKey(api_key): ExtractApiKey,
 ) -> Result<Json<SessionStatusRes>, AppError> {
-    let job_state_result = state.task_db.get_job_state(&job_id, &api_key).await;
-
-    // If job not found in taskdb, check object storage for completed receipt.
-    if let Err(err) = &job_state_result
-        && err.is_not_found()
-    {
-        let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{STARK_BUCKET_DIR}/{job_id}.bincode");
-        if state
-            .storage
-            .object_exists(&receipt_key)
-            .await
-            .context("Failed to check if receipt exists")?
-        {
-            // Receipt exists - job was completed and cleaned up from DB
-            return Ok(Json(SessionStatusRes {
-                state: Some("".into()),
-                receipt_url: Some(format!("http://{hostname}/receipts/stark/receipt/{job_id}")),
-                error_msg: None,
-                status: JobState::Done.to_string(),
-                elapsed_time: None,
-                stats: None,
-            }));
+    // Resolve job state: check taskdb first, fall back to object storage for cleaned-up jobs.
+    let job_state = match state.task_db.get_job_state(&job_id, &api_key).await {
+        Ok(s) => s,
+        Err(err) if err.is_not_found() => {
+            let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{STARK_BUCKET_DIR}/{job_id}.bincode");
+            if state.storage.object_exists(&receipt_key).await.context("Failed to check receipt")? {
+                JobState::Done
+            } else {
+                return Err(err).context("Failed to get job state")?;
+            }
         }
-    }
+        Err(err) => return Err(err).context("Failed to get job state")?,
+    };
 
-    // Job exists in DB or doesn't exist anywhere - return DB result
-    let job_state = job_state_result.context("Failed to get job state")?;
-
-    let (exec_stats, receipt_url) = if job_state == JobState::Done {
-        let exec_stats = helpers::get_exec_stats(&state.task_db, &job_id)
-            .await
-            .context("Failed to get exec stats")?;
-        (
-            Some(SessionStats {
-                cycles: exec_stats.user_cycles,
-                segments: exec_stats.segments as usize,
-                total_cycles: exec_stats.total_cycles,
-            }),
-            Some(format!("http://{hostname}/receipts/stark/receipt/{job_id}")),
-        )
+    let (stats, receipt_url) = if job_state == JobState::Done {
+        let stats =
+            helpers::get_exec_stats(&state.task_db, &job_id).await.ok().map(|s| SessionStats {
+                cycles: s.user_cycles,
+                segments: s.segments as usize,
+                total_cycles: s.total_cycles,
+            });
+        (stats, Some(format!("http://{hostname}/receipts/stark/receipt/{job_id}")))
     } else {
         (None, None)
     };
@@ -606,12 +588,12 @@ async fn stark_status(
     };
 
     Ok(Json(SessionStatusRes {
-        state: Some("".into()), // TODO
+        state: Some("".into()),
         receipt_url,
         error_msg,
         status: job_state.to_string(),
         elapsed_time: None,
-        stats: exec_stats,
+        stats,
     }))
 }
 
@@ -757,8 +739,19 @@ async fn blake3_groth16_status(
     Path(job_id): Path<Uuid>,
     Host(hostname): Host,
 ) -> Result<Json<SnarkStatusRes>, AppError> {
-    let job_state =
-        state.task_db.get_job_state(&job_id, &api_key).await.context("Failed to get job state")?;
+    let job_state = match state.task_db.get_job_state(&job_id, &api_key).await {
+        Ok(s) => s,
+        Err(err) if err.is_not_found() => {
+            let receipt_key =
+                format!("{RECEIPT_BUCKET_DIR}/{BLAKE3_GROTH16_BUCKET_DIR}/{job_id}.bincode");
+            if state.storage.object_exists(&receipt_key).await.context("Failed to check receipt")? {
+                JobState::Done
+            } else {
+                return Err(err).context("Failed to get job state")?;
+            }
+        }
+        Err(err) => return Err(err).context("Failed to get job state")?,
+    };
     let (error_msg, output) = match job_state {
         JobState::Running => (None, None),
         JobState::Done => {
@@ -785,30 +778,18 @@ async fn groth16_status(
     Path(job_id): Path<Uuid>,
     Host(hostname): Host,
 ) -> Result<Json<SnarkStatusRes>, AppError> {
-    let job_state_result = state.task_db.get_job_state(&job_id, &api_key).await;
-
-    // If job not found in taskdb, check object storage for completed receipt.
-    if let Err(err) = &job_state_result
-        && err.is_not_found()
-    {
-        let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{GROTH16_BUCKET_DIR}/{job_id}.bincode");
-        if state
-            .storage
-            .object_exists(&receipt_key)
-            .await
-            .context("Failed to check if receipt exists")?
-        {
-            // Receipt exists - job was completed and cleaned up from taskdb
-            return Ok(Json(SnarkStatusRes {
-                status: JobState::Done.to_string(),
-                error_msg: None,
-                output: Some(format!("http://{hostname}/receipts/groth16/receipt/{job_id}")),
-            }));
+    let job_state = match state.task_db.get_job_state(&job_id, &api_key).await {
+        Ok(s) => s,
+        Err(err) if err.is_not_found() => {
+            let receipt_key = format!("{RECEIPT_BUCKET_DIR}/{GROTH16_BUCKET_DIR}/{job_id}.bincode");
+            if state.storage.object_exists(&receipt_key).await.context("Failed to check receipt")? {
+                JobState::Done
+            } else {
+                return Err(err).context("Failed to get job state")?;
+            }
         }
-    }
-
-    let job_state = job_state_result.context("Failed to get job state")?;
-
+        Err(err) => return Err(err).context("Failed to get job state")?,
+    };
     let (error_msg, output) = match job_state {
         JobState::Running => (None, None),
         JobState::Done => {

--- a/prover/crates/taskdb/examples/redis_e2e.rs
+++ b/prover/crates/taskdb/examples/redis_e2e.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
     let running = db.get_concurrent_jobs(user_id).await.context("get_concurrent_jobs failed")?;
     ensure!(running == 0, "expected no running jobs, got {running}");
 
-    db.delete_job(&job_id).await.context("delete_job failed")?;
+    db.delete_job(&job_id, 3600).await.context("delete_job failed")?;
 
     println!("redis taskdb e2e passed for job: {job_id}");
 

--- a/prover/crates/taskdb/src/lib.rs
+++ b/prover/crates/taskdb/src/lib.rs
@@ -252,8 +252,8 @@ impl TaskDb {
         self.redis.get_task_state_counts().await
     }
 
-    pub async fn clear_completed_jobs(&self) -> Result<i32, TaskDbErr> {
-        self.redis.clear_completed_jobs().await
+    pub async fn clear_completed_jobs(&self, stats_ttl: u64) -> Result<i32, TaskDbErr> {
+        self.redis.clear_completed_jobs(stats_ttl).await
     }
 
     pub async fn get_job_state(&self, job_id: &Uuid, user_id: &str) -> Result<JobState, TaskDbErr> {
@@ -295,7 +295,7 @@ impl TaskDb {
         self.redis.get_task_retries_running(job_id, task_id).await
     }
 
-    pub async fn delete_job(&self, job_id: &Uuid) -> Result<(), TaskDbErr> {
-        self.redis.delete_job(job_id).await
+    pub async fn delete_job(&self, job_id: &Uuid, stats_ttl: u64) -> Result<(), TaskDbErr> {
+        self.redis.delete_job(job_id, stats_ttl).await
     }
 }

--- a/prover/crates/taskdb/src/redis_backend.rs
+++ b/prover/crates/taskdb/src/redis_backend.rs
@@ -504,6 +504,7 @@ end)
 redis.register_function('delete_job', function(keys, args)
   local p = args[1]
   local job_id = args[2]
+  local stats_ttl = tonumber(args[3]) or 3600
   local job_key = p .. ':job:' .. job_id .. ':meta'
   local user_id = redis.call('HGET', job_key, 'user_id')
   if user_id then
@@ -526,7 +527,13 @@ redis.register_function('delete_job', function(keys, args)
       redis.call('SREM', p .. ':deps:' .. job_id .. ':' .. pre, tid)
     end
     redis.call('DEL', p .. ':deps:' .. job_id .. ':' .. tid)
-    redis.call('DEL', tkey)
+    -- Keep the init task key with a TTL so exec stats remain available
+    -- after job cleanup (used by the status API fallback path).
+    if tid == 'init' then
+      redis.call('EXPIRE', tkey, stats_ttl)
+    else
+      redis.call('DEL', tkey)
+    end
   end
   redis.call('DEL', p .. ':tasks:by_job:' .. job_id)
   redis.call('DEL', job_key)
@@ -1225,7 +1232,7 @@ impl RedisTaskDb {
         .await
     }
 
-    pub async fn delete_job(&self, job_id: &Uuid) -> Result<(), TaskDbErr> {
+    pub async fn delete_job(&self, job_id: &Uuid, stats_ttl: u64) -> Result<(), TaskDbErr> {
         record("redis:delete_job", async {
             let mut conn = self.conn().await?;
             self.ensure_functions_loaded(&mut conn).await?;
@@ -1235,6 +1242,7 @@ impl RedisTaskDb {
                 .arg(0)
                 .arg(&self.namespace)
                 .arg(job_id.to_string())
+                .arg(stats_ttl)
                 .query_async(&mut conn)
                 .await?;
             Ok(())
@@ -1320,7 +1328,7 @@ impl RedisTaskDb {
         .await
     }
 
-    pub async fn clear_completed_jobs(&self) -> Result<i32, TaskDbErr> {
+    pub async fn clear_completed_jobs(&self, stats_ttl: u64) -> Result<i32, TaskDbErr> {
         record("redis:clear_completed_jobs", async {
             let mut conn = self.conn().await?;
             let pattern = self.prefixed("job:*:meta");
@@ -1357,7 +1365,7 @@ impl RedisTaskDb {
 
             drop(conn);
             for job_id in &to_delete {
-                self.delete_job(job_id).await?;
+                self.delete_job(job_id, stats_ttl).await?;
             }
 
             Ok(to_delete.len() as i32)

--- a/prover/crates/taskdb/tests/redis_backend.rs
+++ b/prover/crates/taskdb/tests/redis_backend.rs
@@ -709,9 +709,8 @@ async fn delete_job_with_zero_ttl_removes_init_task() -> Result<(), TaskDbErr> {
     };
 
     let stream_id = db.create_stream("CPU", 1, 1.0, "user-zero").await?;
-    let job_id = db
-        .create_job(&stream_id, &serde_json::json!({"init": "zero"}), 0, 30, "user-zero")
-        .await?;
+    let job_id =
+        db.create_job(&stream_id, &serde_json::json!({"init": "zero"}), 0, 30, "user-zero").await?;
 
     let init = db.request_work("CPU").await?.expect("expected init task");
     assert_eq!(init.task_id, INIT_TASK);

--- a/prover/crates/taskdb/tests/redis_backend.rs
+++ b/prover/crates/taskdb/tests/redis_backend.rs
@@ -309,7 +309,7 @@ async fn task_state_counts_drop_to_zero_after_delete_job() -> Result<(), TaskDbE
     assert_eq!(count_for(&counts, "CPU", Priority::Medium, "running"), 1);
     assert_eq!(count_for(&counts, "CPU", Priority::Medium, "pending"), 1);
 
-    db.delete_job(&job_id).await?;
+    db.delete_job(&job_id, 3600).await?;
 
     let counts = db.get_task_state_counts().await?;
     assert_eq!(count_for(&counts, "CPU", Priority::Medium, "ready"), 0);
@@ -657,6 +657,149 @@ async fn request_work_blocking_ignores_stale_notifications() -> Result<(), TaskD
     assert_eq!(task.job_id, second_job);
     assert_eq!(task.task_id, INIT_TASK);
     assert!(started.elapsed() >= tokio::time::Duration::from_millis(75));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_job_preserves_init_task_output() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-stats").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "stats"}), 0, 30, "user-stats")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    assert_eq!(init.task_id, INIT_TASK);
+
+    let stats = serde_json::json!({
+        "segments": 42,
+        "user_cycles": 1000,
+        "total_cycles": 2000,
+        "assumption_count": 0
+    });
+    db.update_task_done(&job_id, INIT_TASK, stats.clone()).await?;
+
+    // Job is done and queryable before deletion.
+    assert_eq!(db.get_job_state(&job_id, "user-stats").await?, JobState::Done);
+    let output: serde_json::Value = db.get_task_output(&job_id, INIT_TASK).await?;
+    assert_eq!(output["total_cycles"], 2000);
+
+    // Delete with a TTL — init task output should survive.
+    db.delete_job(&job_id, 3600).await?;
+
+    // Job metadata is gone.
+    assert!(db.get_job_state(&job_id, "user-stats").await.is_err());
+
+    // Init task output is still readable.
+    let output: serde_json::Value = db.get_task_output(&job_id, INIT_TASK).await?;
+    assert_eq!(output["total_cycles"], 2000);
+    assert_eq!(output["segments"], 42);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_job_with_zero_ttl_removes_init_task() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-zero").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "zero"}), 0, 30, "user-zero")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    assert_eq!(init.task_id, INIT_TASK);
+    db.update_task_done(&job_id, INIT_TASK, serde_json::json!({"total_cycles": 100})).await?;
+
+    // TTL of 0 means Redis expires the key immediately.
+    db.delete_job(&job_id, 0).await?;
+
+    // Allow Redis to process the expiry.
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Init task output should be gone.
+    assert!(db.get_task_output::<serde_json::Value>(&job_id, INIT_TASK).await.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_job_removes_non_init_tasks() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-other").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "other"}), 0, 30, "user-other")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    assert_eq!(init.task_id, INIT_TASK);
+    db.update_task_done(&job_id, INIT_TASK, serde_json::json!({"total_cycles": 100})).await?;
+
+    // Create and complete a child task.
+    db.create_task(
+        &job_id,
+        "prove_0",
+        &stream_id,
+        &serde_json::json!({"task": "prove"}),
+        &serde_json::json!([]),
+        0,
+        30,
+    )
+    .await?;
+    let child = db.request_work("CPU").await?.expect("expected child task");
+    assert_eq!(child.task_id, "prove_0");
+    db.update_task_done(&job_id, "prove_0", serde_json::json!({"ok": true})).await?;
+
+    db.delete_job(&job_id, 3600).await?;
+
+    // Non-init task output is gone.
+    assert!(db.get_task_output::<serde_json::Value>(&job_id, "prove_0").await.is_err());
+
+    // Init task output is preserved.
+    let output: serde_json::Value = db.get_task_output(&job_id, INIT_TASK).await?;
+    assert_eq!(output["total_cycles"], 100);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_completed_jobs_preserves_init_task_output() -> Result<(), TaskDbErr> {
+    let Some(db) = test_db().await else {
+        return Ok(());
+    };
+
+    let stream_id = db.create_stream("CPU", 1, 1.0, "user-clear").await?;
+    let job_id = db
+        .create_job(&stream_id, &serde_json::json!({"init": "clear"}), 0, 30, "user-clear")
+        .await?;
+
+    let init = db.request_work("CPU").await?.expect("expected init task");
+    assert_eq!(init.task_id, INIT_TASK);
+
+    let stats = serde_json::json!({"segments": 10, "user_cycles": 500, "total_cycles": 1000, "assumption_count": 0});
+    db.update_task_done(&job_id, INIT_TASK, stats).await?;
+
+    // Mark the job as done so clear_completed_jobs picks it up.
+    assert_eq!(db.get_job_state(&job_id, "user-clear").await?, JobState::Done);
+
+    let cleared = db.clear_completed_jobs(3600).await?;
+    assert_eq!(cleared, 1);
+
+    // Job metadata is gone.
+    assert!(db.get_job_state(&job_id, "user-clear").await.is_err());
+
+    // Init task output survives.
+    let output: serde_json::Value = db.get_task_output(&job_id, INIT_TASK).await?;
+    assert_eq!(output["total_cycles"], 1000);
 
     Ok(())
 }

--- a/prover/crates/workflow/src/lib.rs
+++ b/prover/crates/workflow/src/lib.rs
@@ -166,6 +166,14 @@ pub struct Args {
     #[clap(env, long, default_value_t = 5 * 60)]
     cleanup_poll_interval: u64,
 
+    /// TTL in seconds for exec stats after job cleanup.
+    ///
+    /// When a completed job is cleaned up, the init task output (exec stats)
+    /// is retained in Redis with this TTL so the status API can still return
+    /// cycle counts. Defaults to 1 hour.
+    #[clap(env, long, default_value_t = 3600)]
+    pub cleanup_stats_ttl: u64,
+
     /// Disable cron to clean up completed jobs in taskdb.
     #[clap(long, default_value_t = false, env = "BENTO_DISABLE_COMPLETED_CLEANUP")]
     disable_completed_cleanup: bool,
@@ -577,12 +585,14 @@ impl Agent {
                     .cloned()
                     .context("[BENTO-WF-106] AUX cleanup requires direct taskdb access")?;
                 let cleanup_interval = self.args.cleanup_poll_interval;
+                let cleanup_stats_ttl = self.args.cleanup_stats_ttl;
                 tokio::spawn(async move {
                     loop {
                         if let Err(e) = Self::poll_for_completed_job_cleanup(
                             term_sig_copy.clone(),
                             task_db_copy.clone(),
                             cleanup_interval,
+                            cleanup_stats_ttl,
                         )
                         .await
                         {
@@ -835,6 +845,7 @@ impl Agent {
         term_sig: Arc<AtomicBool>,
         task_db: TaskDb,
         poll_interval: u64,
+        stats_ttl: u64,
     ) -> Result<()> {
         while !term_sig.load(Ordering::Relaxed) {
             // Sleep before each check to avoid running on startup
@@ -842,7 +853,7 @@ impl Agent {
 
             tracing::debug!("Cleaning up completed jobs...");
 
-            let cleared_count = task_db.clear_completed_jobs().await?;
+            let cleared_count = task_db.clear_completed_jobs(stats_ttl).await?;
             if cleared_count > 0 {
                 tracing::info!("Cleared {} completed jobs", cleared_count);
                 workflow_common::metrics::helpers::record_completed_jobs_garbage_collection_metrics(


### PR DESCRIPTION
The receipt without stats fallback in case of cleanup isn't handled by the broker well, as it errors if no stats even if just used for the prove path.

Second part of this PR changes the cleanup to instead add a configurable TTL on the exec stats instead of deleting immediately. Aside from tests added, I have manually tested stats are present on a freshly succeeded job, stats survive cleanup via the TTL-preserved init key, stats values remain unchanged after cleanup, and stats are correctly absent after the TTL expires, and also that multiple cleanups before TTL does not cause issues.