### PR TITLE
BM-2904: Increase price oracle refresh interval default to 15 minutes

### DIFF
--- a/crates/boundless-market/src/price_oracle/config.rs
+++ b/crates/boundless-market/src/price_oracle/config.rs
@@ -107,7 +107,7 @@ impl Default for PriceOracleConfig {
             eth_usd: PriceValue::Auto,
             zkc_usd: PriceValue::Auto,
             max_secs_without_price_update: 43200, // 12h
-            refresh_interval_secs: 120,
+            refresh_interval_secs: 900,
             timeout_secs: 10,
             aggregation_mode: AggregationMode::Median,
             min_sources: 1,


### PR DESCRIPTION
Raises the default `PriceOracleConfig::refresh_interval_secs` from 120s to 900s to reduce CoinGecko free-tier rate-limiting. With multiple chain workers each running their own oracle manager, a 2-minute cadence was hitting HTTP 429s and causing ZKC/USD (which has no Chainlink fallback) to fail with `[B-PO-002] Insufficient sources` and trip the price oracle alarm.

Changes
* `refresh_interval_secs` default now 900s (15m) in `crates/boundless-market/src/price_oracle/config.rs`