### PR TITLE
BM-2909: Deploy ansible pipelines from main, drop next trigger

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,5 @@
+version = 1
+name = "boundless"
+
+[setup]
+script = "bash .codex/setup-worktree-unix.sh"

--- a/.codex/setup-worktree-unix.sh
+++ b/.codex/setup-worktree-unix.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# Copy ignored files from the source tree to the new worktree while skipping
+# build artifacts that should be rebuilt in the worktree.
+
+if [ -z "${CODEX_SOURCE_TREE_PATH:-}" ]; then
+  echo "Error: CODEX_SOURCE_TREE_PATH environment variable is not set"
+  exit 1
+fi
+
+if [ -z "${CODEX_WORKTREE_PATH:-}" ]; then
+  echo "Error: CODEX_WORKTREE_PATH environment variable is not set"
+  exit 1
+fi
+
+SOURCE_TREE_PATH="${CODEX_SOURCE_TREE_PATH%/}"
+WORKTREE_PATH="${CODEX_WORKTREE_PATH%/}"
+
+EXCLUDE_PATTERN="(target/|node_modules/|/out/|^out/|/cache/|^cache/|/build/|/bin/|build-info|\\.DS_Store|cache_market|^documentation/|crates/guest/povw/)"
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  source_path="$SOURCE_TREE_PATH/$file"
+  worktree_path="$WORKTREE_PATH/$file"
+
+  if [ -e "$source_path" ]; then
+    mkdir -p "$(dirname "$worktree_path")" 2>/dev/null || true
+    cp -R "$source_path" "$worktree_path" 2>/dev/null || true
+  fi
+done < <(
+  cd "$SOURCE_TREE_PATH"
+  git ls-files --ignored --exclude-standard -o --directory | grep -Ev "$EXCLUDE_PATTERN" || true
+)
+
+echo "Worktree setup complete. Run 'cargo build' and 'forge build' to rebuild artifacts."

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ target/
 .aider*
 **/CLAUDE.md
 **/AGENTS.md
-.codex
 scripts/internal
 
 infra/**/build

--- a/infra/pipelines/components/notifications.ts
+++ b/infra/pipelines/components/notifications.ts
@@ -187,6 +187,20 @@ export class Notifications extends pulumi.ComponentResource {
           resources: [arn],
           sid: "Grant publish to codestar for deployment notifications",
         },
+        {
+          actions: ["SNS:Publish"],
+          principals: [{
+            type: "Service",
+            identifiers: ["events.amazonaws.com"],
+          }],
+          resources: [arn],
+          conditions: [{
+            test: "ArnLike",
+            variable: "aws:SourceArn",
+            values: [`arn:aws:events:us-west-2:${args.opsAccountId}:rule/*`],
+          }],
+          sid: "Grant publish to EventBridge for deployment notifications",
+        },
       ],
     }));
 

--- a/infra/pipelines/pipelines/base/LaunchDefaultPipeline.ts
+++ b/infra/pipelines/pipelines/base/LaunchDefaultPipeline.ts
@@ -4,6 +4,7 @@ import { BOUNDLESS_OPS_ACCOUNT_ID, BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, BOUNDLESS
 import { ASSUME_ROLE_CHAINED_MAX_SESSION_SECONDS } from "../../../util";
 import { BasePipelineArgs } from "./BasePipelineArgs";
 import { LaunchBasePipeline, LaunchPipelineConfig } from "./LaunchBasePipeline";
+import { createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./pipelineNotifications";
 
 export class LaunchDefaultPipeline extends LaunchBasePipeline<LaunchPipelineConfig> {
     constructor(
@@ -205,24 +206,30 @@ export class LaunchDefaultPipeline extends LaunchBasePipeline<LaunchPipelineConf
         });
 
         // Create notification rule
-        new aws.codestarnotifications.NotificationRule(`l-${this.config.appName}-pipeline-notifications`, {
-            name: `l-${this.config.appName}-pipeline-notifications`,
-            eventTypeIds: [
+        createLaunchPipelineNotificationRule(
+            `l-${this.config.appName}-pipeline-status-notifications`,
+            pipeline.arn,
+            [
                 "codepipeline-pipeline-manual-approval-succeeded",
-                "codepipeline-pipeline-action-execution-failed",
             ],
-            resource: pipeline.arn,
-            detailType: "FULL",
-            targets: [
-                {
-                    address: slackAlertsTopicArn.apply(arn => arn),
-                },
-            ],
-            tags: {
-                Name: `l-${this.config.appName}-pipeline-notifications`,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-pipeline-status-notifications`,
                 Component: `l-${this.config.appName}`,
             },
-        });
+            { parent: this }
+        );
+
+        createProdStageFailureAlert(
+            `l-${this.config.appName}-prod-stage-failure`,
+            pipeline.arn,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-prod-stage-failure`,
+                Component: `l-${this.config.appName}`,
+            },
+            { parent: this }
+        );
     }
 
     protected getBuildSpec(): string {

--- a/infra/pipelines/pipelines/base/index.ts
+++ b/infra/pipelines/pipelines/base/index.ts
@@ -1,3 +1,4 @@
 export { BasePipelineArgs } from "./BasePipelineArgs";
 export { LaunchBasePipeline, LaunchPipelineConfig, LAUNCH_PIPELINE_DEFAULTS, SecretsResult } from "./LaunchBasePipeline";
 export { LaunchDefaultPipeline } from "./LaunchDefaultPipeline";
+export { createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./pipelineNotifications";

--- a/infra/pipelines/pipelines/base/pipelineNotifications.ts
+++ b/infra/pipelines/pipelines/base/pipelineNotifications.ts
@@ -1,0 +1,74 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const PRODUCTION_STAGE_NAME = "DeployProduction";
+
+export function createLaunchPipelineNotificationRule(
+  name: string,
+  pipelineArn: pulumi.Input<string>,
+  eventTypeIds: string[],
+  slackAlertsTopicArn: pulumi.Input<string>,
+  tags: Record<string, pulumi.Input<string>>,
+  opts?: pulumi.CustomResourceOptions
+): aws.codestarnotifications.NotificationRule {
+  return new aws.codestarnotifications.NotificationRule(
+    name,
+    {
+      name,
+      eventTypeIds,
+      resource: pipelineArn,
+      detailType: "FULL",
+      targets: [
+        {
+          address: slackAlertsTopicArn,
+        },
+      ],
+      tags,
+    },
+    opts
+  );
+}
+
+export function createProdStageFailureAlert(
+  name: string,
+  pipelineArn: pulumi.Input<string>,
+  slackAlertsTopicArn: pulumi.Input<string>,
+  tags: Record<string, pulumi.Input<string>>,
+  opts?: pulumi.ComponentResourceOptions
+): {
+  rule: aws.cloudwatch.EventRule;
+  target: aws.cloudwatch.EventTarget;
+} {
+  const eventPattern = pulumi.output(pipelineArn).apply((arn) =>
+    JSON.stringify({
+      source: ["aws.codepipeline"],
+      "detail-type": ["CodePipeline Stage Execution State Change"],
+      resources: [arn],
+      detail: {
+        state: ["FAILED"],
+        stage: [PRODUCTION_STAGE_NAME],
+      },
+    })
+  );
+
+  const rule = new aws.cloudwatch.EventRule(
+    name,
+    {
+      name,
+      eventPattern,
+      tags,
+    },
+    opts
+  );
+
+  const target = new aws.cloudwatch.EventTarget(
+    `${name}-target`,
+    {
+      rule: rule.name,
+      arn: slackAlertsTopicArn,
+    },
+    opts
+  );
+
+  return { rule, target };
+}

--- a/infra/pipelines/pipelines/l-base.ts
+++ b/infra/pipelines/pipelines/l-base.ts
@@ -1,2 +1,3 @@
 // Re-export from base folder
 export { BasePipelineArgs, LaunchBasePipeline, LaunchDefaultPipeline, LaunchPipelineConfig, LAUNCH_PIPELINE_DEFAULTS, SecretsResult } from "./base/index";
+export { createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./base/index";

--- a/infra/pipelines/pipelines/l-indexer.ts
+++ b/infra/pipelines/pipelines/l-indexer.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN } from "../accountConstants";
-import { LaunchDefaultPipeline, LaunchPipelineConfig, BasePipelineArgs } from "./l-base";
+import { LaunchDefaultPipeline, LaunchPipelineConfig, BasePipelineArgs, createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./l-base";
 
 interface LIndexerPipelineArgs extends BasePipelineArgs {
 }
@@ -251,23 +251,29 @@ export class LIndexerPipeline extends LaunchDefaultPipeline {
         });
 
         // Create notification rule
-        new aws.codestarnotifications.NotificationRule(`l-${this.config.appName}-pipeline-notifications`, {
-            name: `l-${this.config.appName}-pipeline-notifications`,
-            eventTypeIds: [
+        createLaunchPipelineNotificationRule(
+            `l-${this.config.appName}-pipeline-status-notifications`,
+            pipeline.arn,
+            [
                 "codepipeline-pipeline-manual-approval-succeeded",
-                "codepipeline-pipeline-action-execution-failed",
             ],
-            resource: pipeline.arn,
-            detailType: "FULL",
-            targets: [
-                {
-                    address: slackAlertsTopicArn.apply((arn: string) => arn),
-                },
-            ],
-            tags: {
-                Name: `l-${this.config.appName}-pipeline-notifications`,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-pipeline-status-notifications`,
                 Component: `l-${this.config.appName}`,
             },
-        });
+            { parent: this }
+        );
+
+        createProdStageFailureAlert(
+            `l-${this.config.appName}-prod-stage-failure`,
+            pipeline.arn,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-prod-stage-failure`,
+                Component: `l-${this.config.appName}`,
+            },
+            { parent: this }
+        );
     }
 }

--- a/infra/pipelines/pipelines/l-prover-ansible.ts
+++ b/infra/pipelines/pipelines/l-prover-ansible.ts
@@ -1,6 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import { BasePipelineArgs } from "./base";
+import { BasePipelineArgs, createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./base";
 import {
   BOUNDLESS_OPS_ACCOUNT_ID,
   BOUNDLESS_STAGING_ACCOUNT_ID,
@@ -466,27 +466,28 @@ artifacts:
       { parent: this }
     );
 
-    new aws.codestarnotifications.NotificationRule(
-      `l-${APP_NAME}-pipeline-notifications`,
+    createLaunchPipelineNotificationRule(
+      `l-${APP_NAME}-pipeline-status-notifications`,
+      pipeline.arn,
+      [
+        "codepipeline-pipeline-pipeline-execution-succeeded",
+        "codepipeline-pipeline-manual-approval-needed",
+      ],
+      slackAlertsTopicArn,
       {
-        name: `l-${APP_NAME}-pipeline-notifications`,
-        eventTypeIds: [
-          "codepipeline-pipeline-pipeline-execution-failed",
-          "codepipeline-pipeline-action-execution-failed",
-          "codepipeline-pipeline-pipeline-execution-succeeded",
-          "codepipeline-pipeline-manual-approval-needed",
-        ],
-        resource: pipeline.arn,
-        detailType: "FULL",
-        targets: [
-          {
-            address: slackAlertsTopicArn,
-          },
-        ],
-        tags: {
-          Name: `l-${APP_NAME}-pipeline-notifications`,
-          Component: `l-${APP_NAME}`,
-        },
+        Name: `l-${APP_NAME}-pipeline-status-notifications`,
+        Component: `l-${APP_NAME}`,
+      },
+      { parent: this }
+    );
+
+    createProdStageFailureAlert(
+      `l-${APP_NAME}-prod-stage-failure`,
+      pipeline.arn,
+      slackAlertsTopicArn,
+      {
+        Name: `l-${APP_NAME}-prod-stage-failure`,
+        Component: `l-${APP_NAME}`,
       },
       { parent: this }
     );

--- a/infra/pipelines/pipelines/l-prover-ansible.ts
+++ b/infra/pipelines/pipelines/l-prover-ansible.ts
@@ -304,30 +304,16 @@ artifacts:
             name: "Source",
             actions: [
               {
-                name: "GithubMain",
+                name: "Github",
                 category: "Source",
                 owner: "AWS",
                 provider: "CodeStarSourceConnection",
                 version: "1",
-                outputArtifacts: ["source_output_main"],
+                outputArtifacts: ["source_output"],
                 configuration: {
                   ConnectionArn: connection.arn,
                   FullRepositoryId: "boundless-xyz/boundless",
                   BranchName: "main",
-                  OutputArtifactFormat: "CODEBUILD_CLONE_REF",
-                },
-              },
-              {
-                name: "GithubNext",
-                category: "Source",
-                owner: "AWS",
-                provider: "CodeStarSourceConnection",
-                version: "1",
-                outputArtifacts: ["source_output_next"],
-                configuration: {
-                  ConnectionArn: connection.arn,
-                  FullRepositoryId: "boundless-xyz/boundless",
-                  BranchName: "next",
                   OutputArtifactFormat: "CODEBUILD_CLONE_REF",
                 },
               },
@@ -343,7 +329,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 1,
-                inputArtifacts: ["source_output_next"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["staging_output"],
                 configuration: {
                   ProjectName: buildProject.name,
@@ -363,7 +349,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 1,
-                inputArtifacts: ["source_output_next"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["cw_staging_output"],
                 configuration: {
                   ProjectName: cwStagingBuild.name,
@@ -381,7 +367,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 1,
-                inputArtifacts: ["source_output_next"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["nightly_output"],
                 configuration: {
                   ProjectName: buildProject.name,
@@ -401,7 +387,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 1,
-                inputArtifacts: ["source_output_next"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["cw_nightly_production_output"],
                 configuration: {
                   ProjectName: cwProductionBuild.name,
@@ -428,7 +414,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 2,
-                inputArtifacts: ["source_output_main"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["production_output"],
                 configuration: {
                   ProjectName: buildProject.name,
@@ -448,7 +434,7 @@ artifacts:
                 provider: "CodeBuild",
                 version: "1",
                 runOrder: 3,
-                inputArtifacts: ["source_output_main"],
+                inputArtifacts: ["source_output"],
                 outputArtifacts: ["cw_production_output"],
                 configuration: {
                   ProjectName: cwProductionBuild.name,
@@ -461,24 +447,11 @@ artifacts:
           {
             providerType: "CodeStarSourceConnection",
             gitConfiguration: {
-              sourceActionName: "GithubMain",
+              sourceActionName: "Github",
               pushes: [
                 {
                   branches: {
                     includes: ["main"],
-                  },
-                },
-              ],
-            },
-          },
-          {
-            providerType: "CodeStarSourceConnection",
-            gitConfiguration: {
-              sourceActionName: "GithubNext",
-              pushes: [
-                {
-                  branches: {
-                    includes: ["next"],
                   },
                 },
               ],

--- a/infra/pipelines/pipelines/l-requestor-lists.ts
+++ b/infra/pipelines/pipelines/l-requestor-lists.ts
@@ -1,7 +1,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { BOUNDLESS_PROD_DEPLOYMENT_ROLE_ARN, BOUNDLESS_STAGING_DEPLOYMENT_ROLE_ARN } from "../accountConstants";
-import { LaunchBasePipeline, LaunchPipelineConfig, BasePipelineArgs } from "./l-base";
+import { LaunchBasePipeline, LaunchPipelineConfig, BasePipelineArgs, createLaunchPipelineNotificationRule, createProdStageFailureAlert } from "./l-base";
 
 interface LRequestorListsPipelineArgs extends BasePipelineArgs {
 }
@@ -131,24 +131,30 @@ export class LRequestorListsPipeline extends LaunchBasePipeline<LaunchPipelineCo
         });
 
         // Create notification rule
-        new aws.codestarnotifications.NotificationRule(`l-${this.config.appName}-pipeline-notifications`, {
-            name: `l-${this.config.appName}-pipeline-notifications`,
-            eventTypeIds: [
+        createLaunchPipelineNotificationRule(
+            `l-${this.config.appName}-pipeline-status-notifications`,
+            pipeline.arn,
+            [
                 "codepipeline-pipeline-manual-approval-succeeded",
-                "codepipeline-pipeline-action-execution-failed",
             ],
-            resource: pipeline.arn,
-            detailType: "FULL",
-            targets: [
-                {
-                    address: slackAlertsTopicArn.apply((arn: string) => arn),
-                },
-            ],
-            tags: {
-                Name: `l-${this.config.appName}-pipeline-notifications`,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-pipeline-status-notifications`,
                 Component: `l-${this.config.appName}`,
             },
-        });
+            { parent: this }
+        );
+
+        createProdStageFailureAlert(
+            `l-${this.config.appName}-prod-stage-failure`,
+            pipeline.arn,
+            slackAlertsTopicArn,
+            {
+                Name: `l-${this.config.appName}-prod-stage-failure`,
+                Component: `l-${this.config.appName}`,
+            },
+            { parent: this }
+        );
     }
 
     protected getBuildSpec(): string {


### PR DESCRIPTION
Points the Ansible prover CodePipeline at `main` for staging and nightly (previously `next`) and removes the `next` source action and push trigger. Release stays on `main`.

Changes
* Collapses the two Source actions (`GithubMain` + `GithubNext`) back into a single `Github` action on `main`
* Staging and Nightly stages now consume `source_output` from `main`
* Drops the `next` branch push trigger