### PR TITLE
BM-2887: Adjust alerts to better ignore transient rpc failures

### DIFF
--- a/infra/cw-monitoring/proverAlarms.ts
+++ b/infra/cw-monitoring/proverAlarms.ts
@@ -218,9 +218,9 @@ export function buildProverLogPatterns(
             metricName: "chain-monitor-rpc-error",
             alarm: {
                 severity: Severity.SEV2,
-                description: ">=5 chain monitor RPC errors in 1 hour",
-                metricConfig: { period: 3600 },
-                alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 5 },
+                description: ">=1 chain monitor RPC error in 2 of 3 15-min periods",
+                metricConfig: { period: 900 },
+                alarmConfig: { evaluationPeriods: 3, datapointsToAlarm: 2, threshold: 1 },
             },
         },
         {

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -215,10 +215,10 @@ export const alarmConfig: ChainStageAlarms = {
           }
         }],
         submittedRequests: [{
-          description: "less than 2 submitted orders in 30 minutes",
+          description: "less than 2 submitted orders in 1 hour",
           severity: Severity.SEV2,
           metricConfig: {
-            period: 1800
+            period: 3600
           },
           alarmConfig: {
             threshold: 2,


### PR DESCRIPTION
Transient RPC outage triggerred a bunch of non-actionable alerts. Adjusts alarms to handle this.

## Summary
- change chain monitor RPC error alarms to require errors in 2 of 3 15-minute periods across prover monitoring
- extend the Base Sepolia staging submitted-orders alarm window from 30 minutes to 1 hour

## Testing
- npm run build (infra/cw-monitoring)
- npx tsc --noEmit (infra/indexer)