### PR TITLE
BM-2918: make ChainMonitorV2 the default, gate legacy path behind --legacy-rpc

### DIFF
--- a/ansible/roles/prover/README.md
+++ b/ansible/roles/prover/README.md
@@ -104,8 +104,9 @@ Compose defaults can be overridden with env vars: `AGENT_IMAGE`, `CPU_AGENT_IMAG
 | `prover_broker_config_dir`       | `""`         | Config directory (e.g. `configs/broker/prod-mainnet-nightly`). Copies all files. Preferred.     |
 | `prover_broker_toml_local`       | `""`         | Local broker.toml file path. Used when config_dir is not set.                                   |
 | `prover_broker_toml_url`         | (GitHub URL) | URL to broker.toml template (used when config_dir and toml_local are not set)                   |
-| `prover_broker_experimental_rpc` | `false`      | When true, pass `--experimental-rpc` to the broker.                                             |
-| `prover_broker_extra_args`       | `""`         | Extra CLI args for the broker (can combine with experimental_rpc).                              |
+| `prover_broker_experimental_rpc` | `false`      | Deprecated. ChainMonitorV2 is now the broker default; `--experimental-rpc` is a no-op flag.     |
+| `prover_broker_legacy_rpc`       | `false`      | When true, pass `--legacy-rpc` to opt back into the legacy ChainMonitorService + MarketMonitor. |
+| `prover_broker_extra_args`       | `""`         | Extra CLI args for the broker.                                                                  |
 | `prover_chain_rpc_urls`          | `{}`         | Dict of chain_id → RPC URL for multichain (e.g. `{8453: "https://...", 167000: "https://..."}`) |
 | `prover_chain_overrides`         | `{}`         | Dict of chain_id → URL or local path for per-chain broker config overrides                      |
 

--- a/ansible/roles/prover/defaults/main.yml
+++ b/ansible/roles/prover/defaults/main.yml
@@ -76,9 +76,14 @@ prover_private_key: ""
 prover_rpc_url: ""
 prover_rpc_urls: ""
 prover_povw_log_id: ""
-# Set to true to pass --experimental-rpc to the broker (experimental L1Monitor using eth_getBlockReceipts).
+# Deprecated: ChainMonitorV2 (eth_getBlockReceipts) is now the broker default. Setting this
+# to true still passes --experimental-rpc, which is now a no-op flag kept for backwards
+# compatibility. Use prover_broker_legacy_rpc to opt back into the old eth_getLogs path.
 prover_broker_experimental_rpc: false
-# Optional extra CLI args for the broker (e.g. "--other-flag"). Ignored when prover_broker_experimental_rpc is true.
+# Set to true to pass --legacy-rpc to the broker, opting back into the legacy
+# ChainMonitorService + MarketMonitor pair (eth_getLogs based).
+prover_broker_legacy_rpc: false
+# Optional extra CLI args for the broker (e.g. "--other-flag").
 prover_broker_extra_args: ""
 
 # Broker configuration directory. When set, copies broker.toml and all broker.*.toml

--- a/ansible/roles/prover/templates/docker-compose.env.j2
+++ b/ansible/roles/prover/templates/docker-compose.env.j2
@@ -170,6 +170,9 @@ PROVER_RPC_URL_{{ chain_id }}={{ rpc_url }}
 {% if prover_broker_experimental_rpc | default(false) | bool %}
 {% set _ = broker_args.append('--experimental-rpc') %}
 {% endif %}
+{% if prover_broker_legacy_rpc | default(false) | bool %}
+{% set _ = broker_args.append('--legacy-rpc') %}
+{% endif %}
 {% if prover_broker_extra_args is defined and prover_broker_extra_args | string | length > 0 %}
 {% set _ = broker_args.append(prover_broker_extra_args) %}
 {% endif %}

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -554,7 +554,8 @@ mod tests {
             rpc_request_timeout: 30,
             log_json: false,
             listen_only: false,
-            experimental_rpc: false,
+            experimental_rpc: true,
+            legacy_rpc: false,
             version_registry_address: None,
             force_version_check: false,
         }

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -270,7 +270,7 @@ async fn main() -> Result<()> {
             )?;
 
         let rpc_urls =
-            collect_rpc_urls(args.rpc_url.clone(), args.rpc_urls.clone(), args.experimental_rpc)?;
+            collect_rpc_urls(args.rpc_url.clone(), args.rpc_urls.clone(), args.legacy_rpc)?;
 
         let config = base_config_watcher.config.clone();
         let (provider, any_provider, gas_priority_mode) =
@@ -399,7 +399,7 @@ async fn main() -> Result<()> {
 fn collect_rpc_urls(
     rpc_url: Option<String>,
     rpc_urls: Vec<String>,
-    experimental_rpc: bool,
+    legacy_rpc: bool,
 ) -> Result<Vec<Url>> {
     // Use Vec to preserve insertion order: PROVER_RPC_URL is always inserted first,
     let mut all_rpc_urls: Vec<Url> = Vec::new();
@@ -439,7 +439,7 @@ fn collect_rpc_urls(
         }
     }
 
-    if all_rpc_urls.is_empty() && experimental_rpc {
+    if all_rpc_urls.is_empty() && !legacy_rpc {
         all_rpc_urls.push(
             Url::parse("https://base.gateway.tenderly.co")
                 .expect("hardcoded Tenderly URL is valid"),
@@ -655,7 +655,9 @@ mod tests {
 
     #[test]
     fn errors_on_empty() {
-        let result = collect_rpc_urls(None, vec![], false);
+        // legacy_rpc=true disables the Tenderly fallback that the default (V2) path injects,
+        // so an empty input correctly surfaces the "no RPC URLs" error.
+        let result = collect_rpc_urls(None, vec![], true);
         assert!(result.is_err());
     }
 
@@ -679,7 +681,8 @@ mod tests {
             rpc_request_timeout: 15,
             log_json: false,
             listen_only: false,
-            experimental_rpc: false,
+            experimental_rpc: true,
+            legacy_rpc: false,
             version_registry_address: None,
             force_version_check: false,
         }

--- a/crates/broker/src/chain_monitor.rs
+++ b/crates/broker/src/chain_monitor.rs
@@ -58,8 +58,8 @@ pub(crate) struct ChainHead {
 }
 
 /// Trait abstracting the chain monitor query interface.
-/// Allows swapping the standard `ChainMonitorService` with alternative implementations
-/// (e.g. `ChainMonitorV2` behind `--experimental-rpc`).
+/// Implemented by both the default `ChainMonitorV2` (eth_getBlockReceipts) and the
+/// legacy `ChainMonitorService` pair (eth_getLogs, selected via `--legacy-rpc`).
 #[async_trait]
 pub(crate) trait ChainMonitorApi: Send + Sync {
     async fn current_chain_head(&self) -> Result<ChainHead>;

--- a/crates/broker/src/chain_monitor_v2.rs
+++ b/crates/broker/src/chain_monitor_v2.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Experimental ChainMonitorV2 implementation.
+//! ChainMonitorV2 — the default chain-monitor implementation.
 //!
-//! Replaces both `ChainMonitorService` and `MarketMonitor` with a single struct when
-//! `--experimental-rpc` is set. A single polling loop fetches block receipts per block,
-//! extracts market events, and updates the chain-head atomics read by `ChainMonitorApi`.
+//! Replaces both `ChainMonitorService` and `MarketMonitor` with a single struct: one
+//! polling loop fetches block receipts per block, extracts market events, and updates
+//! the chain-head atomics read by `ChainMonitorApi`. Pass `--legacy-rpc` to fall back
+//! to the older `ChainMonitorService` + `MarketMonitor` pair.
 
 use std::{
     sync::{

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -178,9 +178,16 @@ pub struct CoreArgs {
     #[clap(long, default_value_t = false)]
     pub listen_only: bool,
 
-    /// Use the experimental ChainMonitorV2 implementation using eth_getBlockReceipts instead of eth_getLogs.
-    #[clap(long, default_value_t = false)]
+    /// Deprecated and ignored: ChainMonitorV2 (eth_getBlockReceipts) is now the default.
+    /// Pass `--legacy-rpc` to opt back into the legacy ChainMonitorService + MarketMonitor pair.
+    /// Kept for backwards compatibility with existing scripts and inventories.
+    #[clap(long, default_value_t = true, hide = true)]
     pub experimental_rpc: bool,
+
+    /// Use the legacy ChainMonitorService + MarketMonitor pair (eth_getLogs based).
+    /// The default is ChainMonitorV2, which uses eth_getBlockReceipts in a single polling loop.
+    #[clap(long, default_value_t = false)]
+    pub legacy_rpc: bool,
 
     /// VersionRegistry contract address override. Not a CLI flag — set programmatically in tests
     /// to exercise the version check against a locally deployed registry.
@@ -1211,10 +1218,10 @@ impl Broker {
 
         let prover_addr = provider.default_signer_address();
 
-        // Set up chain + market monitoring. Either use the standard ChainMonitorService +
-        // MarketMonitor pair, or the experimental ChainMonitorV2 (--experimental-rpc) which
-        // replaces both with a single implementation.
-        let (chain_monitor, block_times) = if self.args.experimental_rpc {
+        // Set up chain + market monitoring. Default is ChainMonitorV2, a single polling loop
+        // built on eth_getBlockReceipts. Pass `--legacy-rpc` to fall back to the older
+        // ChainMonitorService + MarketMonitor pair (eth_getLogs).
+        let (chain_monitor, block_times) = if !self.args.legacy_rpc {
             let monitor = Arc::new(
                 chain_monitor_v2::ChainMonitorV2::new(
                     db.clone(),
@@ -1809,7 +1816,8 @@ pub mod test_utils {
                 rpc_request_timeout: 30,
                 log_json: false,
                 listen_only: false,
-                experimental_rpc: false,
+                experimental_rpc: true,
+                legacy_rpc: false,
                 version_registry_address: Some(ctx.version_registry_address),
                 force_version_check: false,
             };

--- a/crates/broker/src/tests/e2e.rs
+++ b/crates/broker/src/tests/e2e.rs
@@ -208,7 +208,8 @@ pub(super) fn broker_args(
         rpc_request_timeout: 30,
         log_json: false,
         listen_only: false,
-        experimental_rpc: false,
+        experimental_rpc: true,
+        legacy_rpc: false,
         version_registry_address,
         force_version_check: false,
     }
@@ -359,7 +360,8 @@ async fn simple_e2e_experimental_rpc() {
         .unwrap();
     ctx.customer_market.deposit(utils::parse_ether("0.5").unwrap()).await.unwrap();
 
-    // Start broker with experimental RPC path enabled
+    // Regression test: the deprecated `--experimental-rpc` flag must still parse and behave
+    // identically to the (now-default) V2 path. Setting it explicitly is a no-op.
     let config = new_config(1).await;
     let config_watcher = config.watcher().await;
     let mut args = broker_args(
@@ -380,6 +382,78 @@ async fn simple_e2e_experimental_rpc() {
     )
     .await;
     args.experimental_rpc = true;
+    let broker = Broker::new(args, config_watcher).await.unwrap();
+
+    // Provide URL for ECHO program
+    let storage = MockStorageUploader::new();
+    let image_url = storage.upload_program(ECHO_ELF).await.unwrap();
+
+    // Submit an order
+    let request = generate_request(
+        ctx.customer_market.index_from_nonce().await.unwrap(),
+        &ctx.customer_signer.address(),
+        ProofType::Any,
+        image_url,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    run_with_broker(broker, vec![chain], async move {
+        // Submit the request
+        ctx.customer_market.submit_request(&request, &ctx.customer_signer).await.unwrap();
+
+        // Wait for fulfillment
+        ctx.customer_market
+            .wait_for_request_fulfillment(
+                U256::from(request.id),
+                Duration::from_secs(1),
+                request.expires_at(),
+            )
+            .await
+            .unwrap();
+    })
+    .await;
+}
+
+#[tokio::test]
+#[traced_test]
+async fn simple_e2e_legacy_rpc() {
+    // Setup anvil
+    let anvil = Anvil::new().spawn();
+
+    // Setup signers / providers
+    let ctx = create_test_ctx(&anvil).await.unwrap();
+
+    // Deposit prover / customer balances
+    ctx.prover_market
+        .deposit_collateral_with_permit(default_allowance(), &ctx.prover_signer)
+        .await
+        .unwrap();
+    ctx.customer_market.deposit(utils::parse_ether("0.5").unwrap()).await.unwrap();
+
+    // Start broker with the legacy ChainMonitorService + MarketMonitor pair (--legacy-rpc).
+    let config = new_config(1).await;
+    let config_watcher = config.watcher().await;
+    let mut args = broker_args(
+        config.base_path(),
+        ctx.deployment.clone(),
+        anvil.endpoint_url(),
+        ctx.prover_signer.clone(),
+        Some(ctx.version_registry_address),
+    );
+    let db_dir = tempfile::tempdir().unwrap();
+    let chain = build_test_chain(
+        &ctx.prover_provider,
+        &ctx.prover_signer,
+        &ctx.deployment,
+        anvil.endpoint_url(),
+        &config_watcher.config,
+        db_dir.path(),
+    )
+    .await;
+    args.legacy_rpc = true;
     let broker = Broker::new(args, config_watcher).await.unwrap();
 
     // Provide URL for ECHO program


### PR DESCRIPTION
  ## Summary

  - Flip the broker chain-monitor default: `ChainMonitorV2` (eth_getBlockReceipts polling loop) is now the default. The legacy `ChainMonitorService` + `MarketMonitor` pair (eth_getLogs) is opt-in via a new `--legacy-rpc` flag.
  - Soft rename: `--experimental-rpc` is kept as a hidden, deprecated, no-op flag so existing invocations that pass it continue to parse without error.
  - The ansible role mirrors the same shape: `prover_broker_experimental_rpc` is preserved as a deprecated no-op; new `prover_broker_legacy_rpc` opts into the legacy path.

  ## Migration notes for prover operators

  Whether you run the broker via `just prover` / `cargo run --bin broker`, the published Docker image, or an ansible-managed deployment, the migration is the same:

  - **No action required** if you previously ran with the broker default (V1) and are comfortable moving to V2 — V2 is now selected automatically on upgrade.
  - **No action required** if you previously passed `--experimental-rpc` (or set `prover_broker_experimental_rpc: true` in ansible) — the flag is redundant now but still accepted; behavior is unchanged (V2 stays selected).
  - **To stay on the old path**: pass `--legacy-rpc` on the broker CLI, or set `prover_broker_legacy_rpc: true` in your ansible inventory.

  ## Follow-up (not in this PR)

  After V2 has run as the default in prod for ~2–4 weeks without regressions: delete `chain_monitor.rs`, `market_monitor.rs`, the `--legacy-rpc` flag, the deprecated `--experimental-rpc` field, the legacy ansible vars, and the `simple_e2e_legacy_rpc` regression test.