### PR TITLE
BM-2912: broker: allow configuring min static priority fee

### DIFF
--- a/crates/boundless-market/src/deployments.rs
+++ b/crates/boundless-market/src/deployments.rs
@@ -258,18 +258,21 @@ fn default_presets() -> ChainGasPresets {
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 20.0,
                 dynamic_multiplier_percentage: 3,
+                min_priority_fee_wei: 0,
             },
             medium: PriorityMode::Custom {
                 base_fee_multiplier_percentage: 200,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 30.0,
                 dynamic_multiplier_percentage: 5,
+                min_priority_fee_wei: 0,
             },
             high: PriorityMode::Custom {
                 base_fee_multiplier_percentage: 250,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 50.0,
                 dynamic_multiplier_percentage: 7,
+                min_priority_fee_wei: 0,
             },
         },
         // Conservative settings for profitability estimation: 1x base fee, no
@@ -281,18 +284,21 @@ fn default_presets() -> ChainGasPresets {
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 10.0,
                 dynamic_multiplier_percentage: 0,
+                min_priority_fee_wei: 0,
             },
             medium: PriorityMode::Custom {
                 base_fee_multiplier_percentage: 100,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 20.0,
                 dynamic_multiplier_percentage: 0,
+                min_priority_fee_wei: 0,
             },
             high: PriorityMode::Custom {
                 base_fee_multiplier_percentage: 100,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: 30.0,
                 dynamic_multiplier_percentage: 0,
+                min_priority_fee_wei: 0,
             },
         },
     }
@@ -301,7 +307,10 @@ fn default_presets() -> ChainGasPresets {
 /// Returns gas presets for a chain. Falls back to generic defaults.
 pub fn gas_presets_for_chain(chain_id: u64) -> ChainGasPresets {
     match chain_id {
-        // Taiko: very stable gas at ~0.01 gwei, essentially zero priority fee.
+        // Taiko: very stable gas at ~0.01 gwei, essentially zero priority fee from fee history.
+        // A min_priority_fee_wei floor of 0.01 gwei for Taiko is necessary as with periods of low
+        // gas fees, these txs will be rejected, and the sequencer will not look at future tx's
+        // priority fee for inclusion.
         167000 => ChainGasPresets {
             priority: TierPresets {
                 low: PriorityMode::Custom {
@@ -309,18 +318,21 @@ pub fn gas_presets_for_chain(chain_id: u64) -> ChainGasPresets {
                     priority_fee_multiplier_percentage: 100,
                     priority_fee_percentile: 1.0,
                     dynamic_multiplier_percentage: 2,
+                    min_priority_fee_wei: 10_000_000,
                 },
                 medium: PriorityMode::Custom {
                     base_fee_multiplier_percentage: 100,
                     priority_fee_multiplier_percentage: 100,
                     priority_fee_percentile: 5.0,
                     dynamic_multiplier_percentage: 3,
+                    min_priority_fee_wei: 10_000_000,
                 },
                 high: PriorityMode::Custom {
                     base_fee_multiplier_percentage: 150,
                     priority_fee_multiplier_percentage: 150,
                     priority_fee_percentile: 20.0,
                     dynamic_multiplier_percentage: 4,
+                    min_priority_fee_wei: 10_000_000,
                 },
             },
             estimation: TierPresets {
@@ -329,18 +341,21 @@ pub fn gas_presets_for_chain(chain_id: u64) -> ChainGasPresets {
                     priority_fee_multiplier_percentage: 100,
                     priority_fee_percentile: 10.0,
                     dynamic_multiplier_percentage: 2,
+                    min_priority_fee_wei: 10_000_000,
                 },
                 medium: PriorityMode::Custom {
                     base_fee_multiplier_percentage: 100,
                     priority_fee_multiplier_percentage: 100,
                     priority_fee_percentile: 20.0,
                     dynamic_multiplier_percentage: 3,
+                    min_priority_fee_wei: 10_000_000,
                 },
                 high: PriorityMode::Custom {
                     base_fee_multiplier_percentage: 150,
                     priority_fee_multiplier_percentage: 150,
                     priority_fee_percentile: 30.0,
                     dynamic_multiplier_percentage: 4,
+                    min_priority_fee_wei: 10_000_000,
                 },
             },
         },

--- a/crates/boundless-market/src/dynamic_gas_filler.rs
+++ b/crates/boundless-market/src/dynamic_gas_filler.rs
@@ -67,6 +67,9 @@ pub enum PriorityMode {
         /// The incremental percentage applied per pending tx when scaling the final estimate.
         #[serde(default = "default_custom_dynamic_multiplier_percentage")]
         dynamic_multiplier_percentage: u64,
+        /// Minimum priority fee in wei.
+        #[serde(default = "default_custom_min_priority_fee_wei")]
+        min_priority_fee_wei: u128,
     },
 }
 
@@ -86,6 +89,10 @@ const fn default_custom_dynamic_multiplier_percentage() -> u64 {
     5
 }
 
+const fn default_custom_min_priority_fee_wei() -> u128 {
+    0
+}
+
 impl PriorityMode {
     /// Returns the configuration for this priority mode.
     pub fn config(&self) -> PriorityModeConfig {
@@ -95,29 +102,34 @@ impl PriorityMode {
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: LOW_PRIORITY_PERCENTILE,
                 dynamic_multiplier_percentage: 3,
+                min_priority_fee_wei: 0,
             },
             PriorityMode::Medium => PriorityModeConfig {
                 base_fee_multiplier_percentage: DEFAULT_BASE_FEE_MULTIPLIER_PERCENTAGE,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: MEDIUM_PRIORITY_PERCENTILE,
                 dynamic_multiplier_percentage: 5,
+                min_priority_fee_wei: 0,
             },
             PriorityMode::High => PriorityModeConfig {
                 base_fee_multiplier_percentage: 250,
                 priority_fee_multiplier_percentage: 100,
                 priority_fee_percentile: HIGH_PRIORITY_PERCENTILE,
                 dynamic_multiplier_percentage: 7,
+                min_priority_fee_wei: 0,
             },
             PriorityMode::Custom {
                 base_fee_multiplier_percentage,
                 priority_fee_multiplier_percentage,
                 priority_fee_percentile,
                 dynamic_multiplier_percentage,
+                min_priority_fee_wei,
             } => PriorityModeConfig {
                 base_fee_multiplier_percentage: *base_fee_multiplier_percentage,
                 priority_fee_multiplier_percentage: *priority_fee_multiplier_percentage,
                 priority_fee_percentile: *priority_fee_percentile,
                 dynamic_multiplier_percentage: *dynamic_multiplier_percentage,
+                min_priority_fee_wei: *min_priority_fee_wei,
             },
         }
     }
@@ -156,6 +168,9 @@ pub struct PriorityModeConfig {
     pub priority_fee_percentile: f64,
     /// The incremental percentage applied to the base fee and priority fee per pending transaction (e.g., 0 = no change, 5 = +5% per pending tx).
     pub dynamic_multiplier_percentage: u64,
+    /// Minimum priority fee floor in wei. If the computed priority fee is below this value, this
+    /// value is used instead.
+    pub min_priority_fee_wei: u128,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -341,6 +356,7 @@ struct FeeEstimatorProvider<'a, P, N> {
     priority_fee_percentile: f64,
     base_fee_multiplier_percentage: u64,
     priority_fee_multiplier_percentage: u64,
+    min_priority_fee_wei: u128,
     _network: std::marker::PhantomData<N>,
 }
 
@@ -351,6 +367,7 @@ impl<'a, P, N> FeeEstimatorProvider<'a, P, N> {
             priority_fee_percentile: config.priority_fee_percentile,
             base_fee_multiplier_percentage: config.base_fee_multiplier_percentage,
             priority_fee_multiplier_percentage: config.priority_fee_multiplier_percentage,
+            min_priority_fee_wei: config.min_priority_fee_wei,
             _network: std::marker::PhantomData,
         }
     }
@@ -426,6 +443,25 @@ where
                 }
                 _ => {}
             }
+        }
+
+        // Apply the configured minimum priority fee floor.
+        if self.min_priority_fee_wei > 0
+            && estimation.max_priority_fee_per_gas < self.min_priority_fee_wei
+        {
+            tracing::debug!(
+                "Priority fee {} wei is below configured floor {} wei, applying floor",
+                estimation.max_priority_fee_per_gas,
+                self.min_priority_fee_wei
+            );
+            estimation.max_priority_fee_per_gas = self.min_priority_fee_wei;
+            estimation.max_fee_per_gas = std::cmp::max(
+                estimation.max_fee_per_gas,
+                base_fee_per_gas
+                    .saturating_mul(self.base_fee_multiplier_percentage as u128)
+                    / 100
+                    + self.min_priority_fee_wei,
+            );
         }
 
         Ok(estimation)

--- a/crates/boundless-market/src/dynamic_gas_filler.rs
+++ b/crates/boundless-market/src/dynamic_gas_filler.rs
@@ -457,9 +457,7 @@ where
             estimation.max_priority_fee_per_gas = self.min_priority_fee_wei;
             estimation.max_fee_per_gas = std::cmp::max(
                 estimation.max_fee_per_gas,
-                base_fee_per_gas
-                    .saturating_mul(self.base_fee_multiplier_percentage as u128)
-                    / 100
+                base_fee_per_gas.saturating_mul(self.base_fee_multiplier_percentage as u128) / 100
                     + self.min_priority_fee_wei,
             );
         }

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -638,6 +638,7 @@ where
             priority_fee_multiplier_percentage: 100,
             priority_fee_percentile: 75.0,
             dynamic_multiplier_percentage: 7,
+            min_priority_fee_wei: 0,
         }
         .estimate_max_fee_per_gas(&self.provider)
         .await

--- a/crates/broker/src/config.rs
+++ b/crates/broker/src/config.rs
@@ -421,6 +421,7 @@ error = ?"#;
                 priority_fee_multiplier_percentage: 150,
                 priority_fee_percentile: 15.0,
                 dynamic_multiplier_percentage: 9,
+                min_priority_fee_wei: 0,
             }
         );
     }


### PR DESCRIPTION
Required for Taiko to ensure that the base and priority fee do not go below 0.01gwei