### PR TITLE
BM-2925: add delay to submission failure retry, change default to 3

### DIFF
--- a/crates/boundless-market/src/prover_utils/config.rs
+++ b/crates/boundless-market/src/prover_utils/config.rs
@@ -86,7 +86,11 @@ pub mod defaults {
     }
 
     pub const fn max_submission_attempts() -> u32 {
-        2
+        3
+    }
+
+    pub const fn submit_retry_delay_ms() -> u64 {
+        1500
     }
 
     pub const fn reaper_interval_secs() -> u32 {
@@ -744,6 +748,13 @@ pub struct BatcherConfig {
     /// Number of attempts to make to submit a batch before abandoning
     #[serde(default = "defaults::max_submission_attempts")]
     pub max_submission_attempts: u32,
+    /// Delay (in milliseconds) between batch submission retry attempts.
+    ///
+    /// Inserted between attempts to give the chain and the public RPC's pending-tx view
+    /// time to converge after a transient nonce-state inconsistency (e.g. a concurrent
+    /// lock and fulfill from the same wallet hitting `replacement transaction underpriced`).
+    #[serde(default = "defaults::submit_retry_delay_ms")]
+    pub submit_retry_delay_ms: u64,
 }
 
 impl Default for BatcherConfig {
@@ -759,6 +770,7 @@ impl Default for BatcherConfig {
             single_txn_fulfill: defaults::single_txn_fulfill(),
             withdraw: defaults::withdraw(),
             max_submission_attempts: defaults::max_submission_attempts(),
+            submit_retry_delay_ms: defaults::submit_retry_delay_ms(),
         }
     }
 }
@@ -1142,6 +1154,7 @@ min_mcycle_price = "0.05 ETH"
 
 [batcher]
 min_batch_size = 4
+submit_retry_delay_ms = 250
 "#;
         let config = Config::merge(base, override_toml).unwrap();
         assert_eq!(config.market.min_mcycle_price, Amount::parse("0.05 ETH", None).unwrap());
@@ -1149,6 +1162,7 @@ min_batch_size = 4
         assert_eq!(config.market.lookback_blocks, 100);
         assert_eq!(config.batcher.min_batch_size, 4);
         assert_eq!(config.batcher.batch_max_time, 300);
+        assert_eq!(config.batcher.submit_retry_delay_ms, 250);
     }
 
     #[test]
@@ -1212,5 +1226,12 @@ min_batch_size = 4
         let config = Config::merge(base, override_toml).unwrap();
         assert_eq!(config.market.min_mcycle_price, Amount::parse("0.1 ETH", None).unwrap());
         assert_eq!(config.batcher.min_batch_size, 4);
+    }
+
+    #[test]
+    fn test_batcher_config_defaults() {
+        let config = BatcherConfig::default();
+        assert_eq!(config.max_submission_attempts, 3);
+        assert_eq!(config.submit_retry_delay_ms, 1000);
     }
 }

--- a/crates/boundless-market/src/prover_utils/config.rs
+++ b/crates/boundless-market/src/prover_utils/config.rs
@@ -1232,6 +1232,6 @@ min_batch_size = 4
     fn test_batcher_config_defaults() {
         let config = BatcherConfig::default();
         assert_eq!(config.max_submission_attempts, 3);
-        assert_eq!(config.submit_retry_delay_ms, 1000);
+        assert_eq!(config.submit_retry_delay_ms, 1500);
     }
 }

--- a/crates/broker/src/submitter.rs
+++ b/crates/broker/src/submitter.rs
@@ -604,56 +604,48 @@ where
             return Ok(());
         };
 
-        let max_batch_submission_attempts = self
-            .config
-            .lock_all()
-            .context("Failed to read config")?
-            .batcher
-            .max_submission_attempts;
+        let (max_attempts, retry_delay_ms) = {
+            let cfg = self.config.lock_all().context("Failed to read config")?;
+            (cfg.batcher.max_submission_attempts, cfg.batcher.submit_retry_delay_ms)
+        };
+        let retry_count = u64::from(max_attempts.saturating_sub(1));
 
-        let mut errors = Vec::new();
-        for attempt in 0..max_batch_submission_attempts {
-            match self.submit_batch(batch_id, &batch).await {
-                Ok(_) => {
-                    self.db
-                        .set_batch_submitted(batch_id)
-                        .await
-                        .context("Failed to set batch submitted")?;
-                    tracing::info!(
-                        "Completed batch: {batch_id} total_fees: {}",
-                        format_ether(batch.fees)
-                    );
-                    return Ok(());
-                }
-                Err(SubmitterErr::MarketError(
-                    MarketError::PaymentRequirementsFailedUnknownError(raw),
-                )) => {
-                    tracing::warn!(
-                        "Payment requirement failed for one or more orders, will not retry (raw error: {raw:?})"
-                    );
-                    errors.push(SubmitterErr::MarketError(
-                        MarketError::PaymentRequirementsFailedUnknownError(raw),
-                    ));
-                    break;
-                }
-                Err(SubmitterErr::MarketError(MarketError::PaymentRequirementsFailed(err))) => {
-                    tracing::warn!("Payment requirement failed for one or more orders: {err:?}, will not retry");
-                    errors.push(SubmitterErr::MarketError(MarketError::PaymentRequirementsFailed(
-                        err,
-                    )));
-                    break;
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        "Batch submission attempt {}/{} failed. Error: {err:?}",
-                        attempt + 1,
-                        max_batch_submission_attempts,
-                    );
-                    errors.push(err);
-                }
+        let context = format!("batch_id={batch_id}");
+        let result = crate::futures_retry::retry_only_with_context(
+            retry_count,
+            retry_delay_ms,
+            || async { self.submit_batch(batch_id, &batch).await },
+            "submit_batch",
+            &context,
+            |err: &SubmitterErr| {
+                // Retry on every error except payment-requirements, which is fatal today.
+                !matches!(
+                    err,
+                    SubmitterErr::MarketError(
+                        MarketError::PaymentRequirementsFailed(_)
+                            | MarketError::PaymentRequirementsFailedUnknownError(_),
+                    )
+                )
+            },
+        )
+        .await;
+
+        let err = match result {
+            Ok(()) => {
+                self.db
+                    .set_batch_submitted(batch_id)
+                    .await
+                    .context("Failed to set batch submitted")?;
+                tracing::info!(
+                    "Completed batch: {batch_id} total_fees: {}",
+                    format_ether(batch.fees)
+                );
+                return Ok(());
             }
-        }
-        tracing::warn!("Batch {batch_id} has reached max submission attempts. Errors: {errors:?}");
+            Err(err) => err,
+        };
+
+        tracing::warn!("Batch {batch_id} submission failed after retries: {err:?}");
 
         // Now that retries are exhausted, mark every order in the batch as Failed.
         for order_id in batch.orders.iter() {
@@ -665,15 +657,16 @@ where
             }
         }
 
-        if let Err(err) = self.db.set_batch_failure(batch_id, format!("{errors:?}")).await {
+        if let Err(db_err) = self.db.set_batch_failure(batch_id, format!("{err:?}")).await {
             return Err(SubmitterErr::UnexpectedErr(anyhow!(
-                "Failed to set batch failure in db: {batch_id} - {err:?}"
+                "Failed to set batch failure in db: {batch_id} - {db_err:?}"
             )));
         }
-        if errors.iter().all(|e| matches!(e, SubmitterErr::TxnConfirmationError(_))) {
-            Err(SubmitterErr::BatchSubmissionFailedTimeouts(errors))
+
+        if matches!(err, SubmitterErr::TxnConfirmationError(_)) {
+            Err(SubmitterErr::BatchSubmissionFailedTimeouts(vec![err]))
         } else {
-            Err(SubmitterErr::BatchSubmissionFailed(errors))
+            Err(SubmitterErr::BatchSubmissionFailed(vec![err]))
         }
     }
 }
@@ -1017,17 +1010,31 @@ mod tests {
     #[traced_test]
     async fn submit_batch_retry_max_attempts() {
         let config = ConfigLock::default();
+        {
+            let mut cfg = config.load_write();
+            let cfg = cfg.as_mut().unwrap();
+            // Pin the attempt count for stable assertions and zero out the retry delay
+            // so the test does not wait between attempts.
+            cfg.batcher.max_submission_attempts = 2;
+            cfg.batcher.submit_retry_delay_ms = 0;
+        }
         let (anvil, submitter, db, batch_id) = build_submitter_and_batch(config).await;
 
         let batch = db.get_batch(batch_id).await.unwrap();
         let order_ids = batch.orders.clone();
         assert!(!order_ids.is_empty(), "test batch should have at least one order");
 
-        drop(anvil); // drop anvil to simluate an RPC fault
+        drop(anvil); // drop anvil to simulate an RPC fault
 
         let res = submitter.process_next_batch().await;
-        assert!(logs_contain("Batch submission attempt 1/2 failed"));
-        assert!(logs_contain("reached max submission attempts"));
+        // futures_retry emits this format on each failed attempt:
+        //   "Operation [submit_batch] (context: batch_id=0) failed: ..., starting retry 1/1"
+        assert!(logs_contain("Operation [submit_batch] (context: batch_id=0)"));
+        assert!(logs_contain("starting retry 1/1"));
+        assert!(logs_contain(
+            "Operation [submit_batch] (context: batch_id=0) failed after 1 retries",
+        ));
+        assert!(logs_contain("Batch 0 submission failed after retries"));
         assert!(matches!(res, Err(SubmitterErr::BatchSubmissionFailed(_))));
 
         // After exhaustion, every order in the batch must be marked Failed and the


### PR DESCRIPTION
Currently the retry is instant, and can cause issues if the rpc returns inconsistent state.

Adds a configurable delay and also increases the default retry count from 2 to 3. Only 2 total tries for a submission seems low given the cost.