### PR TITLE
BM-2924: remove deprecated config in template, warn in generate config

### DIFF
--- a/broker-template.toml
+++ b/broker-template.toml
@@ -45,27 +45,6 @@ min_mcycle_price = "0.00002 USD"
 # [market.pricing_overrides.by_requestor_proof_type]
 # "0xAbC...123:0x12345678" = "0.001 USD"
 
-# The minimum price per mega-cycle (i.e. million RISC-V cycles) for the broker
-# to attempt to fulfill an order in the case that the order was locked by another prover
-# but not fulfilled within the lock timeout.
-#
-# If an order is locked by a prover, but not fulfilled within the lock timeout,
-# that prover is slashed by the amount of collateral specified in the order. A
-# portion of this collateral is then used to incentivize other provers to
-# fulfill the order. `min_mcycle_price_collateral_token` determines the minimum
-# price per mega-cycle in collateral token that must be offered by the prover
-# for the broker to attempt to fulfill these orders.
-#
-# Can be specified in USD or ZKC.
-# Plain numbers default to ZKC for backward compatibility.
-# If USD, converted to ZKC at runtime via price oracle.
-
-# Examples: "0.00005 ZKC", "0.00001 USD", "0.00005"
-#
-# Note: attempting to fulfill these orders is a 'proof race' where the first prover
-# to fulfill the order is rewarded with the collateral.
-min_mcycle_price_collateral_token = "0.00005 ZKC"
-
 # Expected probability of winning the secondary fulfillment race, expressed as a percentage.
 # When an order's lock expires, multiple provers may race to fulfill it.
 # Scales the expected reward when evaluating profitability and priority.

--- a/chain-overrides/broker-override-template.toml
+++ b/chain-overrides/broker-override-template.toml
@@ -14,10 +14,6 @@
 # Minimum price per mega-cycle. Can be specified in USD or ETH.
 # min_mcycle_price = "0.00002 USD"
 
-# Minimum price per mega-cycle in collateral token for secondary fulfillment.
-# Can be specified in USD or ZKC.
-# min_mcycle_price_collateral_token = "0.00005 ZKC"
-
 # Maximum collateral the broker will deposit on this chain.
 # max_collateral = "10 USD"
 

--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -1079,9 +1079,7 @@ impl ProverGenerateConfig {
                 }
                 for (key, msg) in REMOVED_MARKET_KEYS {
                     if market.contains_key(key) {
-                        display.warning(&format!(
-                            "[market].{key} {msg}; please remove this entry"
-                        ));
+                        display.warning(&format!("[market].{key} {msg}; please remove this entry"));
                     }
                 }
             }
@@ -1238,8 +1236,7 @@ impl ProverGenerateConfig {
                 let probability_value = toml_edit::value(
                     first_chain.expected_probability_win_secondary_fulfillment as i64,
                 );
-                if let Some(item) =
-                    market.get_mut("expected_probability_win_secondary_fulfillment")
+                if let Some(item) = market.get_mut("expected_probability_win_secondary_fulfillment")
                 {
                     *item = probability_value;
                 } else {

--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -49,6 +49,28 @@ const PRIORITY_REQUESTOR_LIST_LARGE: &str =
 const PRIORITY_REQUESTOR_LIST_XL: &str =
     "https://requestors.boundless.network/boundless-recommended-priority-list.xl.json";
 
+// Keys under [market] that were renamed and whose backwards-compatible serde
+// aliases have been removed. If found in an existing broker.toml, the broker
+// will fail to deserialize them, so the wizard surfaces these as a migration
+// warning. Pairs are (old_name, new_name).
+const RENAMED_MARKET_KEYS: &[(&str, &str)] = &[
+    ("mcycle_price", "min_mcycle_price"),
+    ("max_stake", "max_collateral"),
+    ("stake_balance_warn_threshold", "collateral_balance_warn_threshold"),
+    ("stake_balance_error_threshold", "collateral_balance_error_threshold"),
+    ("max_concurrent_locks", "max_concurrent_proofs"),
+    ("expired_order_fulfillment_priority", "order_commitment_priority"),
+];
+
+// Keys under [market] that have been removed entirely with no replacement key.
+// They are silently ignored by the broker (no `deny_unknown_fields`), so the
+// wizard surfaces them so the user can clean up their broker.toml. Pairs are
+// (old_key, explanation).
+const REMOVED_MARKET_KEYS: &[(&str, &str)] = &[(
+    "min_mcycle_price_collateral_token",
+    "is no longer used; secondary fulfillment now derives its threshold from min_mcycle_price (converted to ZKC at runtime)",
+)];
+
 mod selection_strings {
     // Benchmark performance options
     pub const BENCHMARK_RUN_SUITE: &str =
@@ -1043,6 +1065,28 @@ impl ProverGenerateConfig {
         // Parse with toml_edit (preserves comments and formatting)
         let mut doc = source.parse::<toml_edit::DocumentMut>().context("Failed to parse TOML")?;
 
+        // Surface any keys whose serde aliases were removed — the broker will
+        // refuse to load these names — and any keys that have been removed
+        // outright and are now silently dropped on load.
+        if matches!(strategy, FileHandlingStrategy::ModifyExisting) {
+            if let Some(market) = doc.get("market").and_then(|v| v.as_table()) {
+                for (old_key, new_key) in RENAMED_MARKET_KEYS {
+                    if market.contains_key(old_key) {
+                        display.warning(&format!(
+                            "[market].{old_key} is no longer accepted; rename to [market].{new_key}"
+                        ));
+                    }
+                }
+                for (key, msg) in REMOVED_MARKET_KEYS {
+                    if market.contains_key(key) {
+                        display.warning(&format!(
+                            "[market].{key} {msg}; please remove this entry"
+                        ));
+                    }
+                }
+            }
+        }
+
         // Create CLI wizard metadata section with pretty tags
         let metadata_section = format!(
             "### [CLI Wizard Metadata] #####\n\
@@ -1109,13 +1153,16 @@ impl ProverGenerateConfig {
                 *item = toml_edit::value(config.max_concurrent_proofs as i64);
             }
 
-            // Update priority_requestor_lists
+            // Update priority_requestor_lists (insert if missing)
+            let mut arr = toml_edit::Array::new();
+            for list in &config.priority_requestor_lists {
+                arr.push(list.clone());
+            }
+            let priority_lists_value = toml_edit::value(arr);
             if let Some(item) = market.get_mut("priority_requestor_lists") {
-                let mut arr = toml_edit::Array::new();
-                for list in &config.priority_requestor_lists {
-                    arr.push(list.clone());
-                }
-                *item = toml_edit::value(arr);
+                *item = priority_lists_value;
+            } else {
+                market.insert("priority_requestor_lists", priority_lists_value);
             }
 
             // Update max_concurrent_preflights with calculation comment
@@ -1185,11 +1232,20 @@ impl ProverGenerateConfig {
                 }
             }
 
-            // Update expected_probability_win_secondary_fulfillment (uses first chain's value)
-            if let Some(item) = market.get_mut("expected_probability_win_secondary_fulfillment") {
-                if let Some(first_chain) = config.chains.first() {
-                    *item = toml_edit::value(
-                        first_chain.expected_probability_win_secondary_fulfillment as i64,
+            // Update expected_probability_win_secondary_fulfillment (insert if missing,
+            // uses first chain's value)
+            if let Some(first_chain) = config.chains.first() {
+                let probability_value = toml_edit::value(
+                    first_chain.expected_probability_win_secondary_fulfillment as i64,
+                );
+                if let Some(item) =
+                    market.get_mut("expected_probability_win_secondary_fulfillment")
+                {
+                    *item = probability_value;
+                } else {
+                    market.insert(
+                        "expected_probability_win_secondary_fulfillment",
+                        probability_value,
                     );
                 }
             }

--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -1072,7 +1072,7 @@ impl ProverGenerateConfig {
                 for (old_key, new_key) in RENAMED_MARKET_KEYS {
                     if market.contains_key(old_key) {
                         display.warning(&format!(
-                            "[market].{old_key} is no longer accepted; rename to [market].{new_key}"
+                            "[market].{old_key} is no longer used; rename to [market].{new_key}"
                         ));
                     }
                 }

--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -49,8 +49,8 @@ const PRIORITY_REQUESTOR_LIST_LARGE: &str =
 const PRIORITY_REQUESTOR_LIST_XL: &str =
     "https://requestors.boundless.network/boundless-recommended-priority-list.xl.json";
 
-// Keys under [market] that were renamed. Old names are silently dropped on load, 
-// which looks like the user's tuning is in effect when it isn't. 
+// Keys under [market] that were renamed. Old names are silently dropped on load,
+// which looks like the user's tuning is in effect when it isn't.
 // The wizard surfaces these so the user notices and renames.
 const RENAMED_MARKET_KEYS: &[(&str, &str)] = &[
     ("mcycle_price", "min_mcycle_price"),

--- a/crates/boundless-cli/src/commands/prover/generate_config.rs
+++ b/crates/boundless-cli/src/commands/prover/generate_config.rs
@@ -49,10 +49,9 @@ const PRIORITY_REQUESTOR_LIST_LARGE: &str =
 const PRIORITY_REQUESTOR_LIST_XL: &str =
     "https://requestors.boundless.network/boundless-recommended-priority-list.xl.json";
 
-// Keys under [market] that were renamed and whose backwards-compatible serde
-// aliases have been removed. If found in an existing broker.toml, the broker
-// will fail to deserialize them, so the wizard surfaces these as a migration
-// warning. Pairs are (old_name, new_name).
+// Keys under [market] that were renamed. Old names are silently dropped on load, 
+// which looks like the user's tuning is in effect when it isn't. 
+// The wizard surfaces these so the user notices and renames.
 const RENAMED_MARKET_KEYS: &[(&str, &str)] = &[
     ("mcycle_price", "min_mcycle_price"),
     ("max_stake", "max_collateral"),


### PR DESCRIPTION
Closes BM-2917

removes the `min_mcycle_price_collateral_token` config from broker files, fixes cli to insert the `expected_probability_win_secondary_fulfillment` if missing (would only modify if already existing), and then adds some backwards compatibility support for certain renamed keys.