### PR TITLE
BM-2915: refactor(broker): boilerplate reduction & ServiceRunner adoption (PR-1 of 3)

### DIFF
--- a/crates/broker/src/aggregator.rs
+++ b/crates/broker/src/aggregator.rs
@@ -31,14 +31,15 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    coded_error_impl,
     config::ConfigLock,
     db::{AggregationOrder, DbObj},
     errors::CodedError,
     futures_retry::retry_with_context,
-    impl_coded_debug, now_timestamp,
+    now_timestamp,
     order_committer::{CommitmentComplete, CommitmentOutcome},
     provers::{self, ProverObj},
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     utils::prune_receipt_claim_journal,
     AggregationState, Batch, BatchStatus,
 };
@@ -52,16 +53,10 @@ pub enum AggregatorErr {
     UnexpectedErr(#[from] anyhow::Error),
 }
 
-impl_coded_debug!(AggregatorErr);
-
-impl CodedError for AggregatorErr {
-    fn code(&self) -> &str {
-        match self {
-            AggregatorErr::UnexpectedErr(_) => "[B-AGG-500]",
-            AggregatorErr::CompressionErr(_) => "[B-AGG-400]",
-        }
-    }
-}
+coded_error_impl!(AggregatorErr, "AGG",
+    UnexpectedErr(..)  => "500",
+    CompressionErr(..) => "400",
+);
 
 struct AggregateProofsResult {
     proof_id: String,
@@ -791,35 +786,32 @@ impl AggregatorService {
     }
 }
 
-impl RetryTask for AggregatorService {
+impl BrokerService for AggregatorService {
     type Error = AggregatorErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let self_clone = self.clone();
 
-        Box::pin(async move {
-            tracing::debug!("Starting Aggregator service");
-            loop {
-                if cancel_token.is_cancelled() {
-                    tracing::debug!("Aggregator service received cancellation");
-                    break;
-                }
-
-                let conf_poll_time_ms = {
-                    let config = self_clone
-                        .config
-                        .lock_all()
-                        .context("Failed to lock config")
-                        .map_err(AggregatorErr::UnexpectedErr)
-                        .map_err(SupervisorErr::Recover)?;
-                    config.batcher.batch_poll_time_ms.unwrap_or(1000)
-                };
-
-                self_clone.aggregate().await.map_err(SupervisorErr::Recover)?;
-                tokio::time::sleep(tokio::time::Duration::from_millis(conf_poll_time_ms)).await;
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::debug!("Starting Aggregator service");
+        loop {
+            if cancel_token.is_cancelled() {
+                tracing::debug!("Aggregator service received cancellation");
+                break;
             }
 
-            Ok(())
-        })
+            let conf_poll_time_ms = {
+                let config = self
+                    .config
+                    .lock_all()
+                    .context("Failed to lock config")
+                    .map_err(AggregatorErr::UnexpectedErr)
+                    .map_err(SupervisorErr::Recover)?;
+                config.batcher.batch_poll_time_ms.unwrap_or(1000)
+            };
+
+            self.aggregate().await.map_err(SupervisorErr::Recover)?;
+            tokio::time::sleep(tokio::time::Duration::from_millis(conf_poll_time_ms)).await;
+        }
+
+        Ok(())
     }
 }
 
@@ -892,7 +884,7 @@ mod tests {
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        let _handle = tokio::spawn(chain_monitor.spawn(CancellationToken::new()));
+        let _handle = tokio::spawn((*chain_monitor).clone().run(CancellationToken::new()));
         let chain_id = provider.get_chain_id().await.unwrap();
         let set_builder_id = Digest::from(SET_BUILDER_ID);
         prover.upload_image(&set_builder_id.to_string(), SET_BUILDER_ELF.to_vec()).await.unwrap();
@@ -1056,7 +1048,7 @@ mod tests {
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        let _handle = tokio::spawn(chain_monitor.spawn(CancellationToken::new()));
+        let _handle = tokio::spawn((*chain_monitor).clone().run(CancellationToken::new()));
         let set_builder_id = Digest::from(SET_BUILDER_ID);
         prover.upload_image(&set_builder_id.to_string(), SET_BUILDER_ELF.to_vec()).await.unwrap();
         let assessor_id = Digest::from(ASSESSOR_GUEST_ID);
@@ -1345,7 +1337,7 @@ mod tests {
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
 
-        let _handle = tokio::spawn(chain_monitor.spawn(CancellationToken::new()));
+        let _handle = tokio::spawn((*chain_monitor).clone().run(CancellationToken::new()));
 
         let set_builder_id = Digest::from(SET_BUILDER_ID);
         prover.upload_image(&set_builder_id.to_string(), SET_BUILDER_ELF.to_vec()).await.unwrap();
@@ -1470,7 +1462,7 @@ mod tests {
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
 
-        let _handle = tokio::spawn(chain_monitor.spawn(CancellationToken::new()));
+        let _handle = tokio::spawn((*chain_monitor).clone().run(CancellationToken::new()));
 
         let set_builder_id = Digest::from(SET_BUILDER_ID);
         prover.upload_image(&set_builder_id.to_string(), SET_BUILDER_ELF.to_vec()).await.unwrap();

--- a/crates/broker/src/chain_monitor.rs
+++ b/crates/broker/src/chain_monitor.rs
@@ -27,9 +27,9 @@ use boundless_market::dynamic_gas_filler::PriorityMode;
 use thiserror::Error;
 
 use crate::{
+    coded_error_impl,
     errors::CodedError,
-    impl_coded_debug,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
 };
 
 #[derive(Error)]
@@ -40,16 +40,10 @@ pub enum ChainMonitorErr {
     UnexpectedErr(#[from] anyhow::Error),
 }
 
-impl_coded_debug!(ChainMonitorErr);
-
-impl CodedError for ChainMonitorErr {
-    fn code(&self) -> &str {
-        match self {
-            ChainMonitorErr::RpcErr(_) => "[B-CHM-400]",
-            ChainMonitorErr::UnexpectedErr(_) => "[B-CHM-500]",
-        }
-    }
-}
+coded_error_impl!(ChainMonitorErr, "CHM",
+    RpcErr(..)        => "400",
+    UnexpectedErr(..) => "500",
+);
 
 #[derive(Clone, Debug, Copy)]
 pub(crate) struct ChainHead {
@@ -141,77 +135,74 @@ impl<P: Provider + Send + Sync> ChainMonitorApi for ChainMonitorService<P> {
     }
 }
 
-impl<P> RetryTask for ChainMonitorService<P>
+impl<P> BrokerService for ChainMonitorService<P>
 where
-    P: Provider + 'static + Clone,
+    P: Provider + Clone + Send + Sync + 'static,
 {
     type Error = ChainMonitorErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let self_clone = self.clone();
 
-        Box::pin(async move {
-            tracing::info!("Starting ChainMonitor service");
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting ChainMonitor service");
 
-            let chain_id = self_clone
-                .provider
-                .get_chain_id()
-                .await
-                .context("failed to get chain ID")
-                .map_err(ChainMonitorErr::UnexpectedErr)
-                .map_err(SupervisorErr::Recover)?;
+        let chain_id = self
+            .provider
+            .get_chain_id()
+            .await
+            .context("failed to get chain ID")
+            .map_err(ChainMonitorErr::UnexpectedErr)
+            .map_err(SupervisorErr::Recover)?;
 
-            let chain_poll_time = NamedChain::try_from(chain_id)
-                .ok()
-                .and_then(|chain| chain.average_blocktime_hint())
-                .map(|block_time| block_time.mul_f32(0.6))
-                .unwrap_or(Duration::from_secs(2));
+        let chain_poll_time = NamedChain::try_from(chain_id)
+            .ok()
+            .and_then(|chain| chain.average_blocktime_hint())
+            .map(|block_time| block_time.mul_f32(0.6))
+            .unwrap_or(Duration::from_secs(2));
 
-            loop {
-                tokio::select! {
-                    // Wait for notification or handle cancellation
-                    _ = self_clone.update_notifier.notified() => {
-                        // Needs update, lock next update value to avoid unnecessary notifications.
-                        let mut next_update = self_clone.next_update.write().await;
+        loop {
+            tokio::select! {
+                // Wait for notification or handle cancellation
+                _ = self.update_notifier.notified() => {
+                    // Needs update, lock next update value to avoid unnecessary notifications.
+                    let mut next_update = self.next_update.write().await;
 
-                        // Get the latest block and estimated max fee per gas.
-                        let priority_mode = self_clone.gas_priority_mode.read().await.clone();
-                        let (block_res, gas_price_res) = tokio::join!(
-                            self_clone.provider.get_block_by_number(BlockNumberOrTag::Latest),
-                            priority_mode.estimate_max_fee_per_gas(self_clone.provider.as_ref())
-                        );
+                    // Get the latest block and estimated max fee per gas.
+                    let priority_mode = self.gas_priority_mode.read().await.clone();
+                    let (block_res, gas_price_res) = tokio::join!(
+                        self.provider.get_block_by_number(BlockNumberOrTag::Latest),
+                        priority_mode.estimate_max_fee_per_gas(self.provider.as_ref())
+                    );
 
-                        let block = block_res
-                            .context("failed to latest block")
-                            .map_err(ChainMonitorErr::RpcErr)
-                            .map_err(SupervisorErr::Recover)?
-                            .context("failed to fetch latest block: no block in response")
-                            .map_err(ChainMonitorErr::UnexpectedErr)
-                            .map_err(SupervisorErr::Recover)?;
-                        let head = ChainHead {
-                            block_number: block.header.number,
-                            block_timestamp: block.header.timestamp,
-                        };
-                        let _ = self_clone.head_update.send_replace(head);
+                    let block = block_res
+                        .context("failed to latest block")
+                        .map_err(ChainMonitorErr::RpcErr)
+                        .map_err(SupervisorErr::Recover)?
+                        .context("failed to fetch latest block: no block in response")
+                        .map_err(ChainMonitorErr::UnexpectedErr)
+                        .map_err(SupervisorErr::Recover)?;
+                    let head = ChainHead {
+                        block_number: block.header.number,
+                        block_timestamp: block.header.timestamp,
+                    };
+                    let _ = self.head_update.send_replace(head);
 
-                        let gas_price = gas_price_res
-                            .context("failed to get gas price")
-                            .map_err(ChainMonitorErr::RpcErr)
-                            .map_err(SupervisorErr::Recover)?;
-                        let _ = self_clone.gas_price.send_replace(gas_price);
+                    let gas_price = gas_price_res
+                        .context("failed to get gas price")
+                        .map_err(ChainMonitorErr::RpcErr)
+                        .map_err(SupervisorErr::Recover)?;
+                    let _ = self.gas_price.send_replace(gas_price);
 
-                        // Set timestamp for next update
-                        *next_update = Instant::now() + chain_poll_time;
-                    }
-                    // Handle cancellation
-                    _ = cancel_token.cancelled() => {
-                        tracing::debug!("Chain monitor received cancellation, shutting down gracefully");
-                        break;
-                    }
+                    // Set timestamp for next update
+                    *next_update = Instant::now() + chain_poll_time;
+                }
+                // Handle cancellation
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Chain monitor received cancellation, shutting down gracefully");
+                    break;
                 }
             }
+        }
 
-            Ok(())
-        })
+        Ok(())
     }
 }
 
@@ -241,8 +232,8 @@ mod tests {
 
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
-            Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        tokio::spawn(chain_monitor.spawn(CancellationToken::new()));
+            ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap();
+        tokio::spawn(chain_monitor.clone().run(CancellationToken::new()));
 
         let block = chain_monitor.current_block_number().await.unwrap();
         assert_eq!(block, 0);

--- a/crates/broker/src/chain_monitor_v2.rs
+++ b/crates/broker/src/chain_monitor_v2.rs
@@ -31,14 +31,14 @@ use crate::market_monitor::process_new_logs;
 use crate::{
     block_history::{BlockHistory, BlockHistoryEntry},
     chain_monitor::{ChainHead, ChainMonitorApi},
+    coded_error_impl,
     db::DbObj,
     errors::CodedError,
-    impl_coded_debug,
     market_monitor::{
         process_log, process_order_submitted, process_request_fulfilled, process_request_locked,
         MarketEvent,
     },
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     OrderRequest, OrderStateChange,
 };
 use alloy::{
@@ -82,19 +82,13 @@ pub enum ChainMonitorV2Err {
     ReceiverDropped,
 }
 
-impl_coded_debug!(ChainMonitorV2Err);
-
-impl CodedError for ChainMonitorV2Err {
-    fn code(&self) -> &str {
-        match self {
-            ChainMonitorV2Err::RpcErr(_) => "[B-CMV2-400]",
-            ChainMonitorV2Err::ReceiptsMismatch(_) => "[B-CMV2-401]",
-            ChainMonitorV2Err::LogProcessingFailed(_) => "[B-CMV2-501]",
-            ChainMonitorV2Err::UnexpectedErr(_) => "[B-CMV2-500]",
-            ChainMonitorV2Err::ReceiverDropped => "[B-CMV2-502]",
-        }
-    }
-}
+coded_error_impl!(ChainMonitorV2Err, "CMV2",
+    RpcErr(..)              => "400",
+    ReceiptsMismatch(..)    => "401",
+    LogProcessingFailed(..) => "501",
+    UnexpectedErr(..)       => "500",
+    ReceiverDropped         => "502",
+);
 
 /// Experimental replacement for `ChainMonitorService` + `MarketMonitor`.
 ///
@@ -652,28 +646,22 @@ where
     }
 }
 
-impl<P, ANP> RetryTask for ChainMonitorV2<P, ANP>
+impl<P, ANP> BrokerService for ChainMonitorV2<P, ANP>
 where
-    P: Provider<Ethereum> + Send + Sync + Clone + 'static,
-    ANP: Provider<AnyNetwork> + Send + Sync + Clone + 'static,
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
+    ANP: Provider<AnyNetwork> + Clone + Send + Sync + 'static,
 {
     type Error = ChainMonitorV2Err;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let self_clone = self.clone();
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting ChainMonitorV2");
 
-        Box::pin(async move {
-            tracing::info!("Starting ChainMonitorV2");
+        if !self.open_orders_found.load(Ordering::Relaxed) {
+            self.find_open_orders().await.map_err(SupervisorErr::Recover)?;
+            self.open_orders_found.store(true, Ordering::Relaxed);
+        }
 
-            if !self_clone.open_orders_found.load(Ordering::Relaxed) {
-                self_clone.find_open_orders().await.map_err(SupervisorErr::Recover)?;
-                self_clone.open_orders_found.store(true, Ordering::Relaxed);
-            }
-
-            self_clone.monitor_chain(cancel_token).await.map_err(SupervisorErr::Recover)?;
-
-            Ok(())
-        })
+        self.monitor_chain(cancel_token).await.map_err(SupervisorErr::Recover)
     }
 }
 

--- a/crates/broker/src/channels.rs
+++ b/crates/broker/src/channels.rs
@@ -29,9 +29,6 @@ use tokio::sync::{mpsc, Mutex};
 ///
 /// Use together with [`shared_channel`] when the receiver needs to be owned
 /// by a service that the supervisor may clone on restart.
-// Unused until services are migrated to consume `SharedReceiver` directly
-// (Phase 3 of the broker restructure). Kept here as additive infrastructure.
-#[allow(dead_code)]
 pub type SharedReceiver<T> = Arc<Mutex<mpsc::Receiver<T>>>;
 
 /// Creates an [`mpsc`] channel whose receiver is wrapped as a [`SharedReceiver`].
@@ -39,7 +36,6 @@ pub type SharedReceiver<T> = Arc<Mutex<mpsc::Receiver<T>>>;
 /// Equivalent to `mpsc::channel(capacity)` followed by manually wrapping the
 /// receiver in `Arc<Mutex<…>>` — bundled here so service constructors don't
 /// have to repeat the wrapping.
-#[allow(dead_code)]
 pub fn shared_channel<T>(capacity: usize) -> (mpsc::Sender<T>, SharedReceiver<T>) {
     let (tx, rx) = mpsc::channel(capacity);
     (tx, Arc::new(Mutex::new(rx)))

--- a/crates/broker/src/channels.rs
+++ b/crates/broker/src/channels.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 Boundless Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Channel helpers shared across broker services.
+//!
+//! Several services (e.g. `OrderEvaluator`, `OrderPricer`, `OrderCommitter`)
+//! consume from an `mpsc::Receiver` from inside a `Clone` service struct that
+//! is restarted by the supervisor. Cloning a service requires the receiver to
+//! be wrapped in `Arc<Mutex<…>>` so the same receiver is shared across clones.
+//! The wrapping is mechanical and identical at every call site — this module
+//! captures it once.
+
+use std::sync::Arc;
+
+use tokio::sync::{mpsc, Mutex};
+
+/// A receiver that can be cheaply cloned and shared across `Clone`d services.
+///
+/// Use together with [`shared_channel`] when the receiver needs to be owned
+/// by a service that the supervisor may clone on restart.
+// Unused until services are migrated to consume `SharedReceiver` directly
+// (Phase 3 of the broker restructure). Kept here as additive infrastructure.
+#[allow(dead_code)]
+pub type SharedReceiver<T> = Arc<Mutex<mpsc::Receiver<T>>>;
+
+/// Creates an [`mpsc`] channel whose receiver is wrapped as a [`SharedReceiver`].
+///
+/// Equivalent to `mpsc::channel(capacity)` followed by manually wrapping the
+/// receiver in `Arc<Mutex<…>>` — bundled here so service constructors don't
+/// have to repeat the wrapping.
+#[allow(dead_code)]
+pub fn shared_channel<T>(capacity: usize) -> (mpsc::Sender<T>, SharedReceiver<T>) {
+    let (tx, rx) = mpsc::channel(capacity);
+    (tx, Arc::new(Mutex::new(rx)))
+}

--- a/crates/broker/src/errors.rs
+++ b/crates/broker/src/errors.rs
@@ -46,29 +46,45 @@ pub use impl_coded_debug;
 
 /// Generates `impl CodedError` and `impl_coded_debug!` for a broker error enum.
 ///
-/// Each generated code follows the pattern `[B-<svc>-<code>]`. Tuple variants
-/// must be written as `Variant(..)`; unit variants are written without parens.
+/// Each generated code follows the pattern `[B-<svc>-<code>]`. Variant patterns
+/// are written exactly as they appear in the `match` arm:
+/// - tuple variants as `Variant(..)`
+/// - struct variants as `Variant { .. }`
+/// - unit variants without anything
 ///
 /// # Example
 ///
 /// ```ignore
 /// coded_error_impl!(MyErr, "ME",
-///     DbError(..) => "001",
-///     ConfigErr(..) => "002",
-///     NoData      => "003",
+///     DbError(..)            => "001",
+///     ConfigErr(..)          => "002",
+///     BelowMinimum { .. }    => "003",
+///     NoData                 => "500",
 /// );
 /// ```
 ///
-/// expands to an `impl CodedError` whose `code()` returns `"[B-ME-001]"` for
-/// `DbError`, `"[B-ME-002]"` for `ConfigErr`, and `"[B-ME-003]"` for `NoData`,
-/// plus an `impl_coded_debug!` invocation.
+/// expands to an `impl CodedError` whose `code()` returns the matching
+/// `"[B-ME-NNN]"` string per variant, plus an `impl_coded_debug!` invocation.
 #[macro_export]
 macro_rules! coded_error_impl {
-    ($ty:ident, $svc:literal, $($variant:ident $(( $($_inner:tt)* ))? => $code:literal),+ $(,)?) => {
+    (
+        $ty:ident, $svc:literal,
+        $(
+            $variant:ident
+            $(( $($_args:tt)* ))?
+            $({ $($_fields:tt)* })?
+            => $code:literal
+        ),+ $(,)?
+    ) => {
         impl $crate::errors::CodedError for $ty {
             fn code(&self) -> &str {
                 match self {
-                    $( Self::$variant $(( $($_inner)* ))? => concat!("[B-", $svc, "-", $code, "]") ),+
+                    $(
+                        Self::$variant
+                            $(( $($_args)* ))?
+                            $({ $($_fields)* })?
+                        => concat!("[B-", $svc, "-", $code, "]")
+                    ),+
                 }
             }
         }
@@ -180,24 +196,32 @@ mod tests {
         DbError(String),
         #[error("{code} config: {0}", code = self.code())]
         ConfigErr(anyhow::Error),
+        #[error(
+            "{code} below minimum: have {actual}, need {required}",
+            code = self.code()
+        )]
+        BelowMinimum { actual: u64, required: u64 },
         #[error("{code} no data variant", code = self.code())]
         NoData,
     }
 
     crate::coded_error_impl!(SampleErr, "TST",
-        DbError(..)    => "001",
-        ConfigErr(..)  => "002",
-        NoData         => "500",
+        DbError(..)        => "001",
+        ConfigErr(..)      => "002",
+        BelowMinimum { .. } => "003",
+        NoData             => "500",
     );
 
     #[test]
     fn coded_error_impl_emits_expected_codes() {
         let db = SampleErr::DbError("boom".to_string());
         let cfg = SampleErr::ConfigErr(anyhow::anyhow!("nope"));
+        let strct = SampleErr::BelowMinimum { actual: 1, required: 2 };
         let unit = SampleErr::NoData;
 
         assert_eq!(db.code(), "[B-TST-001]");
         assert_eq!(cfg.code(), "[B-TST-002]");
+        assert_eq!(strct.code(), "[B-TST-003]");
         assert_eq!(unit.code(), "[B-TST-500]");
     }
 
@@ -214,10 +238,12 @@ mod tests {
         // produce a CodedError impl that returns the right code so Display works.
         let db = SampleErr::DbError("boom".to_string());
         let cfg = SampleErr::ConfigErr(anyhow::anyhow!("nope"));
+        let strct = SampleErr::BelowMinimum { actual: 1, required: 2 };
         let unit = SampleErr::NoData;
 
         assert_eq!(format!("{}", db), "[B-TST-001] db: boom");
         assert_eq!(format!("{}", cfg), "[B-TST-002] config: nope");
+        assert_eq!(format!("{}", strct), "[B-TST-003] below minimum: have 1, need 2");
         assert_eq!(format!("{}", unit), "[B-TST-500] no data variant");
     }
 }

--- a/crates/broker/src/errors.rs
+++ b/crates/broker/src/errors.rs
@@ -44,6 +44,38 @@ macro_rules! impl_coded_debug {
 
 pub use impl_coded_debug;
 
+/// Generates `impl CodedError` and `impl_coded_debug!` for a broker error enum.
+///
+/// Each generated code follows the pattern `[B-<svc>-<code>]`. Tuple variants
+/// must be written as `Variant(..)`; unit variants are written without parens.
+///
+/// # Example
+///
+/// ```ignore
+/// coded_error_impl!(MyErr, "ME",
+///     DbError(..) => "001",
+///     ConfigErr(..) => "002",
+///     NoData      => "003",
+/// );
+/// ```
+///
+/// expands to an `impl CodedError` whose `code()` returns `"[B-ME-001]"` for
+/// `DbError`, `"[B-ME-002]"` for `ConfigErr`, and `"[B-ME-003]"` for `NoData`,
+/// plus an `impl_coded_debug!` invocation.
+#[macro_export]
+macro_rules! coded_error_impl {
+    ($ty:ident, $svc:literal, $($variant:ident $(( $($_inner:tt)* ))? => $code:literal),+ $(,)?) => {
+        impl $crate::errors::CodedError for $ty {
+            fn code(&self) -> &str {
+                match self {
+                    $( Self::$variant $(( $($_inner)* ))? => concat!("[B-", $svc, "-", $code, "]") ),+
+                }
+            }
+        }
+        $crate::impl_coded_debug!($ty);
+    };
+}
+
 use boundless_market::telemetry::CompletionOutcome;
 
 use tokio::sync::mpsc;
@@ -135,4 +167,57 @@ pub(crate) async fn cancel_proof_and_fail(
     }
 
     handle_order_failure(db, &order_id, failure, chain_id, proving_completion_tx).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CodedError;
+    use thiserror::Error;
+
+    #[derive(Error)]
+    enum SampleErr {
+        #[error("{code} db: {0}", code = self.code())]
+        DbError(String),
+        #[error("{code} config: {0}", code = self.code())]
+        ConfigErr(anyhow::Error),
+        #[error("{code} no data variant", code = self.code())]
+        NoData,
+    }
+
+    crate::coded_error_impl!(SampleErr, "TST",
+        DbError(..)    => "001",
+        ConfigErr(..)  => "002",
+        NoData         => "500",
+    );
+
+    #[test]
+    fn coded_error_impl_emits_expected_codes() {
+        let db = SampleErr::DbError("boom".to_string());
+        let cfg = SampleErr::ConfigErr(anyhow::anyhow!("nope"));
+        let unit = SampleErr::NoData;
+
+        assert_eq!(db.code(), "[B-TST-001]");
+        assert_eq!(cfg.code(), "[B-TST-002]");
+        assert_eq!(unit.code(), "[B-TST-500]");
+    }
+
+    #[test]
+    fn coded_error_impl_provides_debug_with_code() {
+        let err = SampleErr::DbError("boom".to_string());
+        let dbg = format!("{:?}", err);
+        assert!(dbg.contains("[B-TST-001]"), "debug output missing code: {dbg}");
+    }
+
+    #[test]
+    fn coded_error_impl_display_includes_code_via_self_code() {
+        // Variant attributes use `{code}` bound to `self.code()` — the macro must
+        // produce a CodedError impl that returns the right code so Display works.
+        let db = SampleErr::DbError("boom".to_string());
+        let cfg = SampleErr::ConfigErr(anyhow::anyhow!("nope"));
+        let unit = SampleErr::NoData;
+
+        assert_eq!(format!("{}", db), "[B-TST-001] db: boom");
+        assert_eq!(format!("{}", cfg), "[B-TST-002] config: nope");
+        assert_eq!(format!("{}", unit), "[B-TST-500] no data variant");
+    }
 }

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -887,10 +887,11 @@ impl Broker {
         let chain_dbs: Vec<DbObj> = chains.iter().map(|c| c.db.clone()).collect();
 
         // All chain monitors send discovered orders here; the evaluator reads from evaluator_order_rx.
-        let (evaluator_order_tx, evaluator_order_rx) = mpsc::channel(NEW_ORDER_CHANNEL_CAPACITY);
+        let (evaluator_order_tx, evaluator_order_rx) =
+            channels::shared_channel(NEW_ORDER_CHANNEL_CAPACITY);
         // Pricers send preflight completions here; the evaluator reads from pricing_completion_rx to free capacity.
         let (pricing_completion_tx, pricing_completion_rx) =
-            mpsc::channel(COMPLETION_CHANNEL_CAPACITY);
+            channels::shared_channel(COMPLETION_CHANNEL_CAPACITY);
         // Shared broadcast for on-chain lock/fulfill events. Each chain's MarketMonitor sends into
         // this channel, and both global singletons (OrderEvaluator, OrderCommitter) and per-chain
         // components (OrderPricer, ProvingService) subscribe. Per-chain subscribers must filter by

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -76,6 +76,7 @@ pub(crate) mod aggregator;
 pub(crate) mod block_history;
 pub(crate) mod chain_monitor;
 pub(crate) mod chain_monitor_v2;
+pub(crate) mod channels;
 pub mod config;
 mod db;
 pub use db::{broker_sqlite_url_for_chain, DbObj, SqliteDb};

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -57,11 +57,9 @@ use rpcmetrics::RpcMetricsLayer;
 use sequential_fallback::SequentialFallbackLayer;
 use serde::{Deserialize, Serialize};
 use storage::ConfigurableDownloader;
-use task::{RetryPolicy, Supervisor};
-use tokio::{sync::broadcast, sync::mpsc, sync::RwLock, task::JoinSet};
+use tokio::{sync::broadcast, sync::mpsc, sync::RwLock};
 use tokio_util::sync::CancellationToken;
 use tower::{Layer, ServiceBuilder};
-use tracing::Instrument;
 use url::Url;
 
 const NEW_ORDER_CHANNEL_CAPACITY: usize = 1000;
@@ -393,6 +391,7 @@ pub use boundless_market::prover_utils::{
     OrderPricingOutcome, OrderRequest, PreflightCache, PreflightCacheKey, PreflightCacheValue,
     ProveLimitReason,
 };
+use service_runner::ServiceRunner;
 
 /// On-chain order state change broadcast from MarketMonitor to all unified components
 /// (OrderEvaluator, OrderPricer, OrderCommitter) and the ProvingService.
@@ -878,11 +877,7 @@ impl Broker {
         let base_config = self.config_watcher.config.clone();
         let (prover, aggregation_prover) = self.build_provers(&base_config)?;
 
-        let mut non_critical_tasks: JoinSet<Result<()>> = JoinSet::new();
-        let mut critical_tasks: JoinSet<Result<()>> = JoinSet::new();
-
-        let non_critical_cancel_token = CancellationToken::new();
-        let critical_cancel_token = CancellationToken::new();
+        let mut runner = ServiceRunner::new(base_config.clone());
 
         let chain_dbs: Vec<DbObj> = chains.iter().map(|c| c.db.clone()).collect();
 
@@ -941,10 +936,7 @@ impl Broker {
                 locker_rx,
                 proving_completion_tx.clone(),
                 priority_requestors,
-                &mut non_critical_tasks,
-                &mut critical_tasks,
-                non_critical_cancel_token.clone(),
-                critical_cancel_token.clone(),
+                &mut runner,
             )
             .await?;
         }
@@ -962,15 +954,7 @@ impl Broker {
             order_state_tx.clone(),
             priority_requestors_map.clone(),
         ));
-        let cloned_config = base_config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        non_critical_tasks.spawn(async move {
-            Supervisor::new(order_evaluator, cloned_config, cancel_token)
-                .spawn()
-                .await
-                .context("Failed to start order evaluator")?;
-            Ok(())
-        });
+        runner.spawn(order_evaluator, service_runner::Criticality::NonCritical, "order evaluator");
 
         let order_committer = Arc::new(order_committer::OrderCommitter::new(
             base_config.clone(),
@@ -980,15 +964,19 @@ impl Broker {
             order_state_tx,
             priority_requestors_map,
         ));
-        let cloned_config = base_config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        non_critical_tasks.spawn(async move {
-            Supervisor::new(order_committer, cloned_config, cancel_token)
-                .spawn()
-                .await
-                .context("Failed to start unified order committer")?;
-            Ok(())
-        });
+        runner.spawn(
+            order_committer,
+            service_runner::Criticality::NonCritical,
+            "unified order committer",
+        );
+
+        // Decompose the runner to feed the shutdown loop and cancel-token machinery below.
+        let service_runner::ServiceRunnerParts {
+            mut non_critical_tasks,
+            mut critical_tasks,
+            non_critical_cancel_token,
+            critical_cancel_token,
+        } = runner.into_parts();
 
         // Monitor supervisor tasks and handle shutdown
         let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -1057,10 +1045,7 @@ impl Broker {
         locker_rx: channels::SharedReceiver<Box<OrderRequest>>,
         proving_completion_tx: mpsc::Sender<order_committer::CommitmentComplete>,
         priority_requestors: requestor_monitor::PriorityRequestors,
-        non_critical_tasks: &mut JoinSet<Result<()>>,
-        critical_tasks: &mut JoinSet<Result<()>>,
-        non_critical_cancel_token: CancellationToken,
-        critical_cancel_token: CancellationToken,
+        runner: &mut ServiceRunner,
     ) -> Result<()>
     where
         P: Provider<Ethereum> + WalletProvider + Clone + 'static,
@@ -1091,17 +1076,11 @@ impl Broker {
                 self.args.version_registry_address,
                 self.args.force_version_check,
             ));
-            let config_clone = config.clone();
-            let cancel_token = non_critical_cancel_token.clone();
-            non_critical_tasks.spawn(
-                async move {
-                    Supervisor::new(task, config_clone, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Version check task failed")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                task,
+                service_runner::Criticality::NonCritical,
+                "version check",
+                chain_span.clone(),
             );
         }
 
@@ -1142,16 +1121,14 @@ impl Broker {
                             config.clone(),
                             db.clone(),
                         );
-                        let cancel_token = non_critical_cancel_token.clone();
-                        let cs = chain_span.clone();
-                        non_critical_tasks.spawn(
+                        let cancel_token = runner.non_critical_cancel_token();
+                        runner.spawn_future_in_span(
+                            service_runner::Criticality::NonCritical,
+                            "telemetry service",
+                            chain_span.clone(),
                             async move {
-                                telemetry::run_telemetry_service(service, cancel_token)
-                                    .await
-                                    .context("Telemetry service failed")?;
-                                Ok(())
-                            }
-                            .instrument(cs),
+                                telemetry::run_telemetry_service(service, cancel_token).await
+                            },
                         );
                         handle
                     })
@@ -1172,16 +1149,14 @@ impl Broker {
                             config.clone(),
                             db.clone(),
                         );
-                        let cancel_token = non_critical_cancel_token.clone();
-                        let cs = chain_span.clone();
-                        non_critical_tasks.spawn(
+                        let cancel_token = runner.non_critical_cancel_token();
+                        runner.spawn_future_in_span(
+                            service_runner::Criticality::NonCritical,
+                            "telemetry service",
+                            chain_span.clone(),
                             async move {
-                                telemetry::run_telemetry_service(service, cancel_token)
-                                    .await
-                                    .context("Telemetry service failed")?;
-                                Ok(())
-                            }
-                            .instrument(cs),
+                                telemetry::run_telemetry_service(service, cancel_token).await
+                            },
                         );
                         handle
                     })
@@ -1198,16 +1173,12 @@ impl Broker {
                     config.clone(),
                     db.clone(),
                 );
-                let cancel_token = non_critical_cancel_token.clone();
-                let cs = chain_span.clone();
-                non_critical_tasks.spawn(
-                    async move {
-                        telemetry::run_telemetry_service(service, cancel_token)
-                            .await
-                            .context("Telemetry service failed")?;
-                        Ok(())
-                    }
-                    .instrument(cs),
+                let cancel_token = runner.non_critical_cancel_token();
+                runner.spawn_future_in_span(
+                    service_runner::Criticality::NonCritical,
+                    "telemetry service",
+                    chain_span.clone(),
+                    async move { telemetry::run_telemetry_service(service, cancel_token).await },
                 );
                 handle
             }),
@@ -1236,18 +1207,11 @@ impl Broker {
                 .context("Failed to initialize ChainMonitorV2")?,
             );
 
-            let cloned = monitor.clone();
-            let cloned_config = config.clone();
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(cloned, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start ChainMonitorV2")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                monitor.clone(),
+                service_runner::Criticality::Critical,
+                "ChainMonitorV2",
+                chain_span.clone(),
             );
 
             let block_times = monitor.block_time();
@@ -1262,18 +1226,11 @@ impl Broker {
                 .context("Failed to initialize chain monitor")?,
             );
 
-            let cloned_chain_monitor = chain_monitor_service.clone();
-            let cloned_config = config.clone();
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(cloned_chain_monitor, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start chain monitor")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                chain_monitor_service.clone(),
+                service_runner::Criticality::Critical,
+                "chain monitor",
+                chain_span.clone(),
             );
 
             let market_monitor = Arc::new(market_monitor::MarketMonitor::new(
@@ -1292,17 +1249,11 @@ impl Broker {
             let block_times =
                 market_monitor.get_block_time().await.context("Failed to sample block times")?;
 
-            let cloned_config = config.clone();
-            let cancel_token = non_critical_cancel_token.clone();
-            non_critical_tasks.spawn(
-                async move {
-                    Supervisor::new(market_monitor, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start market monitor")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                market_monitor,
+                service_runner::Criticality::NonCritical,
+                "market monitor",
+                chain_span.clone(),
             );
 
             (chain_monitor_service as chain_monitor::ChainMonitorObj, block_times)
@@ -1317,17 +1268,11 @@ impl Broker {
                     private_key.clone(),
                     evaluator_order_tx.clone(),
                 ));
-            let cloned_config = config.clone();
-            let cancel_token = non_critical_cancel_token.clone();
-            non_critical_tasks.spawn(
-                async move {
-                    Supervisor::new(offchain_market_monitor, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start offchain market monitor")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                offchain_market_monitor,
+                service_runner::Criticality::NonCritical,
+                "offchain market monitor",
+                chain_span.clone(),
             );
         }
 
@@ -1350,18 +1295,11 @@ impl Broker {
                 .build(named_chain, provider.clone())
                 .context("Failed to build price oracle")?,
         );
-        let cloned_config = config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        let price_oracle_clone = price_oracle.clone();
-        non_critical_tasks.spawn(
-            async move {
-                Supervisor::new(price_oracle_clone, cloned_config, cancel_token)
-                    .spawn()
-                    .await
-                    .context("price oracle failed")?;
-                Ok(())
-            }
-            .instrument(chain_span.clone()),
+        runner.spawn_in_span(
+            price_oracle.clone(),
+            service_runner::Criticality::NonCritical,
+            "price oracle",
+            chain_span.clone(),
         );
 
         let allow_requestors = requestor_monitor::AllowRequestors::new(config.clone(), chain_id);
@@ -1396,17 +1334,11 @@ impl Broker {
             chain_id,
             pricing_completion_tx,
         ));
-        let cloned_config = config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        non_critical_tasks.spawn(
-            async move {
-                Supervisor::new(order_pricer, cloned_config, cancel_token)
-                    .spawn()
-                    .await
-                    .context("Failed to start order pricer")?;
-                Ok(())
-            }
-            .instrument(chain_span.clone()),
+        runner.spawn_in_span(
+            order_pricer,
+            service_runner::Criticality::NonCritical,
+            "order pricer",
+            chain_span.clone(),
         );
 
         let order_locker = Arc::new(order_locker::OrderLocker::new(
@@ -1430,17 +1362,11 @@ impl Broker {
             chain_id,
             proving_completion_tx.clone(),
         )?);
-        let cloned_config = config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        non_critical_tasks.spawn(
-            async move {
-                Supervisor::new(order_locker, cloned_config, cancel_token)
-                    .spawn()
-                    .await
-                    .context("Failed to start order locker")?;
-                Ok(())
-            }
-            .instrument(chain_span.clone()),
+        runner.spawn_in_span(
+            order_locker,
+            service_runner::Criticality::NonCritical,
+            "order locker",
+            chain_span.clone(),
         );
 
         if !self.args.listen_only {
@@ -1457,17 +1383,11 @@ impl Broker {
                 proving_completion_tx.clone(),
             ));
 
-            let cloned_config = config.clone();
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(proving_service, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start proving service")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                proving_service,
+                service_runner::Criticality::Critical,
+                "proving service",
+                chain_span.clone(),
             );
 
             let set_builder_img_id = self
@@ -1493,21 +1413,15 @@ impl Broker {
                 .context("Failed to initialize aggregator service")?,
             );
 
-            let cloned_config = config.clone();
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(aggregator, cloned_config, cancel_token)
-                        .with_retry_policy(RetryPolicy::CRITICAL_SERVICE)
-                        .spawn()
-                        .await
-                        .context("Failed to start aggregator service")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                aggregator,
+                service_runner::Criticality::CriticalWithFastRetry,
+                "aggregator service",
+                chain_span.clone(),
             );
 
-            // Start the ReaperTask to check for expired committed orders
+            // Start the ReaperTask to check for expired committed orders.
+            // Using critical cancel token to ensure no stuck expired jobs on shutdown.
             let reaper = Arc::new(reaper::ReaperTask::new(
                 db.clone(),
                 config.clone(),
@@ -1515,18 +1429,11 @@ impl Broker {
                 chain_id,
                 proving_completion_tx.clone(),
             ));
-            let cloned_config = config.clone();
-            // Using critical cancel token to ensure no stuck expired jobs on shutdown
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(reaper, cloned_config, cancel_token)
-                        .spawn()
-                        .await
-                        .context("Failed to start reaper service")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                reaper,
+                service_runner::Criticality::Critical,
+                "reaper service",
+                chain_span.clone(),
             );
 
             let submitter = Arc::new(submitter::Submitter::new(
@@ -1540,18 +1447,11 @@ impl Broker {
                 chain_id,
                 proving_completion_tx.clone(),
             )?);
-            let cloned_config = config.clone();
-            let cancel_token = critical_cancel_token.clone();
-            critical_tasks.spawn(
-                async move {
-                    Supervisor::new(submitter, cloned_config, cancel_token)
-                        .with_retry_policy(RetryPolicy::CRITICAL_SERVICE)
-                        .spawn()
-                        .await
-                        .context("Failed to start submitter service")?;
-                    Ok(())
-                }
-                .instrument(chain_span.clone()),
+            runner.spawn_in_span(
+                submitter,
+                service_runner::Criticality::CriticalWithFastRetry,
+                "submitter service",
+                chain_span.clone(),
             );
         }
 
@@ -1560,17 +1460,11 @@ impl Broker {
             priority_requestors,
             allow_requestors,
         ));
-        let config_clone = config.clone();
-        let cancel_token = non_critical_cancel_token.clone();
-        non_critical_tasks.spawn(
-            async move {
-                Supervisor::new(requestor_monitor, config_clone, cancel_token)
-                    .spawn()
-                    .await
-                    .context("Requestor list monitor panicked")?;
-                Ok(())
-            }
-            .instrument(chain_span.clone()),
+        runner.spawn_in_span(
+            requestor_monitor,
+            service_runner::Criticality::NonCritical,
+            "requestor list monitor",
+            chain_span.clone(),
         );
 
         Ok(())

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -901,10 +901,11 @@ impl Broker {
             std::collections::HashMap::new();
 
         // All per-chain pricers send priced orders here; the order committer reads from priced_orders_rx.
-        let (priced_orders_tx, priced_orders_rx) = mpsc::channel(COMMITMENT_CHANNEL_CAPACITY);
+        let (priced_orders_tx, priced_orders_rx) =
+            channels::shared_channel(COMMITMENT_CHANNEL_CAPACITY);
         // Proving pipeline components send completion signals here; the order committer reads to free capacity.
         let (proving_completion_tx, proving_completion_rx) =
-            mpsc::channel(COMMITMENT_COMPLETION_CHANNEL_CAPACITY);
+            channels::shared_channel(COMMITMENT_COMPLETION_CHANNEL_CAPACITY);
         let mut locker_dispatchers: std::collections::HashMap<
             u64,
             mpsc::Sender<Box<OrderRequest>>,

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -922,7 +922,7 @@ impl Broker {
             chain_dispatchers.insert(chain.chain_id, pricer_tx);
 
             // Order committer dispatches capacity-gated orders to this chain's locker.
-            let (locker_tx, locker_rx) = mpsc::channel(COMMITMENT_CHANNEL_CAPACITY);
+            let (locker_tx, locker_rx) = channels::shared_channel(COMMITMENT_CHANNEL_CAPACITY);
             locker_dispatchers.insert(chain.chain_id, locker_tx);
 
             let priority_requestors =
@@ -1054,7 +1054,7 @@ impl Broker {
         pricing_completion_tx: mpsc::Sender<order_evaluator::PreflightComplete>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
         priced_orders_tx: mpsc::Sender<Box<OrderRequest>>,
-        locker_rx: mpsc::Receiver<Box<OrderRequest>>,
+        locker_rx: channels::SharedReceiver<Box<OrderRequest>>,
         proving_completion_tx: mpsc::Sender<order_committer::CommitmentComplete>,
         priority_requestors: requestor_monitor::PriorityRequestors,
         non_critical_tasks: &mut JoinSet<Result<()>>,

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -918,7 +918,7 @@ impl Broker {
 
         for chain in &chains {
             // Evaluator dispatches capacity-gated orders to this chain's pricer via pricer_tx.
-            let (pricer_tx, pricer_rx) = mpsc::channel(PRICER_CHANNEL_CAPACITY);
+            let (pricer_tx, pricer_rx) = channels::shared_channel(PRICER_CHANNEL_CAPACITY);
             chain_dispatchers.insert(chain.chain_id, pricer_tx);
 
             // Order committer dispatches capacity-gated orders to this chain's locker.
@@ -1050,7 +1050,7 @@ impl Broker {
         prover: ProverObj,
         aggregation_prover: ProverObj,
         evaluator_order_tx: mpsc::Sender<Box<OrderRequest>>,
-        pricer_rx: mpsc::Receiver<Box<OrderRequest>>,
+        pricer_rx: channels::SharedReceiver<Box<OrderRequest>>,
         pricing_completion_tx: mpsc::Sender<order_evaluator::PreflightComplete>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
         priced_orders_tx: mpsc::Sender<Box<OrderRequest>>,

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -97,6 +97,7 @@ pub(crate) mod requestor_monitor;
 pub(crate) mod rpc_retry_policy;
 pub mod rpcmetrics;
 pub mod sequential_fallback;
+pub(crate) mod service_runner;
 pub(crate) mod storage;
 pub(crate) mod submitter;
 pub(crate) mod task;

--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -37,9 +37,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     chain_monitor::ChainMonitorService,
+    coded_error_impl,
     db::{DbError, DbObj},
-    errors::{impl_coded_debug, CodedError},
-    task::{RetryRes, RetryTask, SupervisorErr},
+    errors::CodedError,
+    task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest, OrderStateChange,
 };
 use thiserror::Error;
@@ -63,18 +64,12 @@ pub enum MarketMonitorErr {
     ReceiverDropped,
 }
 
-impl CodedError for MarketMonitorErr {
-    fn code(&self) -> &str {
-        match self {
-            MarketMonitorErr::EventPollingErr(_) => "[B-MM-501]",
-            MarketMonitorErr::LogProcessingFailed(_) => "[B-MM-502]",
-            MarketMonitorErr::UnexpectedErr(_) => "[B-MM-500]",
-            MarketMonitorErr::ReceiverDropped => "[B-MM-502]",
-        }
-    }
-}
-
-impl_coded_debug!(MarketMonitorErr);
+coded_error_impl!(MarketMonitorErr, "MM",
+    EventPollingErr(..)     => "501",
+    LogProcessingFailed(..) => "502",
+    UnexpectedErr(..)       => "500",
+    ReceiverDropped         => "502",
+);
 
 #[derive(Clone)]
 pub struct MarketMonitor<P> {
@@ -651,57 +646,43 @@ pub(crate) async fn process_request_fulfilled(
     Ok(())
 }
 
-impl<P> RetryTask for MarketMonitor<P>
+impl<P> BrokerService for MarketMonitor<P>
 where
-    P: Provider<Ethereum> + 'static + Clone,
+    P: Provider<Ethereum> + Clone + Send + Sync + 'static,
 {
     type Error = MarketMonitorErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let lookback_blocks = self.lookback_blocks;
-        let events_poll_blocks = self.events_poll_blocks;
-        let poll_interval_ms = self.poll_interval_ms;
-        let market_addr = self.market_addr;
-        let provider = self.provider.clone();
-        let prover_addr = self.prover_addr;
-        let chain_monitor = self.chain_monitor.clone();
-        let new_order_tx = self.new_order_tx.clone();
-        let db = self.db.clone();
-        let order_state_tx = self.order_state_tx.clone();
 
-        Box::pin(async move {
-            tracing::info!("Starting up market monitor");
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting up market monitor");
 
-            Self::find_open_orders(
-                lookback_blocks,
-                market_addr,
-                provider.clone(),
-                chain_monitor.clone(),
-                &new_order_tx,
-            )
-            .await
-            .map_err(|err| {
-                tracing::error!("Monitor failed to find open orders on startup.");
-                SupervisorErr::Recover(err)
-            })?;
+        Self::find_open_orders(
+            self.lookback_blocks,
+            self.market_addr,
+            self.provider.clone(),
+            self.chain_monitor.clone(),
+            &self.new_order_tx,
+        )
+        .await
+        .map_err(|err| {
+            tracing::error!("Monitor failed to find open orders on startup.");
+            SupervisorErr::Recover(err)
+        })?;
 
-            Self::monitor_market(
-                market_addr,
-                prover_addr,
-                provider.clone(),
-                chain_monitor,
-                db,
-                lookback_blocks,
-                events_poll_blocks,
-                poll_interval_ms,
-                new_order_tx,
-                order_state_tx,
-                cancel_token,
-            )
-            .await
-            .map_err(SupervisorErr::Recover)?;
-
-            Ok(())
-        })
+        Self::monitor_market(
+            self.market_addr,
+            self.prover_addr,
+            self.provider,
+            self.chain_monitor,
+            self.db,
+            self.lookback_blocks,
+            self.events_poll_blocks,
+            self.poll_interval_ms,
+            self.new_order_tx,
+            self.order_state_tx,
+            cancel_token,
+        )
+        .await
+        .map_err(SupervisorErr::Recover)
     }
 }
 
@@ -793,7 +774,7 @@ mod tests {
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        tokio::spawn(chain_monitor.spawn(Default::default()));
+        tokio::spawn((*chain_monitor).clone().run(Default::default()));
 
         let (order_tx, mut order_rx) = mpsc::channel(16);
         let orders =
@@ -823,7 +804,7 @@ mod tests {
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        tokio::spawn(chain_monitor.spawn(Default::default()));
+        tokio::spawn((*chain_monitor).clone().run(Default::default()));
         let (order_tx, _order_rx) = mpsc::channel(16);
         let db: DbObj = Arc::new(SqliteDb::new("sqlite::memory:").await.unwrap());
         let (order_state_tx, _) = broadcast::channel(16);
@@ -944,7 +925,7 @@ mod tests {
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::default()));
         let chain_monitor =
             Arc::new(ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap());
-        tokio::spawn(chain_monitor.spawn(Default::default()));
+        tokio::spawn((*chain_monitor).clone().run(Default::default()));
         // Ensure chain_monitor has its first cached value.
         let _ = chain_monitor.current_block_number().await.unwrap();
 

--- a/crates/broker/src/market_monitor.rs
+++ b/crates/broker/src/market_monitor.rs
@@ -76,6 +76,7 @@ impl CodedError for MarketMonitorErr {
 
 impl_coded_debug!(MarketMonitorErr);
 
+#[derive(Clone)]
 pub struct MarketMonitor<P> {
     lookback_blocks: u64,
     events_poll_blocks: u64,

--- a/crates/broker/src/offchain_market_monitor.rs
+++ b/crates/broker/src/offchain_market_monitor.rs
@@ -50,6 +50,7 @@ impl CodedError for OffchainMarketMonitorErr {
     }
 }
 
+#[derive(Clone)]
 pub struct OffchainMarketMonitor {
     client: OrderStreamClient,
     signer: PrivateKeySigner,

--- a/crates/broker/src/offchain_market_monitor.rs
+++ b/crates/broker/src/offchain_market_monitor.rs
@@ -18,9 +18,9 @@ use boundless_market::order_stream_client::{order_stream, OrderStreamClient};
 use futures_util::StreamExt;
 
 use crate::{
+    coded_error_impl,
     errors::CodedError,
-    impl_coded_debug,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest,
 };
 use thiserror::Error;
@@ -38,17 +38,11 @@ pub enum OffchainMarketMonitorErr {
     UnexpectedErr(#[from] anyhow::Error),
 }
 
-impl_coded_debug!(OffchainMarketMonitorErr);
-
-impl CodedError for OffchainMarketMonitorErr {
-    fn code(&self) -> &str {
-        match self {
-            OffchainMarketMonitorErr::WebSocketErr(_) => "[B-OMM-001]",
-            OffchainMarketMonitorErr::ReceiverDropped => "[B-OMM-002]",
-            OffchainMarketMonitorErr::UnexpectedErr(_) => "[B-OMM-500]",
-        }
-    }
-}
+coded_error_impl!(OffchainMarketMonitorErr, "OMM",
+    WebSocketErr(..)  => "001",
+    ReceiverDropped   => "002",
+    UnexpectedErr(..) => "500",
+);
 
 #[derive(Clone)]
 pub struct OffchainMarketMonitor {
@@ -124,19 +118,13 @@ impl OffchainMarketMonitor {
     }
 }
 
-impl RetryTask for OffchainMarketMonitor {
+impl BrokerService for OffchainMarketMonitor {
     type Error = OffchainMarketMonitorErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let client = self.client.clone();
-        let signer = self.signer.clone();
-        let new_order_tx = self.new_order_tx.clone();
 
-        Box::pin(async move {
-            tracing::info!("Starting up offchain market monitor");
-            Self::monitor_orders(client, &signer, new_order_tx, cancel_token)
-                .await
-                .map_err(SupervisorErr::Recover)?;
-            Ok(())
-        })
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting up offchain market monitor");
+        Self::monitor_orders(self.client, &self.signer, self.new_order_tx, cancel_token)
+            .await
+            .map_err(SupervisorErr::Recover)
     }
 }

--- a/crates/broker/src/order_committer.rs
+++ b/crates/broker/src/order_committer.rs
@@ -40,17 +40,19 @@ use std::time::{Duration, Instant};
 
 use alloy::primitives::{Address, U256};
 use thiserror::Error;
-use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    channels::SharedReceiver,
+    coded_error_impl,
     config::{ConfigLock, OrderCommitmentPriority},
     errors::CodedError,
     now_timestamp,
     order_locker::OrderCommitmentMeta,
     prioritization::prioritize_orders_to_commit,
     requestor_monitor::PriorityRequestors,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest, OrderStateChange,
 };
 
@@ -97,7 +99,7 @@ struct InFlightOrder {
     proving_started_at: Option<u64>,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub(crate) enum OrderCommitterErr {
     #[error("{code} Config read error: {0}", code = self.code())]
     ConfigReadErr(Arc<anyhow::Error>),
@@ -106,14 +108,10 @@ pub(crate) enum OrderCommitterErr {
     StaleCapacity { order_id: String, elapsed_secs: u64 },
 }
 
-impl CodedError for OrderCommitterErr {
-    fn code(&self) -> &str {
-        match self {
-            OrderCommitterErr::ConfigReadErr(_) => "[B-OC-001]",
-            OrderCommitterErr::StaleCapacity { .. } => "[B-OC-004]",
-        }
-    }
-}
+coded_error_impl!(OrderCommitterErr, "OC",
+    ConfigReadErr(..)   => "001",
+    StaleCapacity { .. } => "004",
+);
 
 struct CommitterConfig {
     max_concurrent_proofs: usize,
@@ -133,9 +131,9 @@ struct CommitterConfig {
 #[derive(Clone)]
 pub(crate) struct OrderCommitter {
     config: ConfigLock,
-    priced_order_rx: Arc<Mutex<mpsc::Receiver<Box<OrderRequest>>>>,
+    priced_order_rx: SharedReceiver<Box<OrderRequest>>,
     locker_dispatchers: Arc<HashMap<u64, mpsc::Sender<Box<OrderRequest>>>>,
-    proving_completion_rx: Arc<Mutex<mpsc::Receiver<CommitmentComplete>>>,
+    proving_completion_rx: SharedReceiver<CommitmentComplete>,
     order_state_tx: broadcast::Sender<OrderStateChange>,
     priority_requestors: Arc<HashMap<u64, PriorityRequestors>>,
 }
@@ -174,17 +172,17 @@ fn record_skip_telemetry(
 impl OrderCommitter {
     pub fn new(
         config: ConfigLock,
-        priced_order_rx: mpsc::Receiver<Box<OrderRequest>>,
+        priced_order_rx: SharedReceiver<Box<OrderRequest>>,
         locker_dispatchers: HashMap<u64, mpsc::Sender<Box<OrderRequest>>>,
-        proving_completion_rx: mpsc::Receiver<CommitmentComplete>,
+        proving_completion_rx: SharedReceiver<CommitmentComplete>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
         priority_requestors: HashMap<u64, PriorityRequestors>,
     ) -> Self {
         Self {
             config,
-            priced_order_rx: Arc::new(Mutex::new(priced_order_rx)),
+            priced_order_rx,
             locker_dispatchers: Arc::new(locker_dispatchers),
-            proving_completion_rx: Arc::new(Mutex::new(proving_completion_rx)),
+            proving_completion_rx,
             order_state_tx,
             priority_requestors: Arc::new(priority_requestors),
         }
@@ -471,152 +469,148 @@ impl OrderCommitter {
     }
 }
 
-impl RetryTask for OrderCommitter {
+impl BrokerService for OrderCommitter {
     type Error = OrderCommitterErr;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let committer = self.clone();
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting order committer");
 
-        Box::pin(async move {
-            tracing::info!("Starting order committer");
+        let mut committer_config = self.read_config().map_err(SupervisorErr::Fault)?;
+        let mut priority_addresses =
+            self.collect_priority_addresses(committer_config.priority_addresses.take());
 
-            let mut committer_config = committer.read_config().map_err(SupervisorErr::Fault)?;
-            let mut priority_addresses =
-                committer.collect_priority_addresses(committer_config.priority_addresses.take());
+        let mut priced_order_rx = self.priced_order_rx.lock().await;
+        let mut proving_completion_rx = self.proving_completion_rx.lock().await;
+        let mut order_state_rx = self.order_state_tx.subscribe();
+        let mut capacity_check_interval = tokio::time::interval(MIN_CAPACITY_CHECK_INTERVAL);
 
-            let mut priced_order_rx = committer.priced_order_rx.lock().await;
-            let mut proving_completion_rx = committer.proving_completion_rx.lock().await;
-            let mut order_state_rx = committer.order_state_tx.subscribe();
-            let mut capacity_check_interval = tokio::time::interval(MIN_CAPACITY_CHECK_INTERVAL);
+        let mut pending_orders: Vec<Box<OrderRequest>> = Vec::new();
+        let mut in_flight: HashMap<String, InFlightOrder> = HashMap::new();
 
-            let mut pending_orders: Vec<Box<OrderRequest>> = Vec::new();
-            let mut in_flight: HashMap<String, InFlightOrder> = HashMap::new();
+        loop {
+            tokio::select! {
+                Some(order) = priced_order_rx.recv() => {
+                    let order_id = order.id();
+                    let chain_id = order.chain_id;
+                    pending_orders.push(order);
+                    tracing::debug!(
+                        chain_id,
+                        "Order committer queued order {order_id} ({} pending [{}], {} in-flight)",
+                        pending_orders.len(),
+                        Self::format_per_chain_counts(&pending_orders),
+                        in_flight.len(),
+                    );
+                }
 
-            loop {
-                tokio::select! {
-                    Some(order) = priced_order_rx.recv() => {
-                        let order_id = order.id();
-                        let chain_id = order.chain_id;
-                        pending_orders.push(order);
+                Some(completion) = proving_completion_rx.recv() => {
+                    if in_flight.remove(&completion.order_id).is_some() {
                         tracing::debug!(
-                            chain_id,
-                            "Order committer queued order {order_id} ({} pending [{}], {} in-flight)",
-                            pending_orders.len(),
-                            Self::format_per_chain_counts(&pending_orders),
+                            chain_id = completion.chain_id,
+                            "Commitment complete for order {} ({}), {} in-flight remaining",
+                            completion.order_id,
+                            completion.outcome,
                             in_flight.len(),
                         );
-                    }
-
-                    Some(completion) = proving_completion_rx.recv() => {
-                        if in_flight.remove(&completion.order_id).is_some() {
-                            tracing::debug!(
-                                chain_id = completion.chain_id,
-                                "Commitment complete for order {} ({}), {} in-flight remaining",
-                                completion.order_id,
-                                completion.outcome,
-                                in_flight.len(),
-                            );
-                        } else {
-                            tracing::trace!(
-                                chain_id = completion.chain_id,
-                                "Received commitment completion for order {} not in in-flight map (possibly reaped)",
-                                completion.order_id,
-                            );
-                        }
-                    }
-
-                    Ok(state_change) = order_state_rx.recv() => {
-                        match state_change {
-                            OrderStateChange::Locked { request_id, prover, chain_id } => {
-                                tracing::debug!(
-                                    chain_id,
-                                    "Order committer: request 0x{:x} on chain {chain_id} locked by 0x{:x}, removing pending LockAndFulfill orders",
-                                    request_id, prover,
-                                );
-                                let initial_len = pending_orders.len();
-                                pending_orders.retain(|order| {
-                                    let same_request = U256::from(order.request.id) == request_id;
-                                    let same_chain = order.chain_id == chain_id;
-                                    let is_lock_and_fulfill = order.fulfillment_type == FulfillmentType::LockAndFulfill;
-                                    !(same_request && same_chain && is_lock_and_fulfill)
-                                });
-                                let removed = initial_len - pending_orders.len();
-                                if removed > 0 {
-                                    tracing::debug!(
-                                        "Removed {removed} LockAndFulfill orders from commitment queue for locked request 0x{:x}",
-                                        request_id,
-                                    );
-                                }
-                            }
-                            OrderStateChange::Fulfilled { request_id, chain_id } => {
-                                tracing::debug!(
-                                    chain_id,
-                                    "Order committer: request 0x{:x} on chain {chain_id} fulfilled, removing all pending orders",
-                                    request_id,
-                                );
-                                let initial_len = pending_orders.len();
-                                pending_orders.retain(|order| {
-                                    !(U256::from(order.request.id) == request_id && order.chain_id == chain_id)
-                                });
-                                let removed = initial_len - pending_orders.len();
-                                if removed > 0 {
-                                    tracing::debug!(
-                                        "Removed {removed} orders from commitment queue for fulfilled request 0x{:x}",
-                                        request_id,
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    _ = capacity_check_interval.tick() => {
-                        let new_config = committer.read_config().map_err(SupervisorErr::Fault)?;
-
-                        if new_config.max_concurrent_proofs != committer_config.max_concurrent_proofs {
-                            tracing::debug!(
-                                "Order committer proving capacity changed from {} to {}",
-                                committer_config.max_concurrent_proofs, new_config.max_concurrent_proofs,
-                            );
-                        }
-                        if new_config.peak_prove_khz != committer_config.peak_prove_khz {
-                            tracing::debug!(
-                                "Order committer peak_prove_khz changed from {:?} to {:?}",
-                                committer_config.peak_prove_khz, new_config.peak_prove_khz,
-                            );
-                        }
-                        if new_config.order_commitment_priority != committer_config.order_commitment_priority {
-                            tracing::debug!(
-                                "Order committer commitment priority changed from {:?} to {:?}",
-                                committer_config.order_commitment_priority, new_config.order_commitment_priority,
-                            );
-                        }
-
-                        committer_config = new_config;
-                        priority_addresses = committer
-                            .collect_priority_addresses(committer_config.priority_addresses.take());
-
-                        Self::reap_stale_capacity(
-                            &mut in_flight,
-                            DEFAULT_MAX_COMMITMENT_DURATION_SECS,
+                    } else {
+                        tracing::trace!(
+                            chain_id = completion.chain_id,
+                            "Received commitment completion for order {} not in in-flight map (possibly reaped)",
+                            completion.order_id,
                         );
-                    }
-
-                    _ = cancel_token.cancelled() => {
-                        tracing::info!("Order committer received cancellation, shutting down");
-                        break;
                     }
                 }
 
-                committer.commit_orders(
-                    &mut pending_orders,
-                    &mut in_flight,
-                    &committer_config,
-                    &priority_addresses,
-                );
+                Ok(state_change) = order_state_rx.recv() => {
+                    match state_change {
+                        OrderStateChange::Locked { request_id, prover, chain_id } => {
+                            tracing::debug!(
+                                chain_id,
+                                "Order committer: request 0x{:x} on chain {chain_id} locked by 0x{:x}, removing pending LockAndFulfill orders",
+                                request_id, prover,
+                            );
+                            let initial_len = pending_orders.len();
+                            pending_orders.retain(|order| {
+                                let same_request = U256::from(order.request.id) == request_id;
+                                let same_chain = order.chain_id == chain_id;
+                                let is_lock_and_fulfill = order.fulfillment_type == FulfillmentType::LockAndFulfill;
+                                !(same_request && same_chain && is_lock_and_fulfill)
+                            });
+                            let removed = initial_len - pending_orders.len();
+                            if removed > 0 {
+                                tracing::debug!(
+                                    "Removed {removed} LockAndFulfill orders from commitment queue for locked request 0x{:x}",
+                                    request_id,
+                                );
+                            }
+                        }
+                        OrderStateChange::Fulfilled { request_id, chain_id } => {
+                            tracing::debug!(
+                                chain_id,
+                                "Order committer: request 0x{:x} on chain {chain_id} fulfilled, removing all pending orders",
+                                request_id,
+                            );
+                            let initial_len = pending_orders.len();
+                            pending_orders.retain(|order| {
+                                !(U256::from(order.request.id) == request_id && order.chain_id == chain_id)
+                            });
+                            let removed = initial_len - pending_orders.len();
+                            if removed > 0 {
+                                tracing::debug!(
+                                    "Removed {removed} orders from commitment queue for fulfilled request 0x{:x}",
+                                    request_id,
+                                );
+                            }
+                        }
+                    }
+                }
+
+                _ = capacity_check_interval.tick() => {
+                    let new_config = self.read_config().map_err(SupervisorErr::Fault)?;
+
+                    if new_config.max_concurrent_proofs != committer_config.max_concurrent_proofs {
+                        tracing::debug!(
+                            "Order committer proving capacity changed from {} to {}",
+                            committer_config.max_concurrent_proofs, new_config.max_concurrent_proofs,
+                        );
+                    }
+                    if new_config.peak_prove_khz != committer_config.peak_prove_khz {
+                        tracing::debug!(
+                            "Order committer peak_prove_khz changed from {:?} to {:?}",
+                            committer_config.peak_prove_khz, new_config.peak_prove_khz,
+                        );
+                    }
+                    if new_config.order_commitment_priority != committer_config.order_commitment_priority {
+                        tracing::debug!(
+                            "Order committer commitment priority changed from {:?} to {:?}",
+                            committer_config.order_commitment_priority, new_config.order_commitment_priority,
+                        );
+                    }
+
+                    committer_config = new_config;
+                    priority_addresses = self
+                        .collect_priority_addresses(committer_config.priority_addresses.take());
+
+                    Self::reap_stale_capacity(
+                        &mut in_flight,
+                        DEFAULT_MAX_COMMITMENT_DURATION_SECS,
+                    );
+                }
+
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Order committer received cancellation, shutting down");
+                    break;
+                }
             }
 
-            Ok(())
-        })
+            self.commit_orders(
+                &mut pending_orders,
+                &mut in_flight,
+                &committer_config,
+                &priority_addresses,
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -676,8 +670,8 @@ mod tests {
         let config = ConfigLock::default();
         config.load_write().unwrap().market.max_concurrent_proofs = max_concurrent_proofs;
 
-        let (order_tx, order_rx) = mpsc::channel(100);
-        let (proving_completion_tx, proving_completion_rx) = mpsc::channel(100);
+        let (order_tx, order_rx) = crate::channels::shared_channel(100);
+        let (proving_completion_tx, proving_completion_rx) = crate::channels::shared_channel(100);
         let (state_tx, _) = broadcast::channel(100);
 
         let mut dispatchers = HashMap::new();
@@ -726,7 +720,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let locker_rx = locker_rxs.get_mut(&1).unwrap();
@@ -752,7 +746,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let locker_rx = locker_rxs.get_mut(&1).unwrap();
@@ -786,7 +780,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let locker_rx = locker_rxs.get_mut(&1).unwrap();
@@ -837,7 +831,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let locker_rx = locker_rxs.get_mut(&1).unwrap();
@@ -880,7 +874,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let chain_1_rx = locker_rxs.get_mut(&1).unwrap();
@@ -926,7 +920,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         order_tx.send(make_order(1, 0, FulfillmentType::LockAndFulfill)).await.unwrap();
@@ -963,7 +957,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         let chain_1_rx = locker_rxs.get_mut(&1).unwrap();
@@ -983,8 +977,8 @@ mod tests {
         let config = ConfigLock::default();
         config.load_write().unwrap().market.max_concurrent_proofs = 1;
 
-        let (order_tx, order_rx) = mpsc::channel(100);
-        let (proving_completion_tx, proving_completion_rx) = mpsc::channel(100);
+        let (order_tx, order_rx) = crate::channels::shared_channel(100);
+        let (proving_completion_tx, proving_completion_rx) = crate::channels::shared_channel(100);
         let (state_tx, _) = broadcast::channel(100);
         let (locker_tx, mut locker_rx) = mpsc::channel(100);
 
@@ -1005,7 +999,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { committer.spawn(cancel).await }
+            async move { committer.run(cancel).await }
         });
 
         for i in 0..3 {

--- a/crates/broker/src/order_evaluator.rs
+++ b/crates/broker/src/order_evaluator.rs
@@ -18,15 +18,17 @@ use std::time::{Duration, Instant};
 
 use alloy::primitives::U256;
 use thiserror::Error;
-use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    channels::SharedReceiver,
+    coded_error_impl,
     config::ConfigLock,
     errors::CodedError,
     prioritization::prioritize_orders_to_evaluate,
     requestor_monitor::PriorityRequestors,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest, OrderStateChange,
 };
 
@@ -61,7 +63,7 @@ pub(crate) struct PreflightComplete {
     pub outcome: PreflightOutcome,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub(crate) enum OrderEvaluatorErr {
     #[error("{code} Config read error: {0}", code = self.code())]
     ConfigReadErr(Arc<anyhow::Error>),
@@ -70,21 +72,17 @@ pub(crate) enum OrderEvaluatorErr {
     StaleCapacity { order_id: String, elapsed_secs: u64 },
 }
 
-impl CodedError for OrderEvaluatorErr {
-    fn code(&self) -> &str {
-        match self {
-            OrderEvaluatorErr::ConfigReadErr(_) => "[B-OE-001]",
-            OrderEvaluatorErr::StaleCapacity { .. } => "[B-OE-004]",
-        }
-    }
-}
+coded_error_impl!(OrderEvaluatorErr, "OE",
+    ConfigReadErr(..)   => "001",
+    StaleCapacity { .. } => "004",
+);
 
 #[derive(Clone)]
 pub(crate) struct OrderEvaluator {
     config: ConfigLock,
-    new_order_rx: Arc<Mutex<mpsc::Receiver<Box<OrderRequest>>>>,
+    new_order_rx: SharedReceiver<Box<OrderRequest>>,
     chain_dispatchers: Arc<HashMap<u64, mpsc::Sender<Box<OrderRequest>>>>,
-    pricing_completion_rx: Arc<Mutex<mpsc::Receiver<PreflightComplete>>>,
+    pricing_completion_rx: SharedReceiver<PreflightComplete>,
     order_state_tx: broadcast::Sender<OrderStateChange>,
     priority_requestors: Arc<HashMap<u64, PriorityRequestors>>,
 }
@@ -92,17 +90,17 @@ pub(crate) struct OrderEvaluator {
 impl OrderEvaluator {
     pub fn new(
         config: ConfigLock,
-        new_order_rx: mpsc::Receiver<Box<OrderRequest>>,
+        new_order_rx: SharedReceiver<Box<OrderRequest>>,
         chain_dispatchers: HashMap<u64, mpsc::Sender<Box<OrderRequest>>>,
-        pricing_completion_rx: mpsc::Receiver<PreflightComplete>,
+        pricing_completion_rx: SharedReceiver<PreflightComplete>,
         order_state_tx: broadcast::Sender<OrderStateChange>,
         priority_requestors: HashMap<u64, PriorityRequestors>,
     ) -> Self {
         Self {
             config,
-            new_order_rx: Arc::new(Mutex::new(new_order_rx)),
+            new_order_rx,
             chain_dispatchers: Arc::new(chain_dispatchers),
-            pricing_completion_rx: Arc::new(Mutex::new(pricing_completion_rx)),
+            pricing_completion_rx,
             order_state_tx,
             priority_requestors: Arc::new(priority_requestors),
         }
@@ -246,150 +244,146 @@ impl OrderEvaluator {
     }
 }
 
-impl RetryTask for OrderEvaluator {
+impl BrokerService for OrderEvaluator {
     type Error = OrderEvaluatorErr;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let evaluator = self.clone();
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting order evaluator");
 
-        Box::pin(async move {
-            tracing::info!("Starting order evaluator");
+        let (mut max_concurrent_preflights, mut priority_mode, static_addresses) =
+            self.read_config().map_err(SupervisorErr::Fault)?;
+        let mut priority_addresses = self.collect_priority_addresses(static_addresses);
 
-            let (mut max_concurrent_preflights, mut priority_mode, static_addresses) =
-                evaluator.read_config().map_err(SupervisorErr::Fault)?;
-            let mut priority_addresses = evaluator.collect_priority_addresses(static_addresses);
+        let mut order_rx = self.new_order_rx.lock().await;
+        let mut pricing_completion_rx = self.pricing_completion_rx.lock().await;
+        let mut order_state_rx = self.order_state_tx.subscribe();
+        let mut capacity_check_interval = tokio::time::interval(MIN_CAPACITY_CHECK_INTERVAL);
 
-            let mut order_rx = evaluator.new_order_rx.lock().await;
-            let mut pricing_completion_rx = evaluator.pricing_completion_rx.lock().await;
-            let mut order_state_rx = evaluator.order_state_tx.subscribe();
-            let mut capacity_check_interval = tokio::time::interval(MIN_CAPACITY_CHECK_INTERVAL);
+        let mut pending_orders: Vec<Box<OrderRequest>> = Vec::new();
+        let mut in_flight: HashMap<String, Instant> = HashMap::new();
 
-            let mut pending_orders: Vec<Box<OrderRequest>> = Vec::new();
-            let mut in_flight: HashMap<String, Instant> = HashMap::new();
+        loop {
+            tokio::select! {
+                Some(order) = order_rx.recv() => {
+                    let order_id = order.id();
+                    let chain_id = order.chain_id;
+                    pending_orders.push(order);
+                    tracing::debug!(
+                        chain_id,
+                        "Evaluator queued order {order_id} ({} pending [{}], {} in-flight)",
+                        pending_orders.len(),
+                        Self::format_per_chain_counts(&pending_orders),
+                        in_flight.len(),
+                    );
+                }
 
-            loop {
-                tokio::select! {
-                    Some(order) = order_rx.recv() => {
-                        let order_id = order.id();
-                        let chain_id = order.chain_id;
-                        pending_orders.push(order);
+                Some(completion) = pricing_completion_rx.recv() => {
+                    if in_flight.remove(&completion.order_id).is_some() {
                         tracing::debug!(
-                            chain_id,
-                            "Evaluator queued order {order_id} ({} pending [{}], {} in-flight)",
-                            pending_orders.len(),
-                            Self::format_per_chain_counts(&pending_orders),
+                            chain_id = completion.chain_id,
+                            "Preflight complete for order {} ({}), {} in-flight remaining",
+                            completion.order_id,
+                            completion.outcome,
                             in_flight.len(),
                         );
-                    }
-
-                    Some(completion) = pricing_completion_rx.recv() => {
-                        if in_flight.remove(&completion.order_id).is_some() {
-                            tracing::debug!(
-                                chain_id = completion.chain_id,
-                                "Preflight complete for order {} ({}), {} in-flight remaining",
-                                completion.order_id,
-                                completion.outcome,
-                                in_flight.len(),
-                            );
-                        } else {
-                            tracing::trace!(
-                                chain_id = completion.chain_id,
-                                "Received completion for order {} not in in-flight map (possibly reaped)",
-                                completion.order_id,
-                            );
-                        }
-                    }
-
-                    Ok(state_change) = order_state_rx.recv() => {
-                        match state_change {
-                            OrderStateChange::Locked { request_id, chain_id, .. } => {
-                                tracing::debug!(
-                                    chain_id,
-                                    "Evaluator: request 0x{:x} locked, removing pending LockAndFulfill orders",
-                                    request_id,
-                                );
-                                let initial_len = pending_orders.len();
-                                pending_orders.retain(|order| {
-                                    let same_request = U256::from(order.request.id) == request_id;
-                                    let same_chain = order.chain_id == chain_id;
-                                    let is_lock_and_fulfill = order.fulfillment_type == FulfillmentType::LockAndFulfill;
-                                    !(same_request && same_chain && is_lock_and_fulfill)
-                                });
-                                let removed = initial_len - pending_orders.len();
-                                if removed > 0 {
-                                    tracing::debug!(
-                                        "Removed {removed} LockAndFulfill orders from preflight queue for locked request 0x{:x}",
-                                        request_id,
-                                    );
-                                }
-                            }
-                            OrderStateChange::Fulfilled { request_id, chain_id } => {
-                                tracing::debug!(
-                                    chain_id,
-                                    "Evaluator: request 0x{:x} fulfilled, removing all pending orders",
-                                    request_id,
-                                );
-                                let initial_len = pending_orders.len();
-                                pending_orders.retain(|order| {
-                                    !(U256::from(order.request.id) == request_id && order.chain_id == chain_id)
-                                });
-                                let removed = initial_len - pending_orders.len();
-                                if removed > 0 {
-                                    tracing::debug!(
-                                        "Removed {removed} orders from preflight queue for fulfilled request 0x{:x}",
-                                        request_id,
-                                    );
-                                }
-                            }
-                        }
-                    }
-
-                    _ = capacity_check_interval.tick() => {
-                        let (new_capacity, new_priority, new_static_addresses) =
-                            evaluator.read_config().map_err(SupervisorErr::Fault)?;
-
-                        if new_capacity != max_concurrent_preflights {
-                            tracing::debug!(
-                                "Evaluator preflight capacity changed from {} to {}",
-                                max_concurrent_preflights, new_capacity,
-                            );
-                            max_concurrent_preflights = new_capacity;
-                        }
-                        if new_priority != priority_mode {
-                            tracing::debug!(
-                                "Evaluator pricing priority changed from {:?} to {:?}",
-                                priority_mode, new_priority,
-                            );
-                            priority_mode = new_priority;
-                        }
-                        priority_addresses =
-                            evaluator.collect_priority_addresses(new_static_addresses);
-
-                        Self::reap_stale_capacity(
-                            &mut in_flight,
-                            DEFAULT_MAX_PREFLIGHT_DURATION_SECS,
+                    } else {
+                        tracing::trace!(
+                            chain_id = completion.chain_id,
+                            "Received completion for order {} not in in-flight map (possibly reaped)",
+                            completion.order_id,
                         );
-                    }
-
-                    _ = cancel_token.cancelled() => {
-                        tracing::info!("Order evaluator received cancellation, shutting down");
-                        break;
                     }
                 }
 
-                evaluator.update_pending_preflight_telemetry(&pending_orders);
+                Ok(state_change) = order_state_rx.recv() => {
+                    match state_change {
+                        OrderStateChange::Locked { request_id, chain_id, .. } => {
+                            tracing::debug!(
+                                chain_id,
+                                "Evaluator: request 0x{:x} locked, removing pending LockAndFulfill orders",
+                                request_id,
+                            );
+                            let initial_len = pending_orders.len();
+                            pending_orders.retain(|order| {
+                                let same_request = U256::from(order.request.id) == request_id;
+                                let same_chain = order.chain_id == chain_id;
+                                let is_lock_and_fulfill = order.fulfillment_type == FulfillmentType::LockAndFulfill;
+                                !(same_request && same_chain && is_lock_and_fulfill)
+                            });
+                            let removed = initial_len - pending_orders.len();
+                            if removed > 0 {
+                                tracing::debug!(
+                                    "Removed {removed} LockAndFulfill orders from preflight queue for locked request 0x{:x}",
+                                    request_id,
+                                );
+                            }
+                        }
+                        OrderStateChange::Fulfilled { request_id, chain_id } => {
+                            tracing::debug!(
+                                chain_id,
+                                "Evaluator: request 0x{:x} fulfilled, removing all pending orders",
+                                request_id,
+                            );
+                            let initial_len = pending_orders.len();
+                            pending_orders.retain(|order| {
+                                !(U256::from(order.request.id) == request_id && order.chain_id == chain_id)
+                            });
+                            let removed = initial_len - pending_orders.len();
+                            if removed > 0 {
+                                tracing::debug!(
+                                    "Removed {removed} orders from preflight queue for fulfilled request 0x{:x}",
+                                    request_id,
+                                );
+                            }
+                        }
+                    }
+                }
 
-                evaluator.dispatch_pending(
-                    &mut pending_orders,
-                    &mut in_flight,
-                    max_concurrent_preflights,
-                    priority_mode,
-                    &priority_addresses,
-                );
+                _ = capacity_check_interval.tick() => {
+                    let (new_capacity, new_priority, new_static_addresses) =
+                        self.read_config().map_err(SupervisorErr::Fault)?;
+
+                    if new_capacity != max_concurrent_preflights {
+                        tracing::debug!(
+                            "Evaluator preflight capacity changed from {} to {}",
+                            max_concurrent_preflights, new_capacity,
+                        );
+                        max_concurrent_preflights = new_capacity;
+                    }
+                    if new_priority != priority_mode {
+                        tracing::debug!(
+                            "Evaluator pricing priority changed from {:?} to {:?}",
+                            priority_mode, new_priority,
+                        );
+                        priority_mode = new_priority;
+                    }
+                    priority_addresses =
+                        self.collect_priority_addresses(new_static_addresses);
+
+                    Self::reap_stale_capacity(
+                        &mut in_flight,
+                        DEFAULT_MAX_PREFLIGHT_DURATION_SECS,
+                    );
+                }
+
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Order evaluator received cancellation, shutting down");
+                    break;
+                }
             }
 
-            Ok(())
-        })
+            self.update_pending_preflight_telemetry(&pending_orders);
+
+            self.dispatch_pending(
+                &mut pending_orders,
+                &mut in_flight,
+                max_concurrent_preflights,
+                priority_mode,
+                &priority_addresses,
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -447,8 +441,8 @@ mod tests {
         let config = ConfigLock::default();
         config.load_write().unwrap().market.max_concurrent_preflights = max_concurrent_preflights;
 
-        let (order_tx, order_rx) = mpsc::channel(100);
-        let (pricing_completion_tx, pricing_completion_rx) = mpsc::channel(100);
+        let (order_tx, order_rx) = crate::channels::shared_channel(100);
+        let (pricing_completion_tx, pricing_completion_rx) = crate::channels::shared_channel(100);
         let (state_tx, _) = broadcast::channel(100);
 
         let mut dispatchers = HashMap::new();
@@ -497,7 +491,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         let pricer_rx = pricer_rxs.get_mut(&1).unwrap();
@@ -526,7 +520,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         let pricer_rx = pricer_rxs.get_mut(&1).unwrap();
@@ -565,7 +559,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         let pricer_rx = pricer_rxs.get_mut(&1).unwrap();
@@ -623,7 +617,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         let pricer_rx = pricer_rxs.get_mut(&1).unwrap();
@@ -672,7 +666,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         order_tx.send(make_order(1, 0, FulfillmentType::LockAndFulfill)).await.unwrap();
@@ -712,7 +706,7 @@ mod tests {
 
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         let chain_1_rx = pricer_rxs.get_mut(&1).unwrap();
@@ -735,8 +729,8 @@ mod tests {
         let config = ConfigLock::default();
         config.load_write().unwrap().market.max_concurrent_preflights = 1;
 
-        let (order_tx, order_rx) = mpsc::channel(100);
-        let (pricing_completion_tx, pricing_completion_rx) = mpsc::channel(100);
+        let (order_tx, order_rx) = crate::channels::shared_channel(100);
+        let (pricing_completion_tx, pricing_completion_rx) = crate::channels::shared_channel(100);
         let (state_tx, _) = broadcast::channel(100);
         let (pricer_tx, mut pricer_rx) = mpsc::channel(100);
 
@@ -757,7 +751,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let handle = tokio::spawn({
             let cancel = cancel.clone();
-            async move { evaluator.spawn(cancel).await }
+            async move { evaluator.run(cancel).await }
         });
 
         // Send 3 orders, capacity = 1

--- a/crates/broker/src/order_locker.rs
+++ b/crates/broker/src/order_locker.rs
@@ -30,12 +30,14 @@
 
 use crate::{
     chain_monitor::{ChainHead, ChainMonitorObj},
+    channels::SharedReceiver,
+    coded_error_impl,
     config::ConfigLock,
     db::DbObj,
     errors::CodedError,
-    impl_coded_debug, now_timestamp,
+    now_timestamp,
     order_committer::{CommitmentComplete, CommitmentOutcome},
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     utils, Erc1271GasCache, FulfillmentType, OrderRequest,
 };
 use alloy::{
@@ -58,7 +60,7 @@ use boundless_market::{
 };
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use thiserror::Error;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 fn estimate_proving_time_no_load(
@@ -108,21 +110,15 @@ pub enum OrderLockerErr {
     PreLockCheckRetry(String),
 }
 
-impl_coded_debug!(OrderLockerErr);
-
-impl CodedError for OrderLockerErr {
-    fn code(&self) -> &str {
-        match self {
-            OrderLockerErr::LockTxNotConfirmed(_) => "[B-OL-006]",
-            OrderLockerErr::LockTxFailed(_) => "[B-OL-007]",
-            OrderLockerErr::AlreadyLocked => "[B-OL-009]",
-            OrderLockerErr::InsufficientBalance => "[B-OL-010]",
-            OrderLockerErr::RpcErr(_) => "[B-OL-011]",
-            OrderLockerErr::PreLockCheckRetry(_) => "[B-OL-012]",
-            OrderLockerErr::UnexpectedError(_) => "[B-OL-500]",
-        }
-    }
-}
+coded_error_impl!(OrderLockerErr, "OL",
+    LockTxNotConfirmed(..)  => "006",
+    LockTxFailed(..)        => "007",
+    AlreadyLocked           => "009",
+    InsufficientBalance     => "010",
+    RpcErr(..)              => "011",
+    PreLockCheckRetry(..)   => "012",
+    UnexpectedError(..)     => "500",
+);
 
 #[derive(Default)]
 pub(crate) struct OrderLockerConfig {
@@ -152,7 +148,7 @@ pub struct OrderLocker<P> {
     market: BoundlessMarketService<Arc<P>>,
     provider: Arc<P>,
     prover_addr: Address,
-    priced_order_rx: Arc<Mutex<mpsc::Receiver<Box<OrderRequest>>>>,
+    priced_order_rx: SharedReceiver<Box<OrderRequest>>,
     supported_selectors: SupportedSelectors,
     erc1271_gas_cache: Erc1271GasCache,
     rpc_retry_config: RpcRetryConfig,
@@ -176,7 +172,7 @@ where
         block_time: u64,
         prover_addr: Address,
         market_addr: Address,
-        priced_orders_rx: mpsc::Receiver<Box<OrderRequest>>,
+        priced_orders_rx: SharedReceiver<Box<OrderRequest>>,
         collateral_token_decimals: u8,
         rpc_retry_config: RpcRetryConfig,
         gas_priority_mode: Arc<tokio::sync::RwLock<PriorityMode>>,
@@ -221,7 +217,7 @@ where
             market,
             provider,
             prover_addr,
-            priced_order_rx: Arc::new(Mutex::new(priced_orders_rx)),
+            priced_order_rx: priced_orders_rx,
             supported_selectors: SupportedSelectors::default(),
             erc1271_gas_cache,
             rpc_retry_config,
@@ -994,18 +990,15 @@ where
     }
 }
 
-impl<P> RetryTask for OrderLocker<P>
+impl<P> BrokerService for OrderLocker<P>
 where
-    P: Provider<Ethereum> + WalletProvider + 'static + Clone,
+    P: Provider<Ethereum> + WalletProvider + Clone + Send + Sync + 'static,
 {
     type Error = OrderLockerErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let monitor_clone = self.clone();
-        Box::pin(async move {
-            tracing::info!("Starting order locker");
-            monitor_clone.start_monitor(cancel_token).await.map_err(SupervisorErr::Recover)?;
-            Ok(())
-        })
+
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting order locker");
+        self.start_monitor(cancel_token).await.map_err(SupervisorErr::Recover)
     }
 }
 
@@ -1163,10 +1156,10 @@ pub(crate) mod tests {
         let chain_monitor_service = Arc::new(
             ChainMonitorService::new(provider.clone(), gas_estimation_priority_mode).await.unwrap(),
         );
-        tokio::spawn(chain_monitor_service.spawn(Default::default()));
+        tokio::spawn((*chain_monitor_service).clone().run(Default::default()));
         let chain_monitor: ChainMonitorObj = chain_monitor_service;
 
-        let (priced_order_tx, priced_order_rx) = mpsc::channel(16);
+        let (priced_order_tx, priced_order_rx) = crate::channels::shared_channel(16);
 
         let gas_priority_mode = Arc::new(tokio::sync::RwLock::new(PriorityMode::Medium));
         let gas_estimation_priority_mode =

--- a/crates/broker/src/order_pricer.rs
+++ b/crates/broker/src/order_pricer.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use crate::OrderPricingOutcome::{Lock, ProveAfterLockExpire, Skip};
 use crate::{
     chain_monitor::ChainMonitorObj,
+    channels::SharedReceiver,
     config::{ConfigLock, MarketConfig},
     db::DbObj,
     errors::CodedError,
@@ -26,7 +27,7 @@ use crate::{
     order_evaluator::{PreflightComplete, PreflightOutcome},
     provers::ProverObj,
     requestor_monitor::{AllowRequestors, PriorityRequestors},
-    task::{RetryRes, RetryTask},
+    task::{BrokerService, SupervisorErr},
     utils, ConfigurableDownloader, Erc1271GasCache, FulfillmentType, OrderPricingContext,
     OrderPricingError, OrderPricingOutcome, OrderRequest, OrderStateChange, PreflightCache,
 };
@@ -45,7 +46,7 @@ use boundless_market::{
 };
 use moka::{future::Cache, policy::EvictionPolicy};
 use tokio::{
-    sync::{broadcast, mpsc, Mutex},
+    sync::{broadcast, mpsc},
     task::JoinSet,
 };
 use tokio_util::sync::CancellationToken;
@@ -151,6 +152,9 @@ const PREFLIGHT_CACHE_TTL_SECS: u64 = 3 * 60 * 60; // 3 hours
 
 type OrderPricerErr = OrderPricingError;
 
+// `coded_error_impl!` doesn't fit here: OrderPricingError is a foreign type
+// (defined in boundless_market::prover_utils) and is `#[non_exhaustive]`, so
+// the match needs a wildcard arm. Keep the manual impl.
 impl CodedError for OrderPricingError {
     fn code(&self) -> &str {
         match self {
@@ -173,8 +177,7 @@ pub struct OrderPricer<P> {
     chain_monitor: ChainMonitorObj,
     market: BoundlessMarketService<Arc<P>>,
     supported_selectors: SupportedSelectors,
-    // TODO ideal not to wrap in mutex, but otherwise would require supervisor refactor, try to find alternative
-    new_order_rx: Arc<Mutex<mpsc::Receiver<Box<OrderRequest>>>>,
+    new_order_rx: SharedReceiver<Box<OrderRequest>>,
     priced_orders_tx: mpsc::Sender<Box<OrderRequest>>,
     collateral_token_decimals: u8,
     order_cache: OrderCache,
@@ -202,7 +205,7 @@ where
         market_addr: Address,
         provider: Arc<P>,
         chain_monitor: ChainMonitorObj,
-        new_order_rx: mpsc::Receiver<Box<OrderRequest>>,
+        new_order_rx: SharedReceiver<Box<OrderRequest>>,
         order_result_tx: mpsc::Sender<Box<OrderRequest>>,
         collateral_token_decimals: u8,
         order_state_tx: broadcast::Sender<OrderStateChange>,
@@ -229,7 +232,7 @@ where
             chain_monitor,
             market,
             supported_selectors: SupportedSelectors::default(),
-            new_order_rx: Arc::new(Mutex::new(new_order_rx)),
+            new_order_rx,
             priced_orders_tx: order_result_tx,
             collateral_token_decimals,
             order_cache: Arc::new(
@@ -684,125 +687,122 @@ where
     }
 }
 
-impl<P> RetryTask for OrderPricer<P>
+impl<P> BrokerService for OrderPricer<P>
 where
-    P: Provider<Ethereum> + 'static + Clone + WalletProvider,
+    P: Provider<Ethereum> + WalletProvider + Clone + Send + Sync + 'static,
 {
     type Error = OrderPricerErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let pricer = self.clone();
 
-        Box::pin(async move {
-            tracing::info!("Starting order pricer");
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting order pricer");
 
-            let mut tasks: JoinSet<(String, U256, PreflightOutcome)> = JoinSet::new();
-            let mut rx = pricer.new_order_rx.lock().await;
-            let mut order_state_rx = pricer.order_state_tx.subscribe();
-            let mut active_preflights = ActivePreflights::default();
-            let mut last_preflights_log: String = String::new();
-            let mut log_interval = tokio::time::interval(LOG_INTERVAL);
+        let mut tasks: JoinSet<(String, U256, PreflightOutcome)> = JoinSet::new();
+        let mut rx = self.new_order_rx.lock().await;
+        let mut order_state_rx = self.order_state_tx.subscribe();
+        let mut active_preflights = ActivePreflights::default();
+        let mut last_preflights_log: String = String::new();
+        let mut log_interval = tokio::time::interval(LOG_INTERVAL);
 
-            loop {
-                tokio::select! {
-                    Some(order) = rx.recv() => {
-                        let order_id = order.id();
-                        let request_id = U256::from(order.request.id);
-                        let chain_id = order.chain_id;
+        loop {
+            tokio::select! {
+                Some(order) = rx.recv() => {
+                    let order_id = order.id();
+                    let request_id = U256::from(order.request.id);
+                    let chain_id = order.chain_id;
 
-                        if active_preflights.contains(&request_id, &order_id) {
-                            tracing::debug!("Skipping order {order_id} - already being processed");
-                            let _ = pricer.pricing_completion_tx.try_send(PreflightComplete {
-                                order_id,
-                                request_id,
-                                chain_id,
-                                outcome: PreflightOutcome::Skipped,
-                            });
-                            continue;
-                        }
-
-                        if pricer.order_cache.get(&order_id).await.is_some() {
-                            tracing::debug!("Skipping duplicate order {order_id}, already being processed");
-                            let _ = pricer.pricing_completion_tx.try_send(PreflightComplete {
-                                order_id,
-                                request_id,
-                                chain_id,
-                                outcome: PreflightOutcome::Skipped,
-                            });
-                            continue;
-                        }
-
-                        pricer.order_cache.insert(order_id.clone(), ()).await;
-
-                        let pricer_clone = pricer.clone();
-                        let task_cancel_token = cancel_token.child_token();
-
-                        active_preflights.insert(&order, task_cancel_token.clone());
-
-                        tasks.spawn(async move {
-                            let accepted = pricer_clone
-                                .price_order_and_update_state(order, task_cancel_token.clone())
-                                .await;
-                            let outcome = match (accepted, task_cancel_token.is_cancelled()) {
-                                (true, _) => PreflightOutcome::Priced,
-                                (false, true) => PreflightOutcome::Cancelled,
-                                (false, false) => PreflightOutcome::Skipped,
-                            };
-                            (order_id, request_id, outcome)
-                        }.instrument(Span::current()));
+                    if active_preflights.contains(&request_id, &order_id) {
+                        tracing::debug!("Skipping order {order_id} - already being processed");
+                        let _ = self.pricing_completion_tx.try_send(PreflightComplete {
+                            order_id,
+                            request_id,
+                            chain_id,
+                            outcome: PreflightOutcome::Skipped,
+                        });
+                        continue;
                     }
-                    Ok(state_change) = order_state_rx.recv() => {
-                        if state_change.chain_id() != pricer.chain_id {
-                            continue;
-                        }
-                        match state_change {
-                            OrderStateChange::Locked { request_id, prover, .. } => {
-                                tracing::debug!("Received order state change for request 0x{:x}: Locked by prover 0x{:x}",
-                                    request_id, prover);
-                                active_preflights.cancel_lock_and_fulfill(&request_id);
-                            }
-                            OrderStateChange::Fulfilled { request_id, .. } => {
-                                tracing::debug!("Received order state change for request 0x{:x}: Fulfilled",
-                                    request_id);
-                                active_preflights.cancel_all(&request_id);
-                            }
-                        }
-                    }
-                    Some(result) = tasks.join_next(), if !tasks.is_empty() => {
-                        match result {
-                            Ok((order_id, request_id, outcome)) => {
-                                active_preflights.remove(&request_id, &order_id);
 
-                                let _ = pricer.pricing_completion_tx.try_send(PreflightComplete {
-                                    order_id: order_id.clone(),
-                                    request_id,
-                                    chain_id: pricer.chain_id,
-                                    outcome,
-                                });
+                    if self.order_cache.get(&order_id).await.is_some() {
+                        tracing::debug!("Skipping duplicate order {order_id}, already being processed");
+                        let _ = self.pricing_completion_tx.try_send(PreflightComplete {
+                            order_id,
+                            request_id,
+                            chain_id,
+                            outcome: PreflightOutcome::Skipped,
+                        });
+                        continue;
+                    }
 
-                                tracing::trace!("Priced task for order {} (request 0x{:x}) completed with {outcome} ({} remaining)",
-                                    order_id, request_id, tasks.len());
-                            }
-                            Err(e) => {
-                                tracing::error!("Pricing task panicked: {e}");
-                            }
-                        }
+                    self.order_cache.insert(order_id.clone(), ()).await;
+
+                    let pricer_clone = self.clone();
+                    let task_cancel_token = cancel_token.child_token();
+
+                    active_preflights.insert(&order, task_cancel_token.clone());
+
+                    tasks.spawn(async move {
+                        let accepted = pricer_clone
+                            .price_order_and_update_state(order, task_cancel_token.clone())
+                            .await;
+                        let outcome = match (accepted, task_cancel_token.is_cancelled()) {
+                            (true, _) => PreflightOutcome::Priced,
+                            (false, true) => PreflightOutcome::Cancelled,
+                            (false, false) => PreflightOutcome::Skipped,
+                        };
+                        (order_id, request_id, outcome)
+                    }.instrument(Span::current()));
+                }
+                Ok(state_change) = order_state_rx.recv() => {
+                    if state_change.chain_id() != self.chain_id {
+                        continue;
                     }
-                    _ = log_interval.tick() => {
-                        let current_log = active_preflights.format();
-                        if last_preflights_log != current_log {
-                            tracing::debug!("Active preflights: [{}]", current_log);
-                            last_preflights_log = current_log;
+                    match state_change {
+                        OrderStateChange::Locked { request_id, prover, .. } => {
+                            tracing::debug!("Received order state change for request 0x{:x}: Locked by prover 0x{:x}",
+                                request_id, prover);
+                            active_preflights.cancel_lock_and_fulfill(&request_id);
                         }
-                    }
-                    _ = cancel_token.cancelled() => {
-                        tracing::debug!("Order pricer received cancellation, shutting down gracefully");
-                        while tasks.join_next().await.is_some() {}
-                        break;
+                        OrderStateChange::Fulfilled { request_id, .. } => {
+                            tracing::debug!("Received order state change for request 0x{:x}: Fulfilled",
+                                request_id);
+                            active_preflights.cancel_all(&request_id);
+                        }
                     }
                 }
+                Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                    match result {
+                        Ok((order_id, request_id, outcome)) => {
+                            active_preflights.remove(&request_id, &order_id);
+
+                            let _ = self.pricing_completion_tx.try_send(PreflightComplete {
+                                order_id: order_id.clone(),
+                                request_id,
+                                chain_id: self.chain_id,
+                                outcome,
+                            });
+
+                            tracing::trace!("Priced task for order {} (request 0x{:x}) completed with {outcome} ({} remaining)",
+                                order_id, request_id, tasks.len());
+                        }
+                        Err(e) => {
+                            tracing::error!("Pricing task panicked: {e}");
+                        }
+                    }
+                }
+                _ = log_interval.tick() => {
+                    let current_log = active_preflights.format();
+                    if last_preflights_log != current_log {
+                        tracing::debug!("Active preflights: [{}]", current_log);
+                        last_preflights_log = current_log;
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Order pricer received cancellation, shutting down gracefully");
+                    while tasks.join_next().await.is_some() {}
+                    break;
+                }
             }
-            Ok(())
-        })
+        }
+        Ok(())
     }
 }
 
@@ -1088,7 +1088,7 @@ pub(crate) mod tests {
             let chain_monitor_service = Arc::new(
                 ChainMonitorService::new(provider.clone(), gas_priority_mode).await.unwrap(),
             );
-            tokio::spawn(chain_monitor_service.spawn(Default::default()));
+            tokio::spawn((*chain_monitor_service).clone().run(Default::default()));
             let chain_monitor: ChainMonitorObj = chain_monitor_service;
 
             let chain_id = provider.get_chain_id().await.unwrap();
@@ -1097,7 +1097,8 @@ pub(crate) mod tests {
             let downloader = ConfigurableDownloader::new(config.clone()).await.unwrap();
 
             const TEST_CHANNEL_CAPACITY: usize = 50;
-            let (_new_order_tx, new_order_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
+            let (_new_order_tx, new_order_rx) =
+                crate::channels::shared_channel(TEST_CHANNEL_CAPACITY);
             let (priced_orders_tx, priced_orders_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
             let (order_state_tx, _) = tokio::sync::broadcast::channel(TEST_CHANNEL_CAPACITY);
             let (pricing_completion_tx, _completion_rx) = mpsc::channel(TEST_CHANNEL_CAPACITY);
@@ -1609,7 +1610,7 @@ pub(crate) mod tests {
         let _request_id =
             ctx.boundless_market.submit_request(&order.request, &ctx.signer(0)).await.unwrap();
 
-        let pricing_task = tokio::spawn(ctx.pricer.spawn(Default::default()));
+        let pricing_task = tokio::spawn(ctx.pricer.clone().run(Default::default()));
 
         ctx.new_order_tx.send(order).await.unwrap();
 
@@ -1630,7 +1631,7 @@ pub(crate) mod tests {
 
         assert!(ctx.priced_orders_rx.is_empty());
 
-        tokio::spawn(ctx.pricer.spawn(Default::default()));
+        tokio::spawn(ctx.pricer.clone().run(Default::default()));
 
         let priced_order =
             tokio::time::timeout(Duration::from_secs(10), ctx.priced_orders_rx.recv())
@@ -2082,7 +2083,7 @@ pub(crate) mod tests {
 
         assert_eq!(order1.id(), order2.id(), "Both orders should have the same ID");
 
-        tokio::spawn(ctx.pricer.spawn(CancellationToken::new()));
+        tokio::spawn(ctx.pricer.clone().run(CancellationToken::new()));
 
         ctx.new_order_tx.send(order1).await?;
         ctx.new_order_tx.send(order2).await?;
@@ -2139,7 +2140,7 @@ pub(crate) mod tests {
         let mut ctx = PricerTestCtxBuilder::default().with_config(config).build().await;
 
         // Start the order pricer task
-        let pricer_task = tokio::spawn(ctx.pricer.spawn(Default::default()));
+        let pricer_task = tokio::spawn(ctx.pricer.clone().run(Default::default()));
 
         // Send an order to trigger the logging
         let order1 =

--- a/crates/broker/src/price_oracle.rs
+++ b/crates/broker/src/price_oracle.rs
@@ -22,9 +22,7 @@ impl BrokerService for PriceOracleManager {
 
     async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
         tracing::info!("Starting price oracle refresh task");
-        self.start_oracle(cancel_token).await.map_err(SupervisorErr::Recover)?;
-        Ok(())
-        }
+        self.start_oracle(cancel_token).await.map_err(SupervisorErr::Recover)
     }
 }
 

--- a/crates/broker/src/price_oracle.rs
+++ b/crates/broker/src/price_oracle.rs
@@ -13,29 +13,30 @@
 // limitations under the License.
 
 use crate::errors::CodedError;
-use crate::task::{RetryRes, RetryTask, SupervisorErr};
+use crate::task::{BrokerService, SupervisorErr};
 use boundless_market::price_oracle::{PriceOracleError, PriceOracleManager};
 use tokio_util::sync::CancellationToken;
 
-impl RetryTask for PriceOracleManager {
+impl BrokerService for PriceOracleManager {
     type Error = PriceOracleError;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let manager = self.clone();
-        Box::pin(async move {
-            tracing::info!("Starting price oracle refresh task");
-            manager.start_oracle(cancel_token).await.map_err(|err| match err {
-                PriceOracleError::UpdateTimeout() => {
-                    tracing::error!("Price oracle could not refresh prices for too long, if this continues consider setting static prices in the config for `eth_usd` and `zkc_usd`: {}", err);
-                    SupervisorErr::Recover(err)
-                },
-                _ => SupervisorErr::Recover(err),
-            })?;
-            Ok(())
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting price oracle refresh task");
+        self.start_oracle(cancel_token).await.map_err(|err| {
+            if matches!(err, PriceOracleError::UpdateTimeout()) {
+                tracing::error!(
+                    "Price oracle could not refresh prices for too long, if this continues consider setting static prices in the config for `eth_usd` and `zkc_usd`: {}",
+                    err
+                );
+            }
+            SupervisorErr::Recover(err)
         })
     }
 }
 
+// `coded_error_impl!` doesn't fit here: PriceOracleError is a foreign type
+// from `boundless_market::price_oracle` and its variants live upstream.
+// Delegate to the upstream-provided `code()` method instead.
 impl CodedError for PriceOracleError {
     fn code(&self) -> &str {
         PriceOracleError::code(self)

--- a/crates/broker/src/proving.rs
+++ b/crates/broker/src/proving.rs
@@ -17,17 +17,18 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 
 use crate::{
+    coded_error_impl,
     config::ConfigLock,
     db::DbObj,
     errors::CodedError,
     errors::{cancel_proof_and_fail, handle_order_failure, BrokerFailure},
     futures_retry::retry_with_context,
-    impl_coded_debug, now_timestamp,
+    now_timestamp,
     order_committer::{CommitmentComplete, CommitmentOutcome},
     provers::{self, ProverObj},
     requestor_monitor::PriorityRequestors,
     storage::{upload_image_uri, upload_input_uri},
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     CompressionType, ConfigurableDownloader, FulfillmentType, Order, OrderStateChange, OrderStatus,
 };
 use alloy::providers::DynProvider;
@@ -65,20 +66,14 @@ pub enum ProvingErr {
     UnexpectedError(#[from] anyhow::Error),
 }
 
-impl_coded_debug!(ProvingErr);
-
-impl CodedError for ProvingErr {
-    fn code(&self) -> &str {
-        match self {
-            ProvingErr::ProvingFailed(_) => "[B-PRO-501]",
-            ProvingErr::CancelFulfilledByAnother => "[B-PRO-502]",
-            ProvingErr::CancelExpired => "[B-PRO-503]",
-            ProvingErr::CompletedFulfilledByAnother => "[B-PRO-505]",
-            ProvingErr::CompletedExpired => "[B-PRO-506]",
-            ProvingErr::UnexpectedError(_) => "[B-PRO-500]",
-        }
-    }
-}
+coded_error_impl!(ProvingErr, "PRO",
+    ProvingFailed(..)            => "501",
+    CancelFulfilledByAnother     => "502",
+    CancelExpired                => "503",
+    CompletedFulfilledByAnother  => "505",
+    CompletedExpired             => "506",
+    UnexpectedError(..)          => "500",
+);
 
 impl ProvingErr {
     fn completion_outcome(&self) -> CompletionOutcome {
@@ -623,54 +618,52 @@ impl ProvingService {
     }
 }
 
-impl RetryTask for ProvingService {
+impl BrokerService for ProvingService {
     type Error = ProvingErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let proving_service_copy = self.clone();
-        Box::pin(async move {
-            tracing::info!("Starting proving service");
 
-            // First search the DB for any existing dangling proofs and kick off their concurrent
-            // monitors
-            proving_service_copy.find_and_monitor_proofs().await.map_err(SupervisorErr::Fault)?;
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting proving service");
 
-            // Start monitoring for new proofs
-            let mut proving_interval = tokio::time::interval(Duration::from_millis(500));
-            proving_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                if cancel_token.is_cancelled() {
-                    tracing::debug!("Proving service received cancellation");
-                    break;
-                }
+        // First search the DB for any existing dangling proofs and kick off their concurrent
+        // monitors
+        self.find_and_monitor_proofs().await.map_err(SupervisorErr::Fault)?;
 
-                // TODO: parallel_proofs management
-                // we need to query the Bento/Bonsai backend and constrain the number of running
-                // parallel proofs currently bonsai does not have this feature but
-                // we could add it to both to support it. Alternatively we could
-                // track it in our local DB but that could de-sync from the proving-backend so
-                // its not ideal
-                let order_res = proving_service_copy
-                    .db
-                    .get_proving_order()
-                    .await
-                    .context("Failed to get proving order")
-                    .map_err(ProvingErr::UnexpectedError)
-                    .map_err(SupervisorErr::Recover)?;
-
-                if let Some(order) = order_res {
-                    let prov_serv = proving_service_copy.clone();
-                    let span = Span::current();
-                    tokio::spawn(
-                        async move { prov_serv.prove_and_update_db(order).await }.instrument(span),
-                    );
-                }
-
-                // TODO: configuration
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        // Start monitoring for new proofs
+        let mut proving_interval = tokio::time::interval(Duration::from_millis(500));
+        proving_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            if cancel_token.is_cancelled() {
+                tracing::debug!("Proving service received cancellation");
+                break;
             }
 
-            Ok(())
-        })
+            // TODO: parallel_proofs management
+            // we need to query the Bento/Bonsai backend and constrain the number of running
+            // parallel proofs currently bonsai does not have this feature but
+            // we could add it to both to support it. Alternatively we could
+            // track it in our local DB but that could de-sync from the proving-backend so
+            // its not ideal
+            let order_res = self
+                .db
+                .get_proving_order()
+                .await
+                .context("Failed to get proving order")
+                .map_err(ProvingErr::UnexpectedError)
+                .map_err(SupervisorErr::Recover)?;
+
+            if let Some(order) = order_res {
+                let prov_serv = self.clone();
+                let span = Span::current();
+                tokio::spawn(
+                    async move { prov_serv.prove_and_update_db(order).await }.instrument(span),
+                );
+            }
+
+            // TODO: configuration
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/broker/src/reaper.rs
+++ b/crates/broker/src/reaper.rs
@@ -14,7 +14,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -24,15 +23,16 @@ use boundless_market::telemetry::CompletionOutcome;
 use tokio::sync::mpsc;
 
 use crate::{
+    coded_error_impl,
     config::{ConfigErr, ConfigLock},
     db::{DbError, DbObj},
     errors::{cancel_proof_and_fail, BrokerFailure, CodedError},
     order_committer::CommitmentComplete,
     provers::ProverObj,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
 };
 
-#[derive(Error, Debug)]
+#[derive(Error)]
 pub enum ReaperError {
     #[error("{code} DB error: {0}", code = self.code())]
     DbError(#[from] DbError),
@@ -41,14 +41,10 @@ pub enum ReaperError {
     ConfigReadErr(#[from] ConfigErr),
 }
 
-impl CodedError for ReaperError {
-    fn code(&self) -> &str {
-        match self {
-            ReaperError::DbError(_) => "[B-REAP-001]",
-            ReaperError::ConfigReadErr(_) => "[B-REAP-002]",
-        }
-    }
-}
+coded_error_impl!(ReaperError, "REAP",
+    DbError(..)       => "001",
+    ConfigReadErr(..) => "002",
+);
 
 #[derive(Clone)]
 pub struct ReaperTask {
@@ -129,16 +125,11 @@ impl ReaperTask {
     }
 }
 
-#[async_trait]
-impl RetryTask for ReaperTask {
+impl BrokerService for ReaperTask {
     type Error = ReaperError;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let this = self.clone();
-        Box::pin(async move {
-            this.run_reaper_loop(cancel_token).await.map_err(SupervisorErr::Recover)?;
-            Ok(())
-        })
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        self.run_reaper_loop(cancel_token).await.map_err(SupervisorErr::Recover)
     }
 }
 

--- a/crates/broker/src/requestor_monitor.rs
+++ b/crates/broker/src/requestor_monitor.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use crate::{
+    coded_error_impl,
     config::ConfigLock,
     errors::CodedError,
-    impl_coded_debug,
-    task::{RetryRes, RetryTask},
+    task::{BrokerService, SupervisorErr},
 };
 use alloy::primitives::Address;
 use anyhow::Result;
@@ -37,15 +37,9 @@ pub enum MonitorError {
     LockFailed,
 }
 
-impl_coded_debug!(MonitorError);
-
-impl CodedError for MonitorError {
-    fn code(&self) -> &str {
-        match self {
-            MonitorError::LockFailed => "[B-RM-4001]",
-        }
-    }
-}
+coded_error_impl!(MonitorError, "RM",
+    LockFailed => "4001",
+);
 
 /// Cached entry that tracks both the requestor data and its source URL
 #[derive(Clone, Debug)]
@@ -246,6 +240,7 @@ impl AllowRequestors {
 }
 
 /// Service for periodically monitoring and refreshing requestor priority and allowed lists
+#[derive(Clone)]
 pub struct RequestorMonitor {
     priority_requestors: PriorityRequestors,
     allow_requestors: AllowRequestors,
@@ -370,18 +365,12 @@ impl RequestorMonitor {
     }
 }
 
-impl RetryTask for RequestorMonitor {
+impl BrokerService for RequestorMonitor {
     type Error = MonitorError;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let priority_requestors = self.priority_requestors.clone();
-        let allow_requestors = self.allow_requestors.clone();
-        let monitor = Self { priority_requestors, allow_requestors };
-
-        Box::pin(async move {
-            monitor.monitor_loop(cancel_token).await;
-            Ok(())
-        })
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        self.monitor_loop(cancel_token).await;
+        Ok(())
     }
 }
 

--- a/crates/broker/src/service_runner.rs
+++ b/crates/broker/src/service_runner.rs
@@ -1,0 +1,282 @@
+// Copyright 2026 Boundless Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Builder for registering supervised broker services.
+//!
+//! Replaces the ~6-line `JoinSet::spawn(async move { Supervisor::new(...) ... })`
+//! block that is otherwise duplicated 18 times in `start_service` and
+//! `start_chain_pipeline`. Each registration is now a single
+//! `runner.spawn(service, Criticality::X, "label")` call.
+
+// Additive infrastructure: not consumed until `start_service` and
+// `start_chain_pipeline` are migrated to use `ServiceRunner` (C22).
+#![allow(dead_code)]
+
+use std::{future::Future, sync::Arc};
+
+use anyhow::{Context, Result};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, Span};
+
+use crate::{
+    config::ConfigLock,
+    task::{RetryPolicy, RetryTask, Supervisor},
+};
+
+/// Classifies a supervised service for shutdown ordering and retry behaviour.
+///
+/// Critical and non-critical tasks live on separate `JoinSet`s and use
+/// independent `CancellationToken`s — the shutdown protocol cancels
+/// non-critical tasks first (to stop taking new work), drains in-flight
+/// commitments, then cancels critical tasks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Criticality {
+    /// Critical task, supervised with the default [`RetryPolicy`].
+    Critical,
+    /// Critical task, supervised with [`RetryPolicy::CRITICAL_SERVICE`]
+    /// (faster retry cadence, capped at `max_critical_task_retries`).
+    CriticalWithFastRetry,
+    /// Non-critical task, supervised with the default [`RetryPolicy`].
+    NonCritical,
+}
+
+/// Decomposed parts of a [`ServiceRunner`], suitable for plugging into the
+/// existing two-phase shutdown loop in `Broker::start_service`.
+pub struct ServiceRunnerParts {
+    pub non_critical_tasks: JoinSet<Result<()>>,
+    pub critical_tasks: JoinSet<Result<()>>,
+    pub non_critical_cancel_token: CancellationToken,
+    pub critical_cancel_token: CancellationToken,
+}
+
+/// Owns the JoinSets and cancellation tokens for the broker's supervised
+/// services and provides one-line registration via [`ServiceRunner::spawn`].
+pub struct ServiceRunner {
+    config: ConfigLock,
+    critical_tasks: JoinSet<Result<()>>,
+    non_critical_tasks: JoinSet<Result<()>>,
+    critical_cancel_token: CancellationToken,
+    non_critical_cancel_token: CancellationToken,
+}
+
+impl ServiceRunner {
+    /// Creates a new runner with empty JoinSets and fresh cancellation tokens.
+    pub fn new(config: ConfigLock) -> Self {
+        Self {
+            config,
+            critical_tasks: JoinSet::new(),
+            non_critical_tasks: JoinSet::new(),
+            critical_cancel_token: CancellationToken::new(),
+            non_critical_cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// Cancellation token for non-critical tasks. Useful when a caller needs
+    /// to spawn a raw future via [`Self::spawn_future`] that consumes the token.
+    pub fn non_critical_cancel_token(&self) -> CancellationToken {
+        self.non_critical_cancel_token.clone()
+    }
+
+    /// Cancellation token for critical tasks. Symmetric counterpart to
+    /// [`Self::non_critical_cancel_token`].
+    pub fn critical_cancel_token(&self) -> CancellationToken {
+        self.critical_cancel_token.clone()
+    }
+
+    /// Registers a supervised service. Equivalent to the legacy
+    /// `tasks.spawn(async move { Supervisor::new(...) ... })` block.
+    pub fn spawn<T>(&mut self, service: Arc<T>, criticality: Criticality, label: &'static str)
+    where
+        T: RetryTask + Send + Sync + 'static,
+        T::Error: Send + Sync + 'static,
+    {
+        self.spawn_in_span(service, criticality, label, Span::current());
+    }
+
+    /// Same as [`Self::spawn`] but instruments the supervisor future with the
+    /// given span — used in `start_chain_pipeline` where each chain's services
+    /// run inside a per-chain `info_span!`.
+    pub fn spawn_in_span<T>(
+        &mut self,
+        service: Arc<T>,
+        criticality: Criticality,
+        label: &'static str,
+        span: Span,
+    ) where
+        T: RetryTask + Send + Sync + 'static,
+        T::Error: Send + Sync + 'static,
+    {
+        let config = self.config.clone();
+        let (joinset, cancel_token, retry_policy) = self.dispatch(criticality);
+        let supervisor =
+            Supervisor::new(service, config, cancel_token).with_retry_policy(retry_policy);
+        joinset.spawn(
+            async move { supervisor.spawn().await.with_context(|| format!("Failed to run {label}")) }
+                .instrument(span),
+        );
+    }
+
+    /// Registers a raw future that performs its own cancellation handling
+    /// (e.g. the telemetry service, which doesn't go through `Supervisor`).
+    pub fn spawn_future<F>(&mut self, criticality: Criticality, label: &'static str, fut: F)
+    where
+        F: Future<Output = Result<()>> + Send + 'static,
+    {
+        self.spawn_future_in_span(criticality, label, Span::current(), fut);
+    }
+
+    /// Same as [`Self::spawn_future`] but with an explicit instrumentation span.
+    pub fn spawn_future_in_span<F>(
+        &mut self,
+        criticality: Criticality,
+        label: &'static str,
+        span: Span,
+        fut: F,
+    ) where
+        F: Future<Output = Result<()>> + Send + 'static,
+    {
+        let (joinset, _cancel_token, _retry_policy) = self.dispatch(criticality);
+        joinset.spawn(
+            async move { fut.await.with_context(|| format!("Failed to run {label}")) }
+                .instrument(span),
+        );
+    }
+
+    /// Decomposes the runner into the JoinSets and tokens consumed by the
+    /// existing shutdown loop. After this call the runner cannot register
+    /// new services — that's intentional, registration happens at startup
+    /// and shutdown handling takes over.
+    pub fn into_parts(self) -> ServiceRunnerParts {
+        ServiceRunnerParts {
+            non_critical_tasks: self.non_critical_tasks,
+            critical_tasks: self.critical_tasks,
+            non_critical_cancel_token: self.non_critical_cancel_token,
+            critical_cancel_token: self.critical_cancel_token,
+        }
+    }
+
+    fn dispatch(
+        &mut self,
+        criticality: Criticality,
+    ) -> (&mut JoinSet<Result<()>>, CancellationToken, RetryPolicy) {
+        match criticality {
+            Criticality::Critical => (
+                &mut self.critical_tasks,
+                self.critical_cancel_token.clone(),
+                RetryPolicy::default(),
+            ),
+            Criticality::CriticalWithFastRetry => (
+                &mut self.critical_tasks,
+                self.critical_cancel_token.clone(),
+                RetryPolicy::CRITICAL_SERVICE,
+            ),
+            Criticality::NonCritical => (
+                &mut self.non_critical_tasks,
+                self.non_critical_cancel_token.clone(),
+                RetryPolicy::default(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        errors::CodedError,
+        task::{BrokerService, SupervisorErr},
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use thiserror::Error;
+
+    #[derive(Error, Debug)]
+    enum TestErr {
+        #[error("test")]
+        _Boom,
+    }
+
+    impl CodedError for TestErr {
+        fn code(&self) -> &str {
+            "[B-TEST-001]"
+        }
+    }
+
+    #[derive(Clone)]
+    struct CountingService {
+        counter: Arc<AtomicUsize>,
+    }
+
+    impl BrokerService for CountingService {
+        type Error = TestErr;
+
+        async fn run(
+            self,
+            cancel_token: CancellationToken,
+        ) -> Result<(), SupervisorErr<Self::Error>> {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+            cancel_token.cancelled().await;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_tokens_are_independent() {
+        let runner = ServiceRunner::new(ConfigLock::default());
+        let crit = runner.critical_cancel_token();
+        let non_crit = runner.non_critical_cancel_token();
+
+        non_crit.cancel();
+        assert!(non_crit.is_cancelled());
+        assert!(!crit.is_cancelled(), "non-critical cancel must not affect critical");
+    }
+
+    #[tokio::test]
+    async fn spawn_routes_to_critical_joinset_and_cancels_cleanly() {
+        let mut runner = ServiceRunner::new(ConfigLock::default());
+        let counter = Arc::new(AtomicUsize::new(0));
+        let svc = Arc::new(CountingService { counter: counter.clone() });
+
+        runner.spawn(svc, Criticality::Critical, "Counter");
+        let crit_token = runner.critical_cancel_token();
+        let mut parts = runner.into_parts();
+
+        // Wait until the service has actually started running.
+        while counter.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        assert!(parts.non_critical_tasks.is_empty(), "should be in critical joinset");
+
+        crit_token.cancel();
+        let res = parts.critical_tasks.join_next().await.unwrap().unwrap();
+        assert!(res.is_ok(), "service should exit cleanly on cancel: {res:?}");
+    }
+
+    #[tokio::test]
+    async fn spawn_future_runs_to_completion() {
+        let mut runner = ServiceRunner::new(ConfigLock::default());
+        let cancel = runner.non_critical_cancel_token();
+
+        runner.spawn_future(Criticality::NonCritical, "Echo", async move {
+            cancel.cancelled().await;
+            Ok(())
+        });
+
+        let non_crit_cancel = runner.non_critical_cancel_token();
+        let mut parts = runner.into_parts();
+        non_crit_cancel.cancel();
+        let res = parts.non_critical_tasks.join_next().await.unwrap().unwrap();
+        assert!(res.is_ok());
+    }
+}

--- a/crates/broker/src/service_runner.rs
+++ b/crates/broker/src/service_runner.rs
@@ -19,10 +19,6 @@
 //! `start_chain_pipeline`. Each registration is now a single
 //! `runner.spawn(service, Criticality::X, "label")` call.
 
-// Additive infrastructure: not consumed until `start_service` and
-// `start_chain_pipeline` are migrated to use `ServiceRunner` (C22).
-#![allow(dead_code)]
-
 use std::{future::Future, sync::Arc};
 
 use anyhow::{Context, Result};
@@ -84,15 +80,10 @@ impl ServiceRunner {
     }
 
     /// Cancellation token for non-critical tasks. Useful when a caller needs
-    /// to spawn a raw future via [`Self::spawn_future`] that consumes the token.
+    /// to spawn a raw future via [`Self::spawn_future_in_span`] that consumes
+    /// the token.
     pub fn non_critical_cancel_token(&self) -> CancellationToken {
         self.non_critical_cancel_token.clone()
-    }
-
-    /// Cancellation token for critical tasks. Symmetric counterpart to
-    /// [`Self::non_critical_cancel_token`].
-    pub fn critical_cancel_token(&self) -> CancellationToken {
-        self.critical_cancel_token.clone()
     }
 
     /// Registers a supervised service. Equivalent to the legacy
@@ -130,14 +121,9 @@ impl ServiceRunner {
 
     /// Registers a raw future that performs its own cancellation handling
     /// (e.g. the telemetry service, which doesn't go through `Supervisor`).
-    pub fn spawn_future<F>(&mut self, criticality: Criticality, label: &'static str, fut: F)
-    where
-        F: Future<Output = Result<()>> + Send + 'static,
-    {
-        self.spawn_future_in_span(criticality, label, Span::current(), fut);
-    }
-
-    /// Same as [`Self::spawn_future`] but with an explicit instrumentation span.
+    /// Instruments the future with the given span — used in
+    /// `start_chain_pipeline` where each chain's services run inside a
+    /// per-chain `info_span!`.
     pub fn spawn_future_in_span<F>(
         &mut self,
         criticality: Criticality,
@@ -234,12 +220,15 @@ mod tests {
     #[tokio::test]
     async fn cancel_tokens_are_independent() {
         let runner = ServiceRunner::new(ConfigLock::default());
-        let crit = runner.critical_cancel_token();
         let non_crit = runner.non_critical_cancel_token();
+        let parts = runner.into_parts();
 
         non_crit.cancel();
         assert!(non_crit.is_cancelled());
-        assert!(!crit.is_cancelled(), "non-critical cancel must not affect critical");
+        assert!(
+            !parts.critical_cancel_token.is_cancelled(),
+            "non-critical cancel must not affect critical"
+        );
     }
 
     #[tokio::test]
@@ -249,7 +238,6 @@ mod tests {
         let svc = Arc::new(CountingService { counter: counter.clone() });
 
         runner.spawn(svc, Criticality::Critical, "Counter");
-        let crit_token = runner.critical_cancel_token();
         let mut parts = runner.into_parts();
 
         // Wait until the service has actually started running.
@@ -258,7 +246,7 @@ mod tests {
         }
         assert!(parts.non_critical_tasks.is_empty(), "should be in critical joinset");
 
-        crit_token.cancel();
+        parts.critical_cancel_token.cancel();
         let res = parts.critical_tasks.join_next().await.unwrap().unwrap();
         assert!(res.is_ok(), "service should exit cleanly on cancel: {res:?}");
     }
@@ -268,10 +256,15 @@ mod tests {
         let mut runner = ServiceRunner::new(ConfigLock::default());
         let cancel = runner.non_critical_cancel_token();
 
-        runner.spawn_future(Criticality::NonCritical, "Echo", async move {
-            cancel.cancelled().await;
-            Ok(())
-        });
+        runner.spawn_future_in_span(
+            Criticality::NonCritical,
+            "Echo",
+            tracing::Span::current(),
+            async move {
+                cancel.cancelled().await;
+                Ok(())
+            },
+        );
 
         let non_crit_cancel = runner.non_critical_cancel_token();
         let mut parts = runner.into_parts();

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -44,12 +44,13 @@ use risc0_zkvm::{
 use tokio::sync::mpsc;
 
 use crate::{
+    coded_error_impl,
     config::ConfigLock,
     db::DbObj,
-    impl_coded_debug, is_dev_mode, now_timestamp,
+    is_dev_mode, now_timestamp,
     order_committer::{CommitmentComplete, CommitmentOutcome},
     provers::ProverObj,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
     Batch, FulfillmentType, Order,
 };
 use thiserror::Error;
@@ -82,21 +83,15 @@ pub enum SubmitterErr {
     UnexpectedErr(#[from] anyhow::Error),
 }
 
-impl_coded_debug!(SubmitterErr);
-
-impl CodedError for SubmitterErr {
-    fn code(&self) -> &str {
-        match self {
-            SubmitterErr::UnexpectedErr(_) => "[B-SUB-500]",
-            SubmitterErr::AllRequestsExpiredBeforeSubmission(_) => "[B-SUB-001]",
-            SubmitterErr::SomeRequestsExpiredBeforeSubmission(_) => "[B-SUB-005]",
-            SubmitterErr::MarketError(_) => "[B-SUB-002]",
-            SubmitterErr::BatchSubmissionFailed(_) => "[B-SUB-004]",
-            SubmitterErr::BatchSubmissionFailedTimeouts(_) => "[B-SUB-003]",
-            SubmitterErr::TxnConfirmationError(_) => "[B-SUB-006]",
-        }
-    }
-}
+coded_error_impl!(SubmitterErr, "SUB",
+    UnexpectedErr(..)                       => "500",
+    AllRequestsExpiredBeforeSubmission(..)  => "001",
+    SomeRequestsExpiredBeforeSubmission(..) => "005",
+    MarketError(..)                         => "002",
+    BatchSubmissionFailed(..)               => "004",
+    BatchSubmissionFailedTimeouts(..)       => "003",
+    TxnConfirmationError(..)                => "006",
+);
 
 #[derive(Clone)]
 pub struct Submitter<P> {
@@ -699,43 +694,40 @@ where
     }
 }
 
-impl<P> RetryTask for Submitter<P>
+impl<P> BrokerService for Submitter<P>
 where
-    P: Provider<Ethereum> + WalletProvider + 'static + Clone,
+    P: Provider<Ethereum> + WalletProvider + Clone + Send + Sync + 'static,
 {
     type Error = SubmitterErr;
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let obj_clone = self.clone();
 
-        Box::pin(async move {
-            tracing::info!("Starting Submitter service");
-            loop {
-                if cancel_token.is_cancelled() {
-                    tracing::debug!("Submitter service received cancellation");
-                    break;
-                }
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        tracing::info!("Starting Submitter service");
+        loop {
+            if cancel_token.is_cancelled() {
+                tracing::debug!("Submitter service received cancellation");
+                break;
+            }
 
-                // Process batch without interruption
-                let result = obj_clone.process_next_batch().await;
-                if let Err(err) = result {
-                    // Only restart the service on unexpected errors.
-                    match err {
-                        SubmitterErr::BatchSubmissionFailed(_)
-                        | SubmitterErr::BatchSubmissionFailedTimeouts(_) => {
-                            tracing::error!("Batch submission failed: {err:?}");
-                        }
-                        _ => {
-                            tracing::error!("Submitter service failed: {err:?}");
-                            return Err(SupervisorErr::Recover(err));
-                        }
+            // Process batch without interruption
+            let result = self.process_next_batch().await;
+            if let Err(err) = result {
+                // Only restart the service on unexpected errors.
+                match err {
+                    SubmitterErr::BatchSubmissionFailed(_)
+                    | SubmitterErr::BatchSubmissionFailedTimeouts(_) => {
+                        tracing::error!("Batch submission failed: {err:?}");
+                    }
+                    _ => {
+                        tracing::error!("Submitter service failed: {err:?}");
+                        return Err(SupervisorErr::Recover(err));
                     }
                 }
-
-                // TODO: configuration
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
             }
-            Ok(())
-        })
+
+            // TODO: configuration
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+        Ok(())
     }
 }
 

--- a/crates/broker/src/task.rs
+++ b/crates/broker/src/task.rs
@@ -52,6 +52,41 @@ pub trait RetryTask {
     fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error>;
 }
 
+/// Simplified service trait for broker components.
+///
+/// Implement this instead of [`RetryTask`] directly. The blanket impl below
+/// turns any `BrokerService` into a `RetryTask` automatically, so service
+/// authors only have to write the actual loop body — no `Box::pin`, no
+/// `self.clone()` ceremony at the trait boundary.
+///
+/// # Ownership
+///
+/// `run` takes `self` by value. The blanket impl clones the service once per
+/// supervisor restart, so implementations are free to consume `self` in the
+/// loop without juggling clones internally.
+///
+/// # Send / 'static
+///
+/// The returned future must be `Send + 'static` so it can be polled across
+/// threads in tokio's multi-thread runtime and outlive the supervisor frame.
+pub trait BrokerService: Clone + Send + Sync + 'static {
+    type Error: CodedError + Send + Sync + 'static;
+
+    fn run(
+        self,
+        cancel_token: CancellationToken,
+    ) -> impl Future<Output = Result<(), SupervisorErr<Self::Error>>> + Send + 'static;
+}
+
+impl<T: BrokerService> RetryTask for T {
+    type Error = T::Error;
+
+    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
+        let this = self.clone();
+        Box::pin(this.run(cancel_token))
+    }
+}
+
 /// Configuration for retry behavior in the supervisor
 #[derive(Debug, Clone)]
 pub(crate) struct RetryPolicy {
@@ -382,6 +417,60 @@ mod tests {
 
         let res = supervisor_task.await;
         assert!(res.unwrap_err().to_string().contains("Exceeded maximum retries for task"));
+    }
+
+    #[derive(Clone)]
+    struct BrokerServiceTask {
+        // Channel the test uses to drive the service. Wrapped in Arc so the
+        // service can be Clone (the supervisor clones on retry).
+        rx: Arc<tokio::sync::Mutex<tokio::sync::mpsc::Receiver<u32>>>,
+    }
+
+    impl BrokerService for BrokerServiceTask {
+        type Error = TestErr;
+
+        async fn run(
+            self,
+            cancel_token: CancellationToken,
+        ) -> Result<(), SupervisorErr<Self::Error>> {
+            let mut rx = self.rx.lock().await;
+            loop {
+                tokio::select! {
+                    msg = rx.recv() => {
+                        match msg {
+                            Some(0) => continue,
+                            Some(2) => return Err(SupervisorErr::Recover(TestErr::SampleErr(
+                                anyhow::anyhow!("recoverable"),
+                            ))),
+                            Some(_) | None => break,
+                        }
+                    }
+                    _ = cancel_token.cancelled() => break,
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn broker_service_blanket_impl_works_with_supervisor() {
+        // A type implementing BrokerService gets RetryTask via the blanket impl,
+        // so it can be supervised without writing any Box::pin / self.clone() code.
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let task = Arc::new(BrokerServiceTask { rx: Arc::new(tokio::sync::Mutex::new(rx)) });
+
+        let supervisor_task =
+            Supervisor::new(task, ConfigLock::default(), CancellationToken::new()).spawn();
+
+        tx.send(0).await.unwrap();
+        // Trigger one recoverable error -> supervisor should restart the service.
+        tx.send(2).await.unwrap();
+        tx.send(0).await.unwrap();
+        // Closing the channel ends the loop cleanly.
+        drop(tx);
+
+        supervisor_task.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/broker/src/tests/e2e.rs
+++ b/crates/broker/src/tests/e2e.rs
@@ -1232,5 +1232,8 @@ async fn version_check_below_minimum_shuts_down_broker() {
         .await
         .unwrap();
     let err = result.expect_err("broker should exit with error when version check fails");
-    assert!(format!("{err:?}").contains("Version check task failed"), "unexpected error: {err:?}");
+    assert!(
+        format!("{err:?}").contains("Failed to run version check"),
+        "unexpected error: {err:?}"
+    );
 }

--- a/crates/broker/src/version_check.rs
+++ b/crates/broker/src/version_check.rs
@@ -20,9 +20,10 @@
 //! be read (RPC error, not deployed, etc.), it logs a warning and continues.
 
 use crate::{
-    errors::{impl_coded_debug, CodedError},
+    coded_error_impl,
+    errors::CodedError,
     is_dev_mode,
-    task::{RetryRes, RetryTask, SupervisorErr},
+    task::{BrokerService, SupervisorErr},
 };
 use alloy::primitives::{address, Address};
 use alloy::providers::Provider;
@@ -116,15 +117,11 @@ pub(crate) enum VersionCheckError {
     BelowMinimum { broker_version: String, min_version: String, chain_id: u64 },
 }
 
-impl_coded_debug!(VersionCheckError);
-impl CodedError for VersionCheckError {
-    fn code(&self) -> &str {
-        match self {
-            VersionCheckError::BelowMinimum { .. } => "[B-VER-001]",
-        }
-    }
-}
+coded_error_impl!(VersionCheckError, "VER",
+    BelowMinimum { .. } => "001",
+);
 
+#[derive(Clone)]
 pub(crate) struct VersionCheckTask<P> {
     /// RPC provider for reading the VersionRegistry contract.
     provider: P,
@@ -213,58 +210,49 @@ async fn check_version<P: Provider>(
     Ok(())
 }
 
-impl<P: Provider + Clone + Send + Sync + 'static> RetryTask for VersionCheckTask<P> {
+impl<P: Provider + Clone + Send + Sync + 'static> BrokerService for VersionCheckTask<P> {
     type Error = VersionCheckError;
 
-    fn spawn(&self, cancel_token: CancellationToken) -> RetryRes<Self::Error> {
-        let provider = self.provider.clone();
-        let chain_id = self.chain_id;
-        let broker_version = self.broker_version;
-        let registry_address = self.registry_address;
-        let poll_interval = self.poll_interval;
-        let force_check = self.force_check;
+    async fn run(self, cancel_token: CancellationToken) -> Result<(), SupervisorErr<Self::Error>> {
+        // Skipping the version check in dev mode is safe because RISC0_DEV_MODE
+        // disables real proof generation entirely — the broker produces fake receipts
+        // that are rejected by on-chain verifiers. A prover cannot use this flag to
+        // bypass only the version check while remaining operational in production.
+        // force_check is set when registry_address is explicitly provided (i.e., in tests)
+        // so that e2e tests can exercise the check even under RISC0_DEV_MODE.
+        if is_dev_mode() && !self.force_check {
+            tracing::info!(
+                "Skipping version check (RISC0_DEV_MODE enabled). Broker version: {}",
+                format_version(self.broker_version)
+            );
+            cancel_token.cancelled().await;
+            return Ok(());
+        }
 
-        Box::pin(async move {
-            // Skipping the version check in dev mode is safe because RISC0_DEV_MODE
-            // disables real proof generation entirely — the broker produces fake receipts
-            // that are rejected by on-chain verifiers. A prover cannot use this flag to
-            // bypass only the version check while remaining operational in production.
-            // force_check is set when registry_address is explicitly provided (i.e., in tests)
-            // so that e2e tests can exercise the check even under RISC0_DEV_MODE.
-            if is_dev_mode() && !force_check {
+        let registry_addr = match self.registry_address {
+            Some(addr) => addr,
+            None => {
                 tracing::info!(
-                    "Skipping version check (RISC0_DEV_MODE enabled). Broker version: {}",
-                    format_version(broker_version)
+                    chain_id = self.chain_id,
+                    "VersionRegistry address not configured for chain. Skipping version check."
                 );
                 cancel_token.cancelled().await;
                 return Ok(());
             }
+        };
 
-            let registry_addr = match registry_address {
-                Some(addr) => addr,
-                None => {
-                    tracing::info!(
-                        chain_id,
-                        "VersionRegistry address not configured for chain. Skipping version check."
-                    );
-                    cancel_token.cancelled().await;
-                    return Ok(());
+        // Because first tick completes immediately, we effectively do a version check on startup.
+        let mut interval = tokio::time::interval(self.poll_interval);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    check_version(&self.provider, registry_addr, self.chain_id, self.broker_version).await?;
                 }
-            };
-
-            // Because first tick completes immediately, we effectively do a version check on startup.
-            let mut interval = tokio::time::interval(poll_interval);
-            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        check_version(&provider, registry_addr, chain_id, broker_version).await?;
-                    }
-                    _ = cancel_token.cancelled() => break,
-                }
+                _ = cancel_token.cancelled() => break,
             }
-            Ok(())
-        })
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
Issue: https://linear.app/boundlessnetwork/issue/BM-2827/refactor-code-structure

This is **PR-1 of 3** for the Broker 2.0 code restructure. The goal of this PR is to land the new boilerplate-reduction infrastructure and migrate every supervised service onto it, **without changing any behaviour**. After this PR the broker still does exactly what it does today, just through cleaner plumbing.

PRs 2 and 3 will follow based on this PR.

## What this PR introduces

Four new mechanisms in `crates/broker/src/`, each landed as additive infrastructure first and adopted incrementally:

- **`BrokerService` trait** (`task.rs`) with a blanket `RetryTask` impl. Service authors now write `async fn run(self, cancel_token) -> Result<…>` instead of the `Box::pin(self.clone() …)` ceremony. The `RetryTask` trait stays around purely to plumb the blanket impl into the existing `Supervisor`.
- **`coded_error_impl!` macro** (`errors.rs`). Generates `impl CodedError` and `impl_coded_debug!` from a compact `Variant => "NNN"` mapping. Supports tuple, struct, and unit variants. Two foreign-type error enums keep their manual impls — comments explain why.
- **`SharedReceiver<T>` + `shared_channel()`** (new `channels.rs`). Bundles the `Arc<Mutex<mpsc::Receiver<T>>>` wrap that several services were doing inline. Adopted in the four channels that feed supervised services (evaluator/committer/locker/pricer inputs).
- **`ServiceRunner` + `Criticality`** (new `service_runner.rs`). Owns the critical/non-critical `JoinSet`s and `CancellationToken`s that `start_service` previously juggled as four separate locals. Each registration is now a single `runner.spawn(svc, Criticality::X, "label")` call. `into_parts()` decomposes back into the existing two-phase shutdown loop unchanged.

Net effect: `start_chain_pipeline` lost ~100 lines and now reads as a flat list of `runner.spawn_in_span(...)` calls. Adding a new service now means writing the service plus a single registration line.

## What's next

- **PR-2 — Structural cleanup of `lib.rs` and the module tree.** Extract `Order` / `OrderStatus` / etc. into `order_types.rs`, `CoreArgs`/`ChainArgs` into `args.rs`, and the `Broker` struct + `start_service` into `broker.rs`. Group shared infrastructure into `shared/` (task, errors, config, prioritization) and utilities into `utils/`. Split the 1830-line `db/mod.rs` into focused files. Pure file moves, no behaviour change.
- **PR-3 — Per-service file splits.** Each supervised service moves into its own directory (`error.rs` / `types.rs` / `service.rs` / etc.) following the [layout](https://docs.google.com/document/d/1vFmXPa59y1HVQabvwqqDmW5stI2LaZjVNvvitQeCVUo/edit?usp=sharing). Largest review surface but minimum semantic risk — strictly mechanical moves.

Each PR will only open after the previous one lands and bakes on `main` to avoid merge-conflict pain.

## How to review

The PR is shaped for **commit-by-commit review** in order. Each commit compiles and passes tests on its own.

Suggested reading path:

1. **First four commits**: the new mechanisms in isolation. Focus on whether each does what it says on the tin (each commit includes its own unit tests).
2. **Two `Clone` derives** on `MarketMonitor` and `OffchainMarketMonitor`: one-line preps so they can satisfy the blanket impl's `Clone` bound.
3. **Service migrations** (one commit per service, ordered simplest first → most complex last): each is the same three-swap pattern — `RetryTask` → `BrokerService`, `impl CodedError` → `coded_error_impl!`, and `Arc<Mutex<Receiver>>` → `SharedReceiver` where applicable. Skim quickly; the diffs are mechanical. The `order_pricer` migration is the most worth a careful look (complex inner loop with child tokens and a `JoinSet`).
4. **Final commit** — `start_service` and `start_chain_pipeline` in `lib.rs` adopt `ServiceRunner`. Compare the before/after of `start_chain_pipeline` to see the cleanup payoff.

Things to watch for:
- Behaviour preservation: each migration commit's title says "migrate" — none should change semantics. Spot-check loop bodies stay identical aside from `service.X` → `self.X` and the dropped outer `Box::pin(self.clone() …)`.
- The `Criticality` mapping in the final commit: the comment in `service_runner.rs` documents the three variants; cross-reference against the original `with_retry_policy(RetryPolicy::CRITICAL_SERVICE)` calls (only `aggregator` and `submitter` had it).
- The `coded_error_impl!` macro is intentionally declarative (not a proc-macro). One small downside: variant names appear in both the `enum` and the macro call. Drift is caught at compile time by Rust's exhaustiveness check.