### PR TITLE
BM-2885: Lower nightly prover min mcycle price

### DIFF
--- a/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.8453.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.8453.toml
@@ -1,4 +1,3 @@
 # Nightly Base Mainnet (8453) chain override
 [market]
-min_mcycle_price = "0.000000025"
 max_collateral = "200"

--- a/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
@@ -1,7 +1,7 @@
 # Nightly base broker config (shared across all chains)
 # Per-chain fields (min_mcycle_price, max_collateral) are in broker.{chain_id}.toml
 [market]
-min_mcycle_price = "0.000000025"
+min_mcycle_price = "0.000000018"
 max_collateral = "200"
 lookback_blocks = 300
 peak_prove_khz = 8000

--- a/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-nightly/broker.toml
@@ -1,7 +1,7 @@
 # Nightly base broker config (shared across all chains)
 # Per-chain fields (min_mcycle_price, max_collateral) are in broker.{chain_id}.toml
 [market]
-min_mcycle_price = "0.000000018"
+min_mcycle_price = "0.000000018 ETH"
 max_collateral = "200"
 lookback_blocks = 300
 peak_prove_khz = 8000


### PR DESCRIPTION
Drops the nightly prover min mcycle price from 0.000000025 to 0.000000018 and removes the redundant pricing override from the Base Mainnet (8453) chain config so it inherits from the base config.

Changes
* Set `min_mcycle_price` to `0.000000018` in the nightly base broker config
* Removed `min_mcycle_price` from `broker.8453.toml` — Base now inherits from the shared config