### PR TITLE
Add a default free RPC for tests from external contributor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,13 +230,16 @@ jobs:
         run: cargo binstall -y cargo-nextest@0.9.128
 
       - name: cargo nextest run
-        run: cargo nextest run --locked --workspace --all-targets --features test-r0vm,test-rpc
+        run: |
+          FEATURES="test-r0vm"
+          [ -n "$ETH_MAINNET_RPC_URL" ] && FEATURES="$FEATURES,test-rpc"
+          cargo nextest run --locked --workspace --all-targets --features "$FEATURES"
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
           RISC0_DEV_MODE: true
           RUST_LOG: order_stream=trace,boundless_market=trace
-          ETH_MAINNET_RPC_URL: ${{ secrets.ETH_MAINNET_RPC_URL_FREE_TIER || 'https://ethereum.publicnode.com' }}
-          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL_FREE_TIER || 'https://mainnet.base.org' }}
+          ETH_MAINNET_RPC_URL: ${{ secrets.ETH_MAINNET_RPC_URL_FREE_TIER }}
+          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL_FREE_TIER }}
 
       - name: sccache stats
         run: sccache --show-stats

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,8 +235,8 @@ jobs:
           DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
           RISC0_DEV_MODE: true
           RUST_LOG: order_stream=trace,boundless_market=trace
-          ETH_MAINNET_RPC_URL: ${{ secrets.ETH_MAINNET_RPC_URL_FREE_TIER }}
-          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL_FREE_TIER }}
+          ETH_MAINNET_RPC_URL: ${{ secrets.ETH_MAINNET_RPC_URL_FREE_TIER || 'https://ethereum.publicnode.com' }}
+          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL_FREE_TIER || 'https://mainnet.base.org' }}
 
       - name: sccache stats
         run: sccache --show-stats


### PR DESCRIPTION
unsure which free RPC we are using for our CI, but this should be fine for external contributor PRs. Opening PR from a fork to test.

downside is that if the secret doesn't exist for us, this will just silently ignore those tests. Didn't seem worthwhile to separate into a different workflow