### PR TITLE
BM-2929: CLI: improve network discovery and switching

### DIFF
--- a/crates/boundless-cli/src/bin/boundless.rs
+++ b/crates/boundless-cli/src/bin/boundless.rs
@@ -132,6 +132,7 @@ async fn show_welcome_screen() -> Result<()> {
     use boundless_cli::commands::rewards::State;
     use boundless_cli::commands::setup::network::display_name_for_network;
     use boundless_cli::config_file::{Config, Secrets};
+    use boundless_cli::display::{DisplayManager, TipItem};
     use colored::Colorize;
 
     println!();
@@ -518,19 +519,25 @@ async fn show_welcome_screen() -> Result<()> {
         println!("  {} {}", "→".cyan(), "Run 'boundless rewards setup'".cyan());
     }
 
-    println!();
-    println!("{}", "Tips:".bold());
-    println!("  {} {}", "•".cyan().bold(), "List supported networks for a module:".white());
-    println!("      {}", "boundless <module> networks".dimmed());
-    println!("          {}", "e.g. boundless requestor networks".dimmed());
-    println!(
-        "  {} {}",
-        "•".cyan().bold(),
-        "Switch the active network for a module (accepts display name or chain ID):".white()
+    let display = DisplayManager::new();
+    display.tip_list(
+        "Tips:",
+        &[
+            TipItem {
+                title: "List supported networks for a module:",
+                command: Some("boundless <module> networks"),
+                examples: &["boundless requestor networks"],
+            },
+            TipItem {
+                title: "Switch the active network for a module (accepts display name or chain ID):",
+                command: Some("boundless <module> networks --set <name|chain-id>"),
+                examples: &[
+                    "boundless requestor networks --set \"Base Mainnet\"",
+                    "boundless requestor networks --set 8453",
+                ],
+            },
+        ],
     );
-    println!("      {}", "boundless <module> networks --set <name|chain-id>".dimmed());
-    println!("          {}", "e.g. boundless requestor networks --set \"Base Mainnet\"".dimmed());
-    println!("          {}", "e.g. boundless requestor networks --set 8453".dimmed());
     println!();
 
     Ok(())

--- a/crates/boundless-cli/src/bin/boundless.rs
+++ b/crates/boundless-cli/src/bin/boundless.rs
@@ -519,12 +519,18 @@ async fn show_welcome_screen() -> Result<()> {
     }
 
     println!();
+    println!("{}", "Tips:".bold());
+    println!("  {} {}", "•".cyan().bold(), "List supported networks for a module:".white());
+    println!("      {}", "boundless <module> networks".dimmed());
+    println!("          {}", "e.g. boundless requestor networks".dimmed());
     println!(
-        "{} {}",
-        "Tip:".bold(),
-        "Run 'boundless <module> networks' to see supported networks (e.g. 'boundless requestor networks')"
-            .dimmed()
+        "  {} {}",
+        "•".cyan().bold(),
+        "Switch the active network for a module (accepts display name or chain ID):".white()
     );
+    println!("      {}", "boundless <module> networks --set <name|chain-id>".dimmed());
+    println!("          {}", "e.g. boundless requestor networks --set \"Base Mainnet\"".dimmed());
+    println!("          {}", "e.g. boundless requestor networks --set 8453".dimmed());
     println!();
 
     Ok(())

--- a/crates/boundless-cli/src/commands/config_display.rs
+++ b/crates/boundless-cli/src/commands/config_display.rs
@@ -48,12 +48,30 @@ impl ModuleType {
         }
     }
 
-    /// Get the help command for this module
-    pub fn help_command(&self) -> &'static str {
+    /// Get the `networks` subcommand for this module
+    pub fn networks_command(&self) -> &'static str {
         match self {
-            ModuleType::Requestor => "boundless requestor --help",
-            ModuleType::Prover => "boundless prover --help",
-            ModuleType::Rewards => "boundless rewards --help",
+            ModuleType::Requestor => "boundless requestor networks",
+            ModuleType::Prover => "boundless prover networks",
+            ModuleType::Rewards => "boundless rewards networks",
+        }
+    }
+
+    /// Example switch-network commands for this module: (display name, chain ID)
+    pub fn switch_network_examples(&self) -> [&'static str; 2] {
+        match self {
+            ModuleType::Requestor => [
+                "boundless requestor networks --set \"Base Mainnet\"",
+                "boundless requestor networks --set 8453",
+            ],
+            ModuleType::Prover => [
+                "boundless prover networks --set \"Base Mainnet\"",
+                "boundless prover networks --set 8453",
+            ],
+            ModuleType::Rewards => [
+                "boundless rewards networks --set \"Ethereum Mainnet\"",
+                "boundless rewards networks --set 1",
+            ],
         }
     }
 
@@ -151,9 +169,22 @@ pub fn display_not_configured(display: &DisplayManager, module: ModuleType) {
     display.warning(&format!("Not configured - run '{}'", module.setup_command()));
 }
 
-/// Display tip message for a module
-pub fn display_tip(display: &DisplayManager, module: ModuleType) {
-    display.note(&format!("💡 Tip: Run '{}' to see available commands", module.help_command()));
+/// Display tip message for a module suggesting how to switch networks
+pub fn display_tip(_display: &DisplayManager, module: ModuleType) {
+    use colored::Colorize;
+
+    println!();
+    println!("{}", "Tips:".bold());
+    println!("  {} {}", "•".cyan().bold(), "List supported networks:".white());
+    println!("      {}", module.networks_command().dimmed());
+    println!(
+        "  {} {}",
+        "•".cyan().bold(),
+        "Switch the active network (accepts display name or chain ID):".white(),
+    );
+    for example in module.switch_network_examples() {
+        println!("          {}", format!("e.g. {example}").dimmed());
+    }
 }
 
 /// Get address from private key as Address type

--- a/crates/boundless-cli/src/commands/config_display.rs
+++ b/crates/boundless-cli/src/commands/config_display.rs
@@ -15,7 +15,7 @@
 //! Shared utilities for displaying configuration status across modules
 
 use crate::commands::setup::secrets::address_from_private_key;
-use crate::display::{obscure_url, DisplayManager};
+use crate::display::{obscure_url, DisplayManager, TipItem};
 use alloy::primitives::Address;
 
 /// Module type for configuration display
@@ -170,21 +170,21 @@ pub fn display_not_configured(display: &DisplayManager, module: ModuleType) {
 }
 
 /// Display tip message for a module suggesting how to switch networks
-pub fn display_tip(_display: &DisplayManager, module: ModuleType) {
-    use colored::Colorize;
-
-    println!();
-    println!("{}", "Tips:".bold());
-    println!("  {} {}", "•".cyan().bold(), "List supported networks:".white());
-    println!("      {}", module.networks_command().dimmed());
-    println!(
-        "  {} {}",
-        "•".cyan().bold(),
-        "Switch the active network (accepts display name or chain ID):".white(),
-    );
-    for example in module.switch_network_examples() {
-        println!("          {}", format!("e.g. {example}").dimmed());
-    }
+pub fn display_tip(display: &DisplayManager, module: ModuleType) {
+    let examples = module.switch_network_examples();
+    let items = [
+        TipItem {
+            title: "List supported networks:",
+            command: Some(module.networks_command()),
+            examples: &[],
+        },
+        TipItem {
+            title: "Switch the active network (accepts display name or chain ID):",
+            command: None,
+            examples: &examples,
+        },
+    ];
+    display.tip_list("Tips:", &items);
 }
 
 /// Get address from private key as Address type

--- a/crates/boundless-cli/src/commands/prover/mod.rs
+++ b/crates/boundless-cli/src/commands/prover/mod.rs
@@ -64,6 +64,8 @@ use crate::{
 pub enum ProverCommands {
     /// Show prover configuration status
     Config(ProverConfigCmd),
+    /// List supported networks or switch the active network
+    Networks(NetworksCmd),
     /// Deposit collateral funds into the market
     #[command(name = "deposit-collateral")]
     DepositCollateral(ProverDepositCollateral),
@@ -91,8 +93,6 @@ pub enum ProverCommands {
     /// Generate optimized broker and compose configuration files
     #[command(name = "generate-config")]
     GenerateConfig(ProverGenerateConfig),
-    /// List supported networks or switch the active network
-    Networks(NetworksCmd),
 }
 
 /// List or switch the active prover network

--- a/crates/boundless-cli/src/commands/requestor/mod.rs
+++ b/crates/boundless-cli/src/commands/requestor/mod.rs
@@ -62,6 +62,8 @@ use crate::{
 pub enum RequestorCommands {
     /// Show requestor configuration status
     Config(RequestorConfigCmd),
+    /// List supported networks or switch the active network
+    Networks(NetworksCmd),
     /// Deposit funds into the market
     Deposit(RequestorDeposit),
     /// Deposit funds into the market on behalf of another address
@@ -90,8 +92,6 @@ pub enum RequestorCommands {
     VerifyProof(RequestorVerifyProof),
     /// Interactive setup wizard for requestor configuration
     Setup(RequestorSetup),
-    /// List supported networks or switch the active network
-    Networks(NetworksCmd),
 }
 
 /// List or switch the active requestor network

--- a/crates/boundless-cli/src/commands/rewards/mod.rs
+++ b/crates/boundless-cli/src/commands/rewards/mod.rs
@@ -78,6 +78,8 @@ use crate::{
 pub enum RewardsCommands {
     /// Show rewards configuration status
     Config(RewardsConfigCmd),
+    /// List supported networks or switch the active network
+    Networks(NetworksCmd),
     /// Stake ZKC tokens
     #[command(name = "stake-zkc")]
     StakeZkc(RewardsStakeZkc),
@@ -119,8 +121,6 @@ pub enum RewardsCommands {
     InspectMiningState(RewardsInspectMiningState),
     /// Interactive setup wizard for rewards configuration
     Setup(RewardsSetup),
-    /// List supported networks or switch the active network
-    Networks(NetworksCmd),
 }
 
 /// List or switch the active rewards network

--- a/crates/boundless-cli/src/display.rs
+++ b/crates/boundless-cli/src/display.rs
@@ -22,6 +22,16 @@ use chrono::{DateTime, Local};
 use colored::Colorize;
 use std::fmt::Display;
 
+/// A single entry within a bulleted tip list rendered by [`DisplayManager::tip_list`].
+pub struct TipItem<'a> {
+    /// Title shown next to the bullet.
+    pub title: &'a str,
+    /// Generic command shown at the primary indent level. `None` skips the line.
+    pub command: Option<&'a str>,
+    /// Concrete examples shown at the deeper indent level (each prefixed with `e.g. `).
+    pub examples: &'a [&'a str],
+}
+
 /// Standard display formatter for CLI output
 pub struct DisplayManager {
     /// Optional network name to display in headers
@@ -145,6 +155,25 @@ impl DisplayManager {
     /// Print a sub-item (extra indented under a main item)
     pub fn subitem(&self, prefix: &str, message: &str) {
         println!("    {} {}", prefix.dimmed(), message);
+    }
+
+    /// Print a bulleted tips block with a header and one or more [`TipItem`]s.
+    ///
+    /// Each item renders as a cyan bullet followed by the item title, an optional
+    /// generic command at the primary indent, and zero or more example lines at the
+    /// deeper indent (each automatically prefixed with `e.g. `).
+    pub fn tip_list(&self, header: &str, items: &[TipItem<'_>]) {
+        println!();
+        println!("{}", header.bold());
+        for item in items {
+            println!("  {} {}", "•".cyan().bold(), item.title.white());
+            if let Some(command) = item.command {
+                println!("      {}", command.dimmed());
+            }
+            for example in item.examples {
+                println!("          {}", format!("e.g. {example}").dimmed());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Tweaks the boundless CLI so the `networks` subcommand is easier to find and so the network-switching workflow is more discoverable from the welcome screen and per-module `config` output.

## Changes
* Move `networks` to second position (just below `config`) in the `requestor`, `prover`, and `rewards` subcommand lists.
* Replace the per-module `config` tip to cover switching networks
* Expand the welcome-screen tip into two bulleted tips (one for listing, one for switching), each on its own line with a colored bullet, and call out that `--set` accepts a display name or a chain ID.

## Ways to switch / override the active network
* `boundless <module> networks --set "Base Mainnet"` — persists the active network for the module to the config file.
* `boundless <module> networks --set 8453` — same as above using a chain ID.
* `boundless <module> networks --set base-mainnet` — same as above using the kebab-case key.
* `boundless --network "Base Mainnet" <module> <cmd>` — global `--network` flag, applies to a single invocation only and does not persist. Accepts display name, kebab-case key, or chain ID.
* `BOUNDLESS_NETWORK="Base Mainnet" boundless <module> <cmd>` — env-var equivalent of the global flag (also accepts kebab-case key or chain ID).
* `boundless <module> setup` — interactive wizard that writes the active network plus credentials.