### PR TITLE
BM-2883: allow debug docker compose builds, cache prover2 build dir

### DIFF
--- a/dockerfiles/broker.dockerfile
+++ b/dockerfiles/broker.dockerfile
@@ -37,12 +37,15 @@ ARG S3_CACHE_PREFIX="public/boundless/rust-cache-docker-Linux-X64/sccache"
 ARG S3_CACHE_BUCKET="boundless-sccache"
 ENV SCCACHE_BUCKET=${S3_CACHE_BUCKET}
 
+ARG RELEASE=true
 RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/root/.cache/sccache/,id=broker_sc \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
     --mount=type=cache,target=/src/target,id=broker_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
-    cargo chef cook --release --recipe-path recipe.json --package broker && \
+    RELEASE_FLAG="" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; fi && \
+    cargo chef cook ${RELEASE_FLAG} --recipe-path recipe.json --package broker && \
     sccache --show-stats
 
 COPY Cargo.toml .
@@ -60,8 +63,10 @@ RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
     --mount=type=cache,target=/src/target,id=broker_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
-    cargo build --release --bin broker && \
-    cp /src/target/release/broker /src/broker && \
+    RELEASE_FLAG="" && PROFILE_DIR="debug" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; PROFILE_DIR="release"; fi && \
+    cargo build ${RELEASE_FLAG} --bin broker && \
+    cp /src/target/${PROFILE_DIR}/broker /src/broker && \
     sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime

--- a/dockerfiles/prover/agent.cpu.dockerfile
+++ b/dockerfiles/prover/agent.cpu.dockerfile
@@ -43,14 +43,19 @@ ARG RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 ENV RUSTFLAGS=${RUSTFLAGS}
 
 # Build WITHOUT cuda feature
+ARG RELEASE=true
 RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/root/.cache/sccache/,id=bento_agent_cpu_sc \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=/src/prover/target-agent-cpu,id=prover_agent_cpu_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
     (ulimit -n 65536 2>/dev/null || true) && \
+    RELEASE_FLAG="" && PROFILE_DIR="debug" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; PROFILE_DIR="release"; fi && \
     export CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-8} && \
     export CARGO_TARGET_DIR=/src/prover/target-agent-cpu && \
-    cargo build --manifest-path prover/Cargo.toml --release -p workflow --bin agent && \
-    cp ${CARGO_TARGET_DIR}/release/agent /src/agent && \
+    cargo build --manifest-path prover/Cargo.toml ${RELEASE_FLAG} -p workflow --bin agent && \
+    cp ${CARGO_TARGET_DIR}/${PROFILE_DIR}/agent /src/agent && \
     sccache --show-stats
 
 FROM ${RUNTIME_IMG} AS runtime

--- a/dockerfiles/prover/agent.dockerfile
+++ b/dockerfiles/prover/agent.dockerfile
@@ -62,14 +62,19 @@ SHELL ["/bin/bash", "-c"]
 ARG RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 ENV RUSTFLAGS=${RUSTFLAGS}
 
+ARG RELEASE=true
 RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/root/.cache/sccache/,id=bento_agent_sc \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=/src/prover/target-agent-gpu,id=prover_agent_gpu_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
     (ulimit -n 65536 2>/dev/null || true) && \
+    RELEASE_FLAG="" && PROFILE_DIR="debug" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; PROFILE_DIR="release"; fi && \
     export CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-8} && \
     export CARGO_TARGET_DIR=/src/prover/target-agent-gpu && \
-    cargo build --manifest-path prover/Cargo.toml --release -p workflow -F cuda --bin agent && \
-    cp ${CARGO_TARGET_DIR}/release/agent /src/agent && \
+    cargo build --manifest-path prover/Cargo.toml ${RELEASE_FLAG} -p workflow -F cuda --bin agent && \
+    cp ${CARGO_TARGET_DIR}/${PROFILE_DIR}/agent /src/agent && \
     sccache --show-stats
 
 FROM ${CUDA_RUNTIME_IMG} AS runtime

--- a/dockerfiles/prover/prover_cli.dockerfile
+++ b/dockerfiles/prover/prover_cli.dockerfile
@@ -42,13 +42,18 @@ SHELL ["/bin/bash", "-c"]
 ARG RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 ENV RUSTFLAGS=${RUSTFLAGS}
 
+ARG RELEASE=true
 RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/root/.cache/sccache/,id=prover_cli_sc \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=/src/prover/target,id=prover_cli_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
     (ulimit -n 65536 2>/dev/null || true) && \
+    RELEASE_FLAG="" && PROFILE_DIR="debug" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; PROFILE_DIR="release"; fi && \
     export CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-8} && \
-    cargo build --manifest-path prover/Cargo.toml --release -p bento-client --bin bento_cli && \
-    cp prover/target/release/bento_cli /src/bento_cli && \
+    cargo build --manifest-path prover/Cargo.toml ${RELEASE_FLAG} -p bento-client --bin bento_cli && \
+    cp prover/target/${PROFILE_DIR}/bento_cli /src/bento_cli && \
     sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime

--- a/dockerfiles/prover/rest_api.dockerfile
+++ b/dockerfiles/prover/rest_api.dockerfile
@@ -18,13 +18,18 @@ SHELL ["/bin/bash", "-c"]
 # Prevent sccache collision in compose-builds
 ENV SCCACHE_SERVER_PORT=4230
 
+ARG RELEASE=true
 RUN --mount=type=secret,id=ci_cache_creds,target=/root/.aws/credentials \
     --mount=type=cache,target=/root/.cache/sccache/,id=prover_api_sccache \
+    --mount=type=cache,target=/usr/local/cargo/registry,id=cargo_registry \
+    --mount=type=cache,target=/src/prover/target,id=prover_api_target \
     source dockerfiles/sccache-config.sh ${S3_CACHE_PREFIX} && \
     (ulimit -n 65536 2>/dev/null || true) && \
+    RELEASE_FLAG="" && PROFILE_DIR="debug" && \
+    if [ "${RELEASE}" = "true" ]; then RELEASE_FLAG="--release"; PROFILE_DIR="release"; fi && \
     export CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-8} && \
-    cargo build --manifest-path prover/Cargo.toml --release -p api --bin rest_api && \
-    cp prover/target/release/rest_api /src/rest_api && \
+    cargo build --manifest-path prover/Cargo.toml ${RELEASE_FLAG} -p api --bin rest_api && \
+    cp prover/target/${PROFILE_DIR}/rest_api /src/rest_api && \
     sccache --show-stats
 
 FROM debian:bookworm-slim AS runtime

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -25,6 +25,7 @@ x-agent-common: &agent-common
     args:
       BLAKE3_GROTH16_ARTIFACTS_URL: ${BLAKE3_GROTH16_ARTIFACTS_URL:-https://staging-signal-artifacts.beboundless.xyz/v3/proving/blake3_groth16_artifacts.tar.xz}
       USE_LOCAL_BLAKE3_GROTH16_SETUP: ${USE_LOCAL_BLAKE3_GROTH16_SETUP:-0}
+      RELEASE: ${BOUNDLESS_RELEASE:-true}
   restart: always
   depends_on:
     redis:
@@ -100,6 +101,8 @@ x-broker-common: &broker-common
   build:
     context: .
     dockerfile: ${BROKER_DOCKERFILE:-dockerfiles/broker.dockerfile}
+    args:
+      RELEASE: ${BOUNDLESS_RELEASE:-true}
   mem_limit: 2G
   cpus: 2
   stop_grace_period: 3h
@@ -171,6 +174,8 @@ services:
     build:
       context: .
       dockerfile: ${PROVER_CPU_AGENT_DOCKERFILE:-dockerfiles/prover/agent.cpu.dockerfile}
+      args:
+        RELEASE: ${BOUNDLESS_RELEASE:-true}
     runtime: runc
     deploy:
       replicas: ${BENTO_EXECUTOR_COUNT:-4}
@@ -181,6 +186,8 @@ services:
     build:
       context: .
       dockerfile: ${PROVER_CPU_AGENT_DOCKERFILE:-dockerfiles/prover/agent.cpu.dockerfile}
+      args:
+        RELEASE: ${BOUNDLESS_RELEASE:-true}
     runtime: runc
     mem_limit: 256M
     deploy:
@@ -218,6 +225,8 @@ services:
     build:
       context: .
       dockerfile: ${PROVER_REST_API_DOCKERFILE:-dockerfiles/prover/rest_api.dockerfile}
+      args:
+        RELEASE: ${BOUNDLESS_RELEASE:-true}
     restart: always
 
     mem_limit: 4G
@@ -291,6 +300,7 @@ services:
         BLAKE3_GROTH16_ARTIFACTS_URL: ${BLAKE3_GROTH16_ARTIFACTS_URL:-https://staging-signal-artifacts.beboundless.xyz/v3/proving/blake3_groth16_artifacts.tar.xz}
         # If set to 1, yes, or true, the agent will expect local mounting of BLAKE3 Groth16 setup files instead of downloading
         USE_LOCAL_BLAKE3_GROTH16_SETUP: ${USE_LOCAL_BLAKE3_GROTH16_SETUP:-0}
+        RELEASE: ${BOUNDLESS_RELEASE:-true}
     restart: always
     depends_on:
       rest_api:


### PR DESCRIPTION
Allows avoiding release builds with an env var `BOUNDLESS_RELEASE=false`

Also adds mounted cache directory for registry and target dir, like bento has (unclear why those weren't included in new prover, seems fine with)