### PR TITLE
build: sort sol interface entries for deterministic codegen

### DIFF
--- a/crates/boundless-market/build.rs
+++ b/crates/boundless-market/build.rs
@@ -78,8 +78,7 @@ fn rewrite_solidity_interface_files() {
 
     // Sort directory entries by path so the generated file is deterministic across
     // filesystems and environments (fs::read_dir order is platform-dependent).
-    let mut entries: Vec<_> =
-        fs::read_dir(sol_iface_dir).unwrap().map(|e| e.unwrap()).collect();
+    let mut entries: Vec<_> = fs::read_dir(sol_iface_dir).unwrap().map(|e| e.unwrap()).collect();
     entries.sort_by_key(|e| e.path());
 
     for entry in entries {

--- a/crates/boundless-market/build.rs
+++ b/crates/boundless-market/build.rs
@@ -76,8 +76,13 @@ fn rewrite_solidity_interface_files() {
 
     let mut combined_sol_contents = String::new();
 
-    for entry in fs::read_dir(sol_iface_dir).unwrap() {
-        let entry = entry.unwrap();
+    // Sort directory entries by path so the generated file is deterministic across
+    // filesystems and environments (fs::read_dir order is platform-dependent).
+    let mut entries: Vec<_> =
+        fs::read_dir(sol_iface_dir).unwrap().map(|e| e.unwrap()).collect();
+    entries.sort_by_key(|e| e.path());
+
+    for entry in entries {
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) == Some("sol") {
             // Skip if the file is in EXCLUDE_CONTRACTS


### PR DESCRIPTION
`fs::read_dir` returns entries in filesystem order, which varies by OS and filesystem. `build.rs` concatenates every `.sol` file in `src/contracts/artifacts` into the generated `boundless_market_generated.rs`, so that ordering leaks into the compiled crate and breaks reproducible builds of any downstream binary that links `boundless-market`.

Sort entries by path before iterating so the generated file is byte-identical across hosts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-script change that only affects the ordering of generated Rust bindings, reducing cross-platform nondeterminism without altering contract logic.
> 
> **Overview**
> Ensures reproducible generation of `boundless_market_generated.rs` by **sorting `src/contracts/artifacts` directory entries by path** before concatenating `.sol` interfaces in `build.rs`, eliminating platform/filesystem-dependent `fs::read_dir` ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260c7d9b430453e5285d78dc60ee68bfe59ee515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->