### PR TITLE
BM-2927: keep telemetry alive during graceful shutdown drain

### DIFF
--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -1145,9 +1145,13 @@ impl Broker {
                             config.clone(),
                             db.clone(),
                         );
-                        let cancel_token = non_critical_cancel_token.clone();
+                        // Bind telemetry to the critical cancel token so it keeps emitting
+                        // broker heartbeats during the Phase 2 drain (in-flight committed
+                        // orders). Otherwise monitoring sees the broker as offline within
+                        // seconds of SIGTERM, while it is in fact still actively proving.
+                        let cancel_token = critical_cancel_token.clone();
                         let cs = chain_span.clone();
-                        non_critical_tasks.spawn(
+                        critical_tasks.spawn(
                             async move {
                                 telemetry::run_telemetry_service(service, cancel_token)
                                     .await
@@ -1175,9 +1179,9 @@ impl Broker {
                             config.clone(),
                             db.clone(),
                         );
-                        let cancel_token = non_critical_cancel_token.clone();
+                        let cancel_token = critical_cancel_token.clone();
                         let cs = chain_span.clone();
-                        non_critical_tasks.spawn(
+                        critical_tasks.spawn(
                             async move {
                                 telemetry::run_telemetry_service(service, cancel_token)
                                     .await
@@ -1201,9 +1205,9 @@ impl Broker {
                     config.clone(),
                     db.clone(),
                 );
-                let cancel_token = non_critical_cancel_token.clone();
+                let cancel_token = critical_cancel_token.clone();
                 let cs = chain_span.clone();
-                non_critical_tasks.spawn(
+                critical_tasks.spawn(
                     async move {
                         telemetry::run_telemetry_service(service, cancel_token)
                             .await

--- a/crates/broker/src/service_runner.rs
+++ b/crates/broker/src/service_runner.rs
@@ -81,9 +81,22 @@ impl ServiceRunner {
 
     /// Cancellation token for non-critical tasks. Useful when a caller needs
     /// to spawn a raw future via [`Self::spawn_future_in_span`] that consumes
-    /// the token.
+    /// the token. Currently only used in tests after telemetry moved to the
+    /// critical token (see [`Self::critical_cancel_token`]); kept as a public
+    /// method for API symmetry and so future non-critical raw-future spawners
+    /// have a getter that mirrors the critical one.
+    #[allow(dead_code)]
     pub fn non_critical_cancel_token(&self) -> CancellationToken {
         self.non_critical_cancel_token.clone()
+    }
+
+    /// Cancellation token for critical tasks. Useful when a caller spawns a
+    /// raw future via [`Self::spawn_future_in_span`] under `Criticality::Critical`
+    /// (or `CriticalWithFastRetry`) and needs to consume the token directly —
+    /// e.g. the telemetry service, which keeps emitting heartbeats during the
+    /// Phase 2 in-flight-order drain and only exits on the critical token.
+    pub fn critical_cancel_token(&self) -> CancellationToken {
+        self.critical_cancel_token.clone()
     }
 
     /// Registers a supervised service. Equivalent to the legacy

--- a/crates/broker/src/telemetry.rs
+++ b/crates/broker/src/telemetry.rs
@@ -1336,4 +1336,63 @@ mod tests {
         service.send_request_heartbeat().await;
         // No panic = success (the client URL is fake, so sending would fail)
     }
+
+    /// Two-phase shutdown contract: the broker uses `non_critical_cancel_token`
+    /// for tasks like OrderPricer/OrderLocker (Phase 1, immediate cancel) and
+    /// `critical_cancel_token` for tasks like ProvingService/Submitter (Phase 2,
+    /// waited up to 2 h while in-flight orders drain).
+    ///
+    /// Telemetry must be bound to the **critical** token so monitoring keeps
+    /// seeing broker heartbeats during the Phase 2 drain. If it were bound to
+    /// the non-critical token, heartbeats would stop within seconds of SIGTERM
+    /// while the broker is still actively proving — causing false "broker
+    /// offline" alarms.
+    ///
+    /// This test validates the function-level contract of `run_telemetry_service`:
+    /// when given a token that has not been cancelled, it keeps running and
+    /// emitting heartbeats indefinitely. The lib.rs wiring is what binds it to
+    /// the right token; this test makes sure the function itself respects that
+    /// contract correctly.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_run_telemetry_only_exits_on_cancel() {
+        // Simulate the broker's two cancel tokens.
+        let non_critical_cancel = CancellationToken::new();
+        let critical_cancel = CancellationToken::new();
+
+        let (_tx, rx) = mpsc::channel(16);
+        let handle = TelemetryHandle::new(_tx.clone());
+        let signer = PrivateKeySigner::random();
+        let config = ConfigLock::default();
+        let db: DbObj = Arc::new(SqliteDb::new("sqlite::memory:").await.unwrap());
+
+        // Short intervals so the broker_heartbeat tick fires quickly inside the test.
+        let mut service = TelemetryService::new_debug(rx, handle, signer, config, db);
+        service.broker_heartbeat_interval_secs = 1;
+        service.request_heartbeat_interval_secs = 1;
+
+        // Wire telemetry to critical_cancel (the FIX). The bug was that lib.rs
+        // wired this to non_critical_cancel, so Phase 1 cancellation killed it.
+        let cancel_token = critical_cancel.clone();
+        let join = tokio::spawn(async move { run_telemetry_service(service, cancel_token).await });
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(!join.is_finished(), "service should be running after startup");
+
+        // Phase 1: non-critical tasks get cancelled. Telemetry is bound to
+        // critical_cancel, so it must NOT exit here.
+        non_critical_cancel.cancel();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !join.is_finished(),
+            "telemetry exited during Phase 1 (non_critical_cancel); \
+             must survive until critical_cancel fires so monitoring continues to see \
+             broker heartbeats during the in-flight-order drain phase",
+        );
+
+        // Phase 2: critical token cancels. Telemetry should now exit cleanly
+        // after a final heartbeat flush.
+        critical_cancel.cancel();
+        let result = tokio::time::timeout(Duration::from_secs(5), join).await;
+        assert!(result.is_ok(), "telemetry did not exit within 5s of critical_cancel");
+    }
 }


### PR DESCRIPTION
Telemetry was bound to `non_critical_cancel_token`, so `SIGTERM` killed heartbeats within seconds while the broker was still draining in-flight orders for up to 2h. This causes the alarms to trigger that a broker is offline while instead is just waiting to be shut down. Bound to `critical_cancel_token` instead.