### PR TITLE
BM-2889: OG: raise Taiko max price cap, reduce frequency on Taiko + Base

### DIFF
--- a/infra/order-generator/Pulumi.l-prod-167000.yaml
+++ b/infra/order-generator/Pulumi.l-prod-167000.yaml
@@ -11,7 +11,7 @@ config:
     secure: v1:v0CqkVuF6OQo6w3I:Ie40GUu+YUdbHL/SdIJeEIjvJs0wY+kkVX379/uaqcbTLHFpaTVeTdR0wglkUt2D3k2mXZ/1yXjV9DzpJxhjDZ8ezWiL3iZKnUu4xgllKllOC+t6znOMyWSjH1djCDAw5sAUKgrRhC/k9OfeDg==
   order-generator-base:INDEXER_URL:
     secure: v1:TU3/Yju/3FP9d/fY:ccwXwEIySoHl0Gnzf4g49Cvd2aSylHhvxwFjk1eytjBJo2KueszIhrAUJM+jOUXqwl2wIjk=
-  order-generator-base:INTERVAL: "900"
+  order-generator-base:INTERVAL: "1800"
   order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "15000000000000000000"
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -47,10 +47,10 @@ config:
   order-generator-offchain:EXEC_RATE_KHZ: "1000"
   order-generator-offchain:INPUT_MAX_MCYCLES: "2000"
   order-generator-offchain:INPUT_MIN_MCYCLES: "1000"
-  order-generator-offchain:INTERVAL: "900"
+  order-generator-offchain:INTERVAL: "1800"
   order-generator-offchain:LOCK_TIMEOUT: "1500"
   order-generator-offchain:MAX_OUTSTANDING_REQUESTS: "15"
-  order-generator-offchain:MAX_PRICE_CAP: "0.000075"
+  order-generator-offchain:MAX_PRICE_CAP: "0.0001"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:C85e3ABgTk030Eup:+LMVZDHLUea4fPhn42jIsQnGIFhZpTnwlv6eyOVik+NqgCUPY78wVTlNaIBQazwDgK0MigKQ+UAoj6klFCygto5+0gM3RFmzMQUuW10ATmc=
   order-generator-offchain:RAMP_UP: "600"
@@ -63,10 +63,10 @@ config:
   order-generator-onchain:EXEC_RATE_KHZ: "1000"
   order-generator-onchain:INPUT_MAX_MCYCLES: "4000"
   order-generator-onchain:INPUT_MIN_MCYCLES: "1000"
-  order-generator-onchain:INTERVAL: "900"
+  order-generator-onchain:INTERVAL: "1800"
   order-generator-onchain:LOCK_TIMEOUT: "2100"
   order-generator-onchain:MAX_OUTSTANDING_REQUESTS: "15"
-  order-generator-onchain:MAX_PRICE_CAP: "0.000075"
+  order-generator-onchain:MAX_PRICE_CAP: "0.0001"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:Wfonliegz8oHLnNJ:VSCTMdfxEzzufPw4NWLsQOfRSE5VDR6MQ+9Byo39aOP9B6r7zVazzNyTWbhttjyD6y0vbF12vsl+4iX8w8HTOewJftwOCoSPsrct3+YLE5w=
   order-generator-onchain:RAMP_UP: "900"

--- a/infra/order-generator/Pulumi.l-prod-8453.yaml
+++ b/infra/order-generator/Pulumi.l-prod-8453.yaml
@@ -17,7 +17,7 @@ config:
   order-generator-base:DOCKER_TAG: latest
   order-generator-base:GH_TOKEN_SECRET:
     secure: v1:pfTxhEjN74NTG5Zk:uqeqk81UF6asWxgfbxYTzL+yhrMfY32xWCvGx+rauPVc/z1jbMHGcHMKVIWhdKuNQx3sgIL7p9C3XrFXxb9IjSv01f02I3aRsPV+OQgUQy5+AsNT9CKGUz2p3vLre+pueTXjNpDcWXzvV3YIdg==
-  order-generator-base:INTERVAL: "32"
+  order-generator-base:INTERVAL: "64"
   order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "15000000000000000000" # 15 ZKC
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -38,7 +38,7 @@ config:
   order-generator-offchain:INPUT_MAX_MCYCLES: "2000"
   order-generator-offchain:LOCK_TIMEOUT: "1500"
   order-generator-offchain:RAMP_UP: "600"
-  order-generator-offchain:INTERVAL: "90"
+  order-generator-offchain:INTERVAL: "180"
   order-generator-offchain:RAMP_UP_SECONDS_PER_MCYCLE: "2"
   order-generator-offchain:SECONDS_PER_MCYCLE: "7"
   order-generator-offchain:TIMEOUT: "1500"
@@ -48,7 +48,7 @@ config:
   order-generator-onchain:AUTO_DEPOSIT: "0.015"
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "1000"
-  order-generator-onchain:INTERVAL: "110"
+  order-generator-onchain:INTERVAL: "220"
   order-generator-onchain:INPUT_MIN_MCYCLES: "1000"
   order-generator-onchain:INPUT_MAX_MCYCLES: "4000"
   order-generator-onchain:LOCK_TIMEOUT: "2100"


### PR DESCRIPTION
## Summary
- **Taiko prod**: Raise `MAX_PRICE_CAP` from 0.000075 to 0.0001 ETH for offchain and onchain OGs (gas costs are ~0.000081 ETH, orders were being skipped with [S-OP-006])
- **Taiko prod**: Increase `INTERVAL` from 900s to 1800s (30m) for all OGs
- **Base mainnet**: Reduce OG frequency by 50% (base 32->64s, offchain 90->180s, onchain 110->220s)

## Context
On Taiko, gas costs for lock+fulfill are ~0.000081 ETH, but the OGs were capping maxPrice at 0.000075 ETH. The broker correctly skipped these with `[S-OP-006]` (gas cost exceeds max price). The new cap of 0.0001 ETH matches Base mainnet and provides ~23% headroom.

## Test plan
- [ ] Verify Taiko OG deployment picks up new MAX_PRICE_CAP and INTERVAL
- [ ] Monitor telemetry for reduced `[S-OP-006]` skips on Taiko from r0-og-offchain/onchain
- [ ] Verify Base mainnet OG order rate drops by ~50%