### PR TITLE
BM-2926: switch prover2 compose namespace

### DIFF
--- a/ansible/roles/vector/templates/vector.yaml.j2
+++ b/ansible/roles/vector/templates/vector.yaml.j2
@@ -62,7 +62,7 @@ sources:
     mode: scheduled
     scheduled:
       exec_interval_secs: {{ vector_bento_process_interval_secs | default(60) }}
-    command: ["/bin/sh", "-c", "PATH=/usr/bin:/bin docker ps -q --filter label=com.docker.compose.project=bento 2>/dev/null | wc -l"]
+    command: ["/bin/sh", "-c", "PATH=/usr/bin:/bin; b=$(docker ps -q --filter label=com.docker.compose.project=bento 2>/dev/null | wc -l); p=$(docker ps -q --filter label=com.docker.compose.project=prover 2>/dev/null | wc -l); echo $((b + p))"]
 {% endif %}
 
 {% if vector_track_kailua_process | default(false) | bool %}

--- a/compose.blake3-local.yml
+++ b/compose.blake3-local.yml
@@ -15,7 +15,6 @@
 # `just bento up` / `just prover up` auto-include this file whenever
 # BLAKE3_GROTH16_SETUP_DIR is set in the environment.
 
-name: bento
 services:
   gpu_prove_agent:
     volumes:

--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -1,4 +1,4 @@
-name: bento
+name: prover
 # GPU Configuration:
 # The gpu_prove_agent service automatically detects all available GPUs using nvidia-smi
 # and spawns a prove agent process for each GPU. No manual configuration needed.


### PR DESCRIPTION
The issue is that currently bento and prover2 share the same namespace, which means that redis data is overlapping, but also if you run a clean using the new stack, it will clear the previous data. I think this is a footgun that either could cause issues for provers.

This change might cause some complications for our prover, so one way we can avoid this is just changing the redis namespace (and double check nothing else overlapping), but this seems safer to avoid any potential overlap. cc @zeroecco 