### PR TITLE
BM-2921: e2e testing examples scripts

### DIFF
--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -1,0 +1,67 @@
+name: Release E2E
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # Keep in sync with main.yml / nightly-examples.yml
+  RISC0_TOOLCHAIN_VERSION: 1.88.0
+  RISC0_CRATE_VERSION: "3.0.3"
+  FOUNDRY_VERSION: v1.5.0
+  CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+jobs:
+  release-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Remove stale submodules
+        run: rm -rf lib/
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive --depth=1 --jobs=8
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - name: Install Rust toolchain
+        uses: risc0/risc0/.github/actions/rustup@v3.0.3
+
+      - name: Install cargo risczero
+        uses: ./.github/actions/bininstall-risc0
+        with:
+          risczero-version: ${{ env.RISC0_CRATE_VERSION }}
+          toolchain-version: ${{ env.RISC0_TOOLCHAIN_VERSION }}
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run release e2e
+        env:
+          RISC0_DEV_MODE: "1"
+          RUST_LOG: "info,broker=debug,boundless_market=debug"
+        run: just test-e2e-release
+
+      - name: Tear down localnet (safety net)
+        if: always()
+        run: just localnet down || true

--- a/.github/workflows/release-e2e.yml
+++ b/.github/workflows/release-e2e.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   release-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Remove stale submodules

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ network_address_labels.json
 
 # Ignore broker config file(s) in repo root and chain-overrides/
 *broker*.toml
-# But track Ansible-managed broker configs
+# But track the localnet broker config and Ansible-managed broker configs
+!broker.localnet.toml
 !ansible/roles/prover/configs/broker/**
 ansible/inventory.yml
 # Custom ansible inventories

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/test-utils",
     "crates/zkc",
 ]
+exclude = ["examples/echo-unpinned"]
 
 [workspace.package]
 version = "1.5.0-alpha.0"

--- a/broker.localnet.toml
+++ b/broker.localnet.toml
@@ -23,7 +23,7 @@ skip_gas_profitability_check = true
 peak_prove_khz = 1000
 max_collateral = "20 ZKC"
 max_concurrent_preflights = 8
-max_concurrent_proofs = 1
+max_concurrent_proofs = 4
 priority_requestor_lists = []
 
 [price_oracle]

--- a/broker.localnet.toml
+++ b/broker.localnet.toml
@@ -1,0 +1,34 @@
+# Broker configuration used by the localnet dev-broker container.
+# Mounted read-only into /app/broker.toml inside the broker container by
+# dockerfiles/compose.localnet.yml.
+#
+# These values are tuned to make localnet testing fast:
+#   - min_mcycle_price = "0 ETH" and min_mcycle_price_collateral_token = "0 ZKC"
+#     put orders on the "lock ASAP" path, so the broker locks as soon as it
+#     sees a request rather than waiting for the offer's ramp to cover its
+#     gas-cost floor.
+#   - skip_gas_profitability_check = true bypasses the pre-lock check that
+#     would otherwise make the broker retry each block until the offer's
+#     ramp lifts the reward above gas cost.
+#   - priority_requestor_lists is empty to avoid fetching a remote list during
+#     startup (no internet dependency for CI).
+#   - The price_oracle uses static prices because anvil has no chainlink feeds.
+#
+# This config is NOT suitable for any real network.
+
+[market]
+min_mcycle_price = "0 ETH"
+min_mcycle_price_collateral_token = "0 ZKC"
+skip_gas_profitability_check = true
+peak_prove_khz = 1000
+max_collateral = "20 ZKC"
+max_concurrent_preflights = 8
+max_concurrent_proofs = 1
+priority_requestor_lists = []
+
+[price_oracle]
+eth_usd = "2500.0"
+zkc_usd = "1.0"
+
+[price_oracle.onchain.chainlink]
+enabled = false

--- a/compose.blake3-local.yml
+++ b/compose.blake3-local.yml
@@ -1,0 +1,25 @@
+# Optional Compose override that bind-mounts host-provided BLAKE3 Groth16 setup
+# artifacts over the baked-in artifacts in the agent image.
+#
+# Use this when:
+#   - The agent image was built with USE_LOCAL_BLAKE3_GROTH16_SETUP=1 (no baked artifacts), or
+#   - You want to swap in different artifacts than what the prebuilt image ships with.
+#
+# Required env: BLAKE3_GROTH16_SETUP_DIR — host path containing
+# verify_for_guest_final.zkey and verify_for_guest_graph.bin.
+#
+# Usage (raw compose):
+#   docker compose -f compose.yml -f compose.blake3-local.yml up
+#   docker compose -f prover-compose.yml -f compose.blake3-local.yml up
+#
+# `just bento up` / `just prover up` auto-include this file whenever
+# BLAKE3_GROTH16_SETUP_DIR is set in the environment.
+
+name: bento
+services:
+  gpu_prove_agent:
+    volumes:
+      - type: bind
+        source: ${BLAKE3_GROTH16_SETUP_DIR:?BLAKE3_GROTH16_SETUP_DIR must be set when using compose.blake3-local.yml}
+        target: /.blake3_groth16_artifacts/
+        read_only: true

--- a/compose.yml
+++ b/compose.yml
@@ -108,14 +108,13 @@ x-gpu-prove-agent: &gpu-prove-agent
       "-c",
       "for gpu in $(nvidia-smi --query-gpu=index --format=csv,noheader,nounits); do CUDA_VISIBLE_DEVICES=$$gpu /app/agent -t prove --redis-ttl $$REDIS_TTL & done; wait",
     ]
-  # When USE_LOCAL_BLAKE3_GROTH16_SETUP=1 the image has no artifacts; set BLAKE3_GROTH16_SETUP_DIR
-  # to the host path containing verify_for_guest_final.zkey and verify_for_guest_graph.bin.
-  # When using Ansible, BLAKE3_GROTH16_SETUP_DIR is set in .env and this dir is populated.
-  volumes:
-    - type: bind
-      source: ${BLAKE3_GROTH16_SETUP_DIR}
-      target: /.blake3_groth16_artifacts/
-      read_only: true
+  # By default, the prebuilt agent image ships with the BLAKE3 Groth16 setup
+  # artifacts baked in at /.blake3_groth16_artifacts/. To swap in host-provided
+  # artifacts (e.g., images built with USE_LOCAL_BLAKE3_GROTH16_SETUP=1, or
+  # Ansible-managed deployments), opt in by passing the override file:
+  #   docker compose -f compose.yml -f compose.blake3-local.yml up
+  # `just bento up` / `just prover up` auto-include it whenever
+  # BLAKE3_GROTH16_SETUP_DIR is set in the environment.
 
 x-broker-common: &broker-common
   image: ${BROKER_IMAGE-ghcr.io/boundless-xyz/boundless/broker:latest}

--- a/dockerfiles/compose.localnet.yml
+++ b/dockerfiles/compose.localnet.yml
@@ -154,7 +154,7 @@ services:
       ORDER_STREAM_URL: "http://localhost:8585"
     volumes:
       - deployer-env:/shared:ro
-      - ../broker.toml:/app/broker.toml:ro
+      - ../broker.localnet.toml:/app/broker.toml:ro
     restart: unless-stopped
 
 volumes:

--- a/examples/echo-unpinned/.gitignore
+++ b/examples/echo-unpinned/.gitignore
@@ -1,0 +1,4 @@
+# This crate must not commit a Cargo.lock — each run regenerates it to exercise
+# unpinned transitive dependency resolution.
+/Cargo.lock
+/target

--- a/examples/echo-unpinned/Cargo.toml
+++ b/examples/echo-unpinned/Cargo.toml
@@ -1,0 +1,26 @@
+# Intentionally out-of-workspace. This crate exercises unpinned transitive dep
+# resolution for boundless-market. Its Cargo.lock is gitignored (see .gitignore).
+
+[package]
+name = "echo-unpinned"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+# Match the workspace toolchain pin (rust-toolchain.toml = "1.89") and use
+# the MSRV-aware resolver so transitive deps are picked compatibly with 1.89.
+rust-version = "1.89"
+resolver = "3"
+
+[dependencies]
+# Path dep — does NOT test published boundless-market. Tests the dep graph our
+# local boundless-market declares when resolved independently of the workspace.
+boundless-market = { path = "../../crates/boundless-market" }
+
+alloy = { version = "1.0", features = ["signer-local"] }
+anyhow = "1"
+clap = { version = "4", features = ["derive", "env"] }
+guest-util = { path = "../../crates/guest/util" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2"

--- a/examples/echo-unpinned/src/main.rs
+++ b/examples/echo-unpinned/src/main.rs
@@ -1,0 +1,75 @@
+// Copyright 2026 Boundless Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use alloy::signers::local::PrivateKeySigner;
+use anyhow::Result;
+use boundless_market::{request_builder::OfferParams, Client, Deployment, StorageUploaderConfig};
+use clap::Parser;
+use guest_util::ECHO_ELF;
+use tracing_subscriber::EnvFilter;
+use url::Url;
+
+#[derive(Parser, Debug)]
+#[clap(about = "Unpinned echo smoke test — exercises fresh transitive dep resolution")]
+struct Args {
+    #[clap(short, long, env)]
+    rpc_url: Url,
+
+    #[clap(long, env)]
+    requestor_key: PrivateKeySigner,
+
+    #[clap(flatten)]
+    storage_config: StorageUploaderConfig,
+
+    #[clap(flatten)]
+    deployment: Option<Deployment>,
+
+    #[clap(flatten, next_help_heading = "Offer")]
+    offer_params: OfferParams,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env()).init();
+    let args = Args::parse();
+
+    let client = Client::builder()
+        .with_rpc_url(args.rpc_url)
+        .with_deployment(args.deployment)
+        .with_uploader_config(&args.storage_config)
+        .await?
+        .with_private_key(args.requestor_key)
+        .build()
+        .await?;
+
+    let request = client
+        .new_request()
+        .with_program(ECHO_ELF)
+        .with_stdin(b"Hello, Boundless (unpinned)!")
+        .with_offer(args.offer_params);
+
+    let (request_id, expires_at) = client.submit(request).await?;
+    println!("Submitted request: {:x}", request_id);
+
+    let fulfillment =
+        client.wait_for_request_fulfillment(request_id, Duration::from_secs(5), expires_at).await?;
+
+    println!(
+        "Fulfilled! Journal: {}",
+        String::from_utf8_lossy(fulfillment.data()?.journal().unwrap())
+    );
+    Ok(())
+}

--- a/examples/smart-contract-requestor/contracts/scripts/Deploy.s.sol
+++ b/examples/smart-contract-requestor/contracts/scripts/Deploy.s.sol
@@ -15,23 +15,21 @@
 pragma solidity ^0.8.26;
 
 import {Script, console2} from "forge-std/Script.sol";
-import {IRiscZeroVerifier} from "risc0/IRiscZeroVerifier.sol";
-import {Counter} from "../src/Counter.sol";
-import {ImageID} from "boundless-market/libraries/UtilImageID.sol";
+import {SmartContractRequestor} from "../src/SmartContractRequestor.sol";
 
 contract Deploy is Script {
     function run() external payable {
-        // load ENV variables first
         uint256 key = vm.envUint("PRIVATE_KEY");
-        address verifierAddress = vm.envAddress("VERIFIER_ADDRESS");
+        address owner = vm.addr(key);
         address boundlessMarketAddress = vm.envAddress("BOUNDLESS_MARKET_ADDRESS");
+        // Valid for any day since epoch — the example uses today's day-since-epoch as the request id.
+        uint32 startDay = 0;
+        uint32 endDay = type(uint32).max;
+
         vm.startBroadcast(key);
-
-        IRiscZeroVerifier verifier = IRiscZeroVerifier(verifierAddress);
-        Counter counter = new Counter(verifier, boundlessMarketAddress, ImageID.ECHO_ID);
-        address counterAddress = address(counter);
-        console2.log("Deployed Counter to", counterAddress);
-
+        SmartContractRequestor scr = new SmartContractRequestor(owner, boundlessMarketAddress, startDay, endDay);
+        address scrAddress = address(scr);
+        console2.log("Deployed SmartContractRequestor to", scrAddress);
         vm.stopBroadcast();
     }
 }

--- a/justfile
+++ b/justfile
@@ -482,7 +482,9 @@ job-status job_id:
 # Intended to be run before cutting a release, and from CI via .github/workflows/release-e2e.yml.
 test-e2e-release:
     #!/usr/bin/env bash
-    set -euo pipefail
+    set -uo pipefail
+    mkdir -p target/e2e-logs
+    rm -f target/e2e-logs/*.log
     # Guarantee teardown on any exit path.
     trap 'just _e2e-teardown "$?" || true' EXIT
     just localnet up
@@ -491,8 +493,52 @@ test-e2e-release:
     set -a
     source .env.localnet
     set +a
-    just _e2e-run-submit-echo onchain
-    just _e2e-run-submit-echo offchain
+
+    # Launch all examples in parallel. Each runs in a separate bash job with its own
+    # private key and log file. pids maps PID -> example name.
+    declare -A pids=()
+
+    just _e2e-run-submit-echo onchain target/e2e-logs/submit-echo-onchain.log &
+    pids[$!]=submit-echo-onchain
+    just _e2e-run-submit-echo offchain target/e2e-logs/submit-echo-offchain.log &
+    pids[$!]=submit-echo-offchain
+    just _e2e-run-counter {{E2E_KEY_COUNTER}} target/e2e-logs/counter.log &
+    pids[$!]=counter
+    just _e2e-run-counter-with-callback {{E2E_KEY_COUNTER_CALLBACK}} target/e2e-logs/counter-with-callback.log &
+    pids[$!]=counter-with-callback
+    just _e2e-run-composition {{E2E_KEY_COMPOSITION}} target/e2e-logs/composition.log &
+    pids[$!]=composition
+    just _e2e-run-smart-contract-requestor {{E2E_KEY_SCR}} target/e2e-logs/smart-contract-requestor.log &
+    pids[$!]=smart-contract-requestor
+    just _e2e-run-blake3-groth16 {{E2E_KEY_BLAKE3}} target/e2e-logs/blake3-groth16.log &
+    pids[$!]=blake3-groth16
+    just _e2e-run-echo-unpinned {{E2E_KEY_UNPINNED}} target/e2e-logs/echo-unpinned.log &
+    pids[$!]=echo-unpinned
+
+    echo "[test-e2e-release] launched ${#pids[@]} parallel examples"
+
+    failures=()
+    for pid in "${!pids[@]}"; do
+        name="${pids[$pid]}"
+        if wait "$pid"; then
+            echo "[test-e2e-release] PASS: $name"
+        else
+            rc=$?
+            echo "[test-e2e-release] FAIL ($rc): $name"
+            failures+=("$name")
+        fi
+    done
+
+    if [ "${#failures[@]}" -gt 0 ]; then
+        for name in "${failures[@]}"; do
+            echo "::group::${name} log"
+            cat "target/e2e-logs/${name}.log" 2>&1 || true
+            echo "::endgroup::"
+        done
+        echo "[test-e2e-release] ${#failures[@]} example(s) failed: ${failures[*]}"
+        exit 1
+    fi
+    echo "[test-e2e-release] all examples passed"
 
 # Private: on failure, dump docker logs to stdout (visible inline in CI),
 # then tear down localnet regardless of state. Safe to call even if no containers
@@ -514,19 +560,35 @@ _e2e-teardown status:
 # Private: run the submit_echo example in either on-chain or off-chain mode.
 # Arg `mode` must be "onchain" or "offchain".
 E2E_SUBMIT_ECHO_TIMEOUT := "180"
-_e2e-run-submit-echo mode:
+# Per-example wall-clock timeouts (seconds). Tuned for dev-mode proving + cargo cold build.
+E2E_EXAMPLE_TIMEOUT := "600"
+# Anvil default-mnemonic keys. Slot 0 = deployer, slot 3 = prover — both reserved.
+# See docs/superpowers/plans/2026-04-23-release-e2e-phase-2-3.md for the full allocation.
+E2E_KEY_SUBMIT_ECHO_ONCHAIN := "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+E2E_KEY_SUBMIT_ECHO_OFFCHAIN := "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+E2E_KEY_COUNTER := "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"
+E2E_KEY_COUNTER_CALLBACK := "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba"
+E2E_KEY_COMPOSITION := "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e"
+E2E_KEY_SCR := "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
+E2E_KEY_BLAKE3 := "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
+E2E_KEY_UNPINNED := "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+_e2e-run-submit-echo mode log_path:
     #!/usr/bin/env bash
     set -uo pipefail
-    echo "[test-e2e-release] submit_echo ({{mode}}) (timeout {{E2E_SUBMIT_ECHO_TIMEOUT}}s)"
+    echo "[test-e2e-release] submit_echo ({{mode}}) -> {{log_path}}"
     case "{{mode}}" in
         onchain)
             timeout --foreground {{E2E_SUBMIT_ECHO_TIMEOUT}} \
-                env -u ORDER_STREAM_URL cargo run --quiet --example submit_echo -p boundless-market
+                env -u ORDER_STREAM_URL REQUESTOR_KEY={{E2E_KEY_SUBMIT_ECHO_ONCHAIN}} \
+                cargo run --quiet --example submit_echo -p boundless-market \
+                > "{{log_path}}" 2>&1
             rc=$?
             ;;
         offchain)
             timeout --foreground {{E2E_SUBMIT_ECHO_TIMEOUT}} \
-                cargo run --quiet --example submit_echo -p boundless-market
+                env REQUESTOR_KEY={{E2E_KEY_SUBMIT_ECHO_OFFCHAIN}} \
+                cargo run --quiet --example submit_echo -p boundless-market \
+                > "{{log_path}}" 2>&1
             rc=$?
             ;;
         *)
@@ -536,5 +598,183 @@ _e2e-run-submit-echo mode:
     esac
     if [ "$rc" = "124" ]; then
         echo "[test-e2e-release] submit_echo ({{mode}}) timed out after {{E2E_SUBMIT_ECHO_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+# Private: run the blake3-groth16 example. Takes a private key (for request submission)
+# and a log path. Redirects all cargo stdout/stderr to the log.
+_e2e-run-blake3-groth16 private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] blake3-groth16 -> {{log_path}}"
+    timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+        env PRIVATE_KEY={{private_key}} \
+        cargo run --quiet --release \
+            --manifest-path examples/blake3-groth16/Cargo.toml \
+            -p example-blake3-groth16 \
+        > "{{log_path}}" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] blake3-groth16 timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+_e2e-deploy-via-forge example_dir contract_name log_path private_key extra_env="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    {
+        echo "=== deploy {{contract_name}} ({{example_dir}}) ==="
+        (cd {{example_dir}} && \
+            env PRIVATE_KEY="{{private_key}}" {{extra_env}} \
+            forge script contracts/scripts/Deploy.s.sol --rpc-url "$RPC_URL" --broadcast -vv) \
+            || { echo "forge deploy failed"; exit 1; }
+    } >> "{{log_path}}" 2>&1
+    jq -re \
+        '.transactions[] | select(.contractName == "{{contract_name}}") | .contractAddress' \
+        "{{example_dir}}/broadcast/Deploy.s.sol/31337/run-latest.json"
+
+# Private: run the counter example. Deploys its own Counter.sol instance using the passed key.
+_e2e-run-counter private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] counter -> {{log_path}}"
+    log="{{log_path}}"
+    key="{{private_key}}"
+    : > "$log"
+    counter_addr=$(just _e2e-deploy-via-forge examples/counter Counter "$log" "$key" "VERIFIER_ADDRESS=$VERIFIER_ADDRESS") \
+        || { echo "[test-e2e-release] counter: deploy failed; see $log" >&2; exit 1; }
+    {
+        echo "Counter deployed at: $counter_addr"
+        echo "=== run counter example ==="
+        timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+            env PRIVATE_KEY="$key" COUNTER_ADDRESS="$counter_addr" \
+            cargo run --quiet --release \
+                --manifest-path examples/counter/Cargo.toml \
+                -p example-counter
+    } >> "$log" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] counter timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+# Private: run the composition example. Deploys its own Counter.sol instance.
+_e2e-run-composition private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    # The IDENTITY guest enables risc0-zkvm/disable-dev-mode (see
+    # crates/guest/util/identity/Cargo.toml), so it rejects FakeReceipts even
+    # when RISC0_DEV_MODE=1. Composition is exercised in nightly-examples.yml
+    # with real Groth16 proving.
+    if [ "${RISC0_DEV_MODE:-}" = "1" ]; then
+        echo "[test-e2e-release] composition: SKIPPED (incompatible with RISC0_DEV_MODE=1)"
+        echo "SKIPPED: composition requires real proofs (identity guest sets risc0-zkvm/disable-dev-mode)" > "{{log_path}}"
+        exit 0
+    fi
+    echo "[test-e2e-release] composition -> {{log_path}}"
+    log="{{log_path}}"
+    key="{{private_key}}"
+    : > "$log"
+    counter_addr=$(just _e2e-deploy-via-forge examples/composition Counter "$log" "$key" "VERIFIER_ADDRESS=$VERIFIER_ADDRESS") \
+        || { echo "[test-e2e-release] composition: deploy failed; see $log" >&2; exit 1; }
+    {
+        echo "Counter deployed at: $counter_addr"
+        echo "=== run composition example ==="
+        timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+            env PRIVATE_KEY="$key" COUNTER_ADDRESS="$counter_addr" \
+            cargo run --quiet --release \
+                --manifest-path examples/composition/Cargo.toml \
+                -p example-composition
+    } >> "$log" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] composition timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+# Private: run the counter-with-callback example. Deploys its own callback-variant Counter.sol.
+_e2e-run-counter-with-callback private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] counter-with-callback -> {{log_path}}"
+    log="{{log_path}}"
+    key="{{private_key}}"
+    : > "$log"
+    counter_addr=$(just _e2e-deploy-via-forge examples/counter-with-callback Counter "$log" "$key" "VERIFIER_ADDRESS=$VERIFIER_ADDRESS BOUNDLESS_MARKET_ADDRESS=$BOUNDLESS_MARKET_ADDRESS") \
+        || { echo "[test-e2e-release] counter-with-callback: deploy failed; see $log" >&2; exit 1; }
+    {
+        echo "Counter deployed at: $counter_addr"
+        echo "=== run counter-with-callback example ==="
+        timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+            env PRIVATE_KEY="$key" COUNTER_ADDRESS="$counter_addr" \
+            cargo run --quiet --release \
+                --manifest-path examples/counter-with-callback/Cargo.toml \
+                -p example-counter-with-callback
+    } >> "$log" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] counter-with-callback timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+# Private: run the smart-contract-requestor example. Deploys its own SCR contract.
+_e2e-run-smart-contract-requestor private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] smart-contract-requestor -> {{log_path}}"
+    log="{{log_path}}"
+    key="{{private_key}}"
+    : > "$log"
+    scr_addr=$(just _e2e-deploy-via-forge examples/smart-contract-requestor SmartContractRequestor "$log" "$key" "BOUNDLESS_MARKET_ADDRESS=$BOUNDLESS_MARKET_ADDRESS") \
+        || { echo "[test-e2e-release] smart-contract-requestor: deploy failed; see $log" >&2; exit 1; }
+    {
+        echo "SmartContractRequestor deployed at: $scr_addr"
+        echo "=== fund SmartContractRequestor via execute(deposit) ==="
+        # Send ETH to the SCR contract, then have it call BoundlessMarket.deposit() with that ETH.
+        # deposit() selector is 0xd0e30db0; value 0.01 ETH is sufficient for a single ECHO request.
+        cast send --private-key "$key" --rpc-url "$RPC_URL" \
+            --value 0.01ether "$scr_addr" \
+            || { echo "send ETH to SCR failed"; exit 1; }
+        cast send --private-key "$key" --rpc-url "$RPC_URL" \
+            "$scr_addr" "execute(address,bytes,uint256)" \
+            "$BOUNDLESS_MARKET_ADDRESS" "0xd0e30db0" "10000000000000000" \
+            || { echo "SCR deposit to market failed"; exit 1; }
+        echo "=== run smart-contract-requestor example ==="
+        timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+            env PRIVATE_KEY="$key" SMART_CONTRACT_REQUESTOR_ADDRESS="$scr_addr" \
+            cargo run --quiet --release \
+                --manifest-path examples/smart-contract-requestor/Cargo.toml \
+                -p example-smart-contract-requestor
+    } >> "$log" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] smart-contract-requestor timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"
+
+# Private: run the out-of-workspace echo-unpinned example. Regenerates Cargo.lock each run
+# to exercise fresh transitive dependency resolution.
+_e2e-run-echo-unpinned private_key log_path:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] echo-unpinned -> {{log_path}}"
+    log="{{log_path}}"
+    key="{{private_key}}"
+    : > "$log"
+    {
+        echo "=== cargo generate-lockfile (fresh resolution) ==="
+        (cd examples/echo-unpinned && cargo generate-lockfile) \
+            || { echo "generate-lockfile failed"; exit 1; }
+        echo "=== cargo update (latest compatible deps) ==="
+        (cd examples/echo-unpinned && cargo update) \
+            || { echo "cargo update failed"; exit 1; }
+        echo "=== run echo-unpinned ==="
+        timeout --foreground {{E2E_EXAMPLE_TIMEOUT}} \
+            env -u ORDER_STREAM_URL REQUESTOR_KEY="$key" \
+            cargo run --quiet --release --manifest-path examples/echo-unpinned/Cargo.toml
+    } >> "$log" 2>&1
+    rc=$?
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] echo-unpinned timed out after {{E2E_EXAMPLE_TIMEOUT}}s" >&2
     fi
     exit "$rc"

--- a/justfile
+++ b/justfile
@@ -261,13 +261,8 @@ localnet action="up":
     COMPOSE="docker compose -f dockerfiles/compose.localnet.yml --profile order-stream"
     DEV_MODE="${RISC0_DEV_MODE:-1}"
 
-    # Ensure broker.toml exists with localnet-compatible price oracle config
-    if [ ! -f broker.toml ]; then
-        cp broker-template.toml broker.toml
-    fi
-    if ! grep -q '\[price_oracle\]' broker.toml 2>/dev/null; then
-        printf '\n# Localnet price oracle: static prices, no on-chain feeds (anvil has no chainlink).\n[price_oracle]\neth_usd = "2500.0"\nzkc_usd = "1.0"\n\n[price_oracle.onchain.chainlink]\nenabled = false\n' >> broker.toml
-    fi
+    # The dev-broker container mounts broker.localnet.toml (committed), which
+    # is tuned for fast localnet runs and independent of the user's broker.toml.
 
     # In dev mode, include the broker container
     if [ "$DEV_MODE" = "1" ] || [ "$DEV_MODE" = "true" ]; then
@@ -482,3 +477,64 @@ bento-setup:
 job-status job_id:
     #!/usr/bin/env bash
     ./scripts/job_status.sh {{job_id}}
+
+# Run the end-to-end release smoke test: localnet up + submit_echo (on-chain and off-chain) + teardown.
+# Intended to be run before cutting a release, and from CI via .github/workflows/release-e2e.yml.
+test-e2e-release:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Guarantee teardown on any exit path.
+    trap 'just _e2e-teardown "$?" || true' EXIT
+    just localnet up
+    # Source the deployer-written contract addresses (and RISC0_DEV_MODE,
+    # which localnet-deploy.sh patches in before writing .env.localnet).
+    set -a
+    source .env.localnet
+    set +a
+    just _e2e-run-submit-echo onchain
+    just _e2e-run-submit-echo offchain
+
+# Private: on failure, dump docker logs to stdout (visible inline in CI),
+# then tear down localnet regardless of state. Safe to call even if no containers
+# are running.
+_e2e-teardown status:
+    #!/usr/bin/env bash
+    set +e
+    if [ "{{status}}" != "0" ]; then
+        for svc in anvil deployer order-stream broker; do
+            echo "${svc} logs:"
+            docker compose -f dockerfiles/compose.localnet.yml \
+                --profile order-stream --profile dev-broker logs "$svc" \
+                2>&1 || true
+            echo "::end::"
+        done
+    fi
+    just localnet down || true
+
+# Private: run the submit_echo example in either on-chain or off-chain mode.
+# Arg `mode` must be "onchain" or "offchain".
+E2E_SUBMIT_ECHO_TIMEOUT := "180"
+_e2e-run-submit-echo mode:
+    #!/usr/bin/env bash
+    set -uo pipefail
+    echo "[test-e2e-release] submit_echo ({{mode}}) (timeout {{E2E_SUBMIT_ECHO_TIMEOUT}}s)"
+    case "{{mode}}" in
+        onchain)
+            timeout --foreground {{E2E_SUBMIT_ECHO_TIMEOUT}} \
+                env -u ORDER_STREAM_URL cargo run --quiet --example submit_echo -p boundless-market
+            rc=$?
+            ;;
+        offchain)
+            timeout --foreground {{E2E_SUBMIT_ECHO_TIMEOUT}} \
+                cargo run --quiet --example submit_echo -p boundless-market
+            rc=$?
+            ;;
+        *)
+            echo "unknown mode: {{mode}}" >&2
+            exit 2
+            ;;
+    esac
+    if [ "$rc" = "124" ]; then
+        echo "[test-e2e-release] submit_echo ({{mode}}) timed out after {{E2E_SUBMIT_ECHO_TIMEOUT}}s" >&2
+    fi
+    exit "$rc"

--- a/justfile
+++ b/justfile
@@ -581,7 +581,6 @@ _e2e-teardown status:
 E2E_SUBMIT_ECHO_TIMEOUT := if env_var_or_default("RISC0_DEV_MODE", "1") == "1" { "180" } else { "1800" }
 E2E_EXAMPLE_TIMEOUT := if env_var_or_default("RISC0_DEV_MODE", "1") == "1" { "600" } else { "3600" }
 # Anvil default-mnemonic keys. Slot 0 = deployer, slot 3 = prover — both reserved.
-# See docs/superpowers/plans/2026-04-23-release-e2e-phase-2-3.md for the full allocation.
 E2E_KEY_SUBMIT_ECHO_ONCHAIN := "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 E2E_KEY_SUBMIT_ECHO_OFFCHAIN := "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
 E2E_KEY_COUNTER := "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a"

--- a/justfile
+++ b/justfile
@@ -329,6 +329,12 @@ bento action="up" env_file="" compose_flags="" detached="true" services="":
     if [ "${PROVER_STACK:-}" = "experimental" ]; then
         COMPOSE_FILE_FLAG="-f prover-compose.yml"
     fi
+    # Bind-mount host-provided BLAKE3 Groth16 setup artifacts only when the user
+    # explicitly opts in via BLAKE3_GROTH16_SETUP_DIR. Default uses the artifacts
+    # baked into the prebuilt agent image at /.blake3_groth16_artifacts/.
+    if [ -n "${BLAKE3_GROTH16_SETUP_DIR:-}" ]; then
+        COMPOSE_FILE_FLAG="$COMPOSE_FILE_FLAG -f compose.blake3-local.yml"
+    fi
 
     if [ "{{action}}" = "up" ]; then
         if [ -n "{{env_file}}" ] && [ ! -f "{{env_file}}" ]; then

--- a/justfile
+++ b/justfile
@@ -487,12 +487,23 @@ test-e2e-release:
     rm -f target/e2e-logs/*.log
     # Guarantee teardown on any exit path.
     trap 'just _e2e-teardown "$?" || true' EXIT
+    # Ensure a clean slate so each run gets a fresh anvil + redeployed contracts.
+    just localnet down || true
     just localnet up
     # Source the deployer-written contract addresses (and RISC0_DEV_MODE,
     # which localnet-deploy.sh patches in before writing .env.localnet).
     set -a
     source .env.localnet
     set +a
+
+    # Non-dev mode: bring up our own bento+broker cluster, but refuse if one is
+    # already running so we don't clobber the user's stack.
+    if [ "${RISC0_DEV_MODE:-1}" != "1" ]; then
+        n=$(docker compose ps --services --filter status=running 2>/dev/null | grep -cE '^(rest_api|broker)$')
+        [ "$n" = 0 ] || { echo "[test-e2e-release] bento/broker already running; stop them first" >&2; exit 1; }
+        trap 'rc=$?; just prover down || true; just _e2e-teardown "$rc" || true' EXIT
+        BOUNDLESS_MINING=false just prover
+    fi
 
     # Launch all examples in parallel. Each runs in a separate bash job with its own
     # private key and log file. pids maps PID -> example name.
@@ -559,9 +570,10 @@ _e2e-teardown status:
 
 # Private: run the submit_echo example in either on-chain or off-chain mode.
 # Arg `mode` must be "onchain" or "offchain".
-E2E_SUBMIT_ECHO_TIMEOUT := "180"
-# Per-example wall-clock timeouts (seconds). Tuned for dev-mode proving + cargo cold build.
-E2E_EXAMPLE_TIMEOUT := "600"
+# Per-example wall-clock timeouts (seconds). Dev mode uses fake proofs; real
+# proving via Bento is dramatically slower (Groth16 + recursion), so we scale up.
+E2E_SUBMIT_ECHO_TIMEOUT := if env_var_or_default("RISC0_DEV_MODE", "1") == "1" { "180" } else { "1800" }
+E2E_EXAMPLE_TIMEOUT := if env_var_or_default("RISC0_DEV_MODE", "1") == "1" { "600" } else { "3600" }
 # Anvil default-mnemonic keys. Slot 0 = deployer, slot 3 = prover — both reserved.
 # See docs/superpowers/plans/2026-04-23-release-e2e-phase-2-3.md for the full allocation.
 E2E_KEY_SUBMIT_ECHO_ONCHAIN := "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -74,14 +74,13 @@ x-gpu-prove-agent: &gpu-prove-agent
       "-c",
       "for gpu in $(nvidia-smi --query-gpu=index --format=csv,noheader,nounits); do CUDA_VISIBLE_DEVICES=$$gpu /app/agent -t prove --redis-ttl $$REDIS_TTL & done; wait",
     ]
-  # When USE_LOCAL_BLAKE3_GROTH16_SETUP=1 the image has no artifacts; set BLAKE3_GROTH16_SETUP_DIR
-  # to the host path containing verify_for_guest_final.zkey and verify_for_guest_graph.bin.
-  # When using Ansible, BLAKE3_GROTH16_SETUP_DIR is set in .env and this dir is populated.
-  volumes:
-    - type: bind
-      source: ${BLAKE3_GROTH16_SETUP_DIR}
-      target: /.blake3_groth16_artifacts/
-      read_only: true
+  # By default, the prebuilt agent image ships with the BLAKE3 Groth16 setup
+  # artifacts baked in at /.blake3_groth16_artifacts/. To swap in host-provided
+  # artifacts (e.g., images built with USE_LOCAL_BLAKE3_GROTH16_SETUP=1, or
+  # Ansible-managed deployments), opt in by passing the override file:
+  #   docker compose -f prover-compose.yml -f compose.blake3-local.yml up
+  # `just bento up` / `just prover up` auto-include it whenever
+  # BLAKE3_GROTH16_SETUP_DIR is set in the environment.
 
 x-broker-common: &broker-common
   image: ${BROKER_IMAGE-ghcr.io/boundless-xyz/boundless/broker:latest}


### PR DESCRIPTION
This also fixes what seems to be a bug with blake3groth16 such that the bind mount was conflicting with the files downloaded, which at least caused issues with any configuration I tried when running this outside of dev mode.

Another small change is that localnet will use a separate broker.toml file, to avoid conflicts with any other configuration or modifying the same broker.toml file.

Adds a simple example without a pinned lockfile, to ensure no issues with that on latest version, as that had been an issue before.

TLDR this command `just test-e2e-release` will spin up a localnet (dev more or full proving) and run all examples against it in parallel.