### PR TITLE
BM-2930: Enable pagerduty/slack alerts for taiko stacks

### DIFF
--- a/infra/distributor/Pulumi.l-prod-167000.yaml
+++ b/infra/distributor/Pulumi.l-prod-167000.yaml
@@ -28,13 +28,13 @@ config:
   distributor:OFFCHAIN_REQUESTOR_ADDRESSES: 0xc197ebe12c7bcf1d9f3b415342bdbc795425335c,0x076aCA5883aDB08C31E9308C59cD8495A2513DA7
   distributor:ORDER_GENERATOR_KEYS:
     secure: v1:zBogdaLX2gKWsGFn:GqALVfh5/l56rSddPbFllFrDLpus7bVY+DWz2xk4C+RkTD6Ot6sh9RACVwPFXPVRuQqfK/7MTTbHd4k6uy0ZhYy1/EmYgi+q8a3suePAeQcvGXNqCezIvaDMCKUZKfuA9Dt0uhDkRUKt2zmgMdTx3JPItNEeMY6xnjD9NxWA4/0tfNAryGf1lLZ/pzdCTLOyudMdeZVsNaDiInd+jJMRuf0AwR3TeQq8qcYWwbf6tH/Q6kzjuKOLm5rmJF8YggcOII8umklBXC5tqkQZyLu0V7D7R2DLKDI5gROoig872nZjCLHsMrRU2tkL92/5rYdQcV7VsTB7Hs9VlgQjmeqTiaE0YF4q032flNxDoDuq9ET9RHR2hoAzfZb4LlhiiXyWDK0DpPrcNpFMS171PzfG1cFJWEgG/RS0KvadICJH4LpUdSxUrjoQUlB0J9dOoMoVxOK3nc2h0l6U4RtTc15cXWOq8IcsfmuSiaMHIxH60k7ndeVC14VUio2mnI2998prs8hmTq4UpmlfvGISl74ZnbXSEDv2
-    #  distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   distributor:PROVER_ETH_DONATE_THRESHOLD: "0.4"
   distributor:PROVER_KEYS:
     secure: v1:v2E7Hd67cnP+8KJi:bhTLLiK2z5esuOntUHWMcbmH8n3+cyKwQ7yBhTLKW086SWmgHKxrbrrDQQuZQrE+31n/C5O0llCixB/V7scFoLa/ILHhnU3pKmg+5pwHVzkdPCe2XqQFKAK7Mo+QV9y1J3r4s22zY0k9h4WMv80GlskWLQS+urEX1rHEOAt4hOrZQaWxvWwbmWF4Ttp9iDAoHA==
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "500.0"
   distributor:SCHEDULE_MINUTES: "90"
-  #  distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
+  distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   distributor:SLASHER_KEY:
     secure: v1:K0Af69eM3IjaBdfh:RVHWgyJGtJZ41nTwr7twWdYNwAXLvpLtbVQMmUrJcameCVxIt/IWH/uTxL/3IWaO5e/GhZoLSvqbnLXDKXyrSnGKcXU+WSnumcB/1gWxfzY=
   distributor:STAKE_THRESHOLD: "100"

--- a/infra/distributor/Pulumi.l-staging-167000.yaml
+++ b/infra/distributor/Pulumi.l-staging-167000.yaml
@@ -29,14 +29,14 @@ config:
   distributor:MIN_BCYCLES_THRESHOLD: "100"
   distributor:ORDER_GENERATOR_KEYS:
     secure: v1:cgFbnETQoySqs0jo:x17dGakW/ymvvbVtP3NrhzCOWfKYkkLdoz6Yw8+d2iGfeELfZMtJtaKPlTfI0ComWiS1WLILzY37hCGKBRp5LF/igEiXpThlBDow1FDPEko/zg8HcAAiN9iKD9NE+9xyWrcuCdqUVV+qcVjXWmiABDSzrVTUHnOS1eiDaqwVm9jJwLQWOhSQUGcoG6jsBAOfE8scqhUO7Lr1HdLhvg+tATH51lRmHKIKPZ6NqHnjk0tGDiKSLB7aBK/DlCvOTagF+i3N8afsWVlfdP6CmJ04idfyuXrSYsFLdrofJ1ICGf7Bi9e6Am653VM5UXYtR2hZJj8Ez3roRCt2rFVLI2fgtlks8OT+B1hAhaktr928JOykeouiUxA2CZbDabdWPzFnh2Sos0Do8UMAD8pEzCi7oJgAATclaPTB7fAKYUUXTAjQgftCoVtMwdKpW6BjtK1h3+X6wDBFyP7Pcce0Aj4g77sNyXXpz7YPTRpU9ptgfuD6CzjCkXQQ/aGyD37d/id7NQvRCXDPyVK9W/qoAEnxtYThei3Rv5FKVY2WZSnvPAdhRnLzT7k1AgN0Vu8nSFeC1klfFSMIB3Gymp7Gn8sF4uiqiHGoJcQ+k2f5NWKGLyeeTTSZr9tudQM7R54xJNFJwVMfv5lfzqX2lYVfSqUYxaaOx8qdPyJIZdyu2tI4YLBh0fvfLZqEXP2LJ04EmN3qR83Ht2Zr0w==
-#  distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  distributor:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   distributor:PROVER_ETH_DONATE_THRESHOLD: "0.2"
   distributor:PROVER_KEYS:
     secure: v1:Sz42CYl6pldA0wRa:KfALsOi/YJHf+b7QlMEu4720p+cKfijmide77Vf1fWsgxR1kBO5LtR+dko9aqJt2Ay2gdM6qhlBD8rPnsmqtUlyfjOqbut5eot/i7ecZlfo=
   distributor:PROVER_STAKE_DONATE_THRESHOLD: "500.0"
   distributor:SCHEDULE_MINUTES: "90"
   distributor:SET_VERIFIER_ADDR: 0x6135DC08D14EF8a44496B009e2181426628B8ebd
-#  distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
+  distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
   distributor:SLASHER_KEY:
     secure: v1:qLo7sKRsnZ6Z6n9X:SUA3LvOqdWVi6CXAvQp1A0bkq0Ai4vXBwZd2dMGi7Y/2sESHxrPVn6c7SkhfVw2ukto9K+T/hdfCYrbdJnF2XzJfTykZd3Zq2KwoT+9XhiU=
   distributor:STAKE_THRESHOLD: "100"

--- a/infra/indexer/Pulumi.l-prod-167000.yaml
+++ b/infra/indexer/Pulumi.l-prod-167000.yaml
@@ -24,7 +24,7 @@ config:
     secure: v1:jRnEC0ITCjWjtawv:WMxiA9eNu0xWwOinKzFk8zogBGJSPwZLlTdElVRL
   indexer:ORDER_STREAM_URL:
     secure: v1:DV6+i/4nICnQAuho:3Zr57euv3Uk8BkBTTRiwTILOWn8sJtSaCkM/jspB3ZxiWZo2xaC+lU+6+dNOu7HYtvSjmvCodtSG68C+uLKsId3t837RGVvHvD21xp3lqoyNjL1Psw8h0Wz4Tg==
-#  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:PREMIUM_API_KEY:
     secure: v1:CtMR8aiDjeNb79XR:HdqjuQ1Mt96mu1PAI16GXaNjzdt2kVsm5+zI7g==
   indexer:PROXY_SECRET:
@@ -34,7 +34,7 @@ config:
   indexer:RUST_LOG_API: debug
   indexer:RUST_LOG_INDEXER: info,boundless_indexer=debug
   indexer:RUST_LOG_MONITOR: info,indexer_monitor=debug
-#  indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
+  indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   indexer:START_BLOCK: "4819525"
   indexer:ETH_RPC_URL:
     secure: v1:i5OnXx7QhxsA5/di:+RUggBiN4cB2Or9ddL924PybNqI3lhDOYB63eYKwQWtYye4TteC8dajkJY6P

--- a/infra/indexer/Pulumi.l-staging-167000.yaml
+++ b/infra/indexer/Pulumi.l-staging-167000.yaml
@@ -22,7 +22,7 @@ config:
     secure: v1:rZ441O0GJyS+PJVD:uWkGiv3ym2Ch0HulTFlVSE6jWxKALZVvLdQeM3E3
   indexer:ORDER_STREAM_URL:
     secure: v1:eZhG593tITU/mvTt:wu1zmqe23pkcEuicGx4HH2DVNS+cu3CStNxQnwpcbU6tbpYxC25nzNU0vVXlHH9pxb0cF2npNUvnR/CbzrYYHkhDzM95fzm+EsZ9oEy2ihVnB7OKiAbKMkJxR9oe
-#  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  indexer:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   indexer:PREMIUM_API_KEY:
     secure: v1:2BarWx91nEbBVpyv:ti6xTrkR+D9XXiDGTF2p+Ibz6OYSpj9q+NVJHw==
   indexer:PROXY_SECRET:
@@ -32,7 +32,7 @@ config:
   indexer:RUST_LOG_API: info,indexer_api=debug
   indexer:RUST_LOG_INDEXER: info,boundless_indexer=debug
   indexer:RUST_LOG_MONITOR: info,indexer_monitor=debug
-#  indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
+  indexer:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
   indexer:START_BLOCK: "4819525"
   indexer:ETH_RPC_URL:
     secure: v1:GDCVmeBDnCDJPel7:TIqIAhs5ctadWkwXZIBWtbiYcaPdrIj9/YV2/J3KRlF59TgCOET9zLf2vhVU

--- a/infra/order-generator/Pulumi.l-prod-167000.yaml
+++ b/infra/order-generator/Pulumi.l-prod-167000.yaml
@@ -19,11 +19,11 @@ config:
   order-generator-base:MIN_PRICE_PER_MCYCLE: "0"
   order-generator-base:ORDER_STREAM_URL:
     secure: v1:Dl7yVnXPLngSEO/T:Osm6/+L8w7oVrzkGOmDM3jgmqhdmrtqI8ANNPAlPNQl1eJpHQIJ83Rk4dVsDOEK+UlOsRvMoFOQ0vDK3T4LICGjsZNhvcKt0oBq3vCzIBGMFh/4nZ5MUujjhtw==
-#  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-generator-base:PINATA_JWT:
     secure: v1:kkgNfCRVdBU8NZI0:LXHxPYog21/UhXNTpE/KlAvkeOYzVaDGodUNWp9fIOIkpUAmaSp6wKY05XBDPUoqx6HhHLi3PRmypgvqdnrKUvJbuqKUkemYob76g8yOFbtmQtcya3DU20I81jrivjFLXHjhZ8CiXZuI0xfAIfAibOmw1qPGvNL6xVEpuimOtMUqLE6StweEVovfDHCWfPJY1cxWLrpbbwRwTVFeqPxCc3JVqp3iWqHh2Em9mgDBr57eoHzyNCRPNGw3oXQGjPJ96HNhivHi0sqWqq5C64bRsk0Q8487xHmYQqMW1szRqxs563yY99RrknoIQ40TaOjA27GXr+zq2q855e/VmL4SwOqovXN5RypM2xgbpSMNXe1zIhJ3APffWBMiBBnmc4z7toVYn0ow4JlcQOumZ0A+rFMMRpuU9pfO/7Fpgb3iAgMMhnZKqeTBlpr3D+USPk1fKI1DtgFmKOUV91eBd3+8nzKiFU+HDlZnEnbWvLoYSKayAu2vl04Fuo5qPW81RJyMSMByouN09D6lm4WIkkPf4iC78AtjzfA/zCepEtCP6eDgS1ga5anqY/kguQwr4ugoi8N2axjP9xyG04gdnEXMDSfdZiWMgn2yL6RyAfHkwyx/E/p+3iki3xrKgt79HwMwAw6ATDZj8fdWodUFW04/VEcuw8EL0ftrfdJ0X/cLFUBp6iEhmLpqIQ+1SD0Zluib1mzJn4/m81IVBq+mF5gYGH3q+TKkoIrLk7OrhSRPj8p5q1AbTNbiYUaJqbI4+wmhhXBiUIavd+9MRE0SOgdSB0YhyUtqWACPkNRZcEFCbxQi3PS7rVcmsGjiW3xGcU10xfMHjBBP2YzHqByKkmx64htKrJlFXbBmZEZENwGaCmMx7gImIWs5nog5FOLRVpNL0avSbyJh4XL19c5rKXrLab98V23E7l/Z
   order-generator-base:SET_VERIFIER_ADDR: 0x6135DC08D14EF8a44496B009e2181426628B8ebd
-#  order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
+  order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   order-generator-base:TX_TIMEOUT: "90"
   order-generator-evm-requestor:AUTO_DEPOSIT: "0.015"
   order-generator-evm-requestor:ERROR_BALANCE_BELOW: "0.005"

--- a/infra/order-generator/Pulumi.l-staging-167000.yaml
+++ b/infra/order-generator/Pulumi.l-staging-167000.yaml
@@ -20,11 +20,11 @@ config:
   order-generator-base:MIN_PRICE_PER_MCYCLE: "0"
   order-generator-base:ORDER_STREAM_URL:
     secure: v1:dE+iyAYTU4c+cU1I:0BHDcE+hZ0NJW3/4g1+GIHJVx/F6hkrkS65F9HAxYS2mKPVxQRS9cLYm2StHAg+RmtfUVtSZEOXpo1zfwpiFRl15hQRW9P+nycXoq2ZBtq1NLIZrGcaeoVIxqJT2
-#  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  order-generator-base:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-generator-base:PINATA_JWT:
     secure: v1:goIhuYEEnYx8NgJ8:UQztEOUX/Ti1UNGfOB82JtPhVdyZKkUlBZvxd05FjDx+j50elh5Z7VRDgyhuRuI6T9D47Dgce0LCyn157AjO1bz7qI/Pwo+EWPDAuCsJKDcALavu+9xMnAAq9mJjTpGyesD65sT8X4oKmV/CSY4Ga0tqMTp4kSqjVNcKPppqDA28Xem1muCq5yvgRhw6J24NypaOvz7K2lX31mznEWaGOrbHtcOgmi3/AiIAmqoOh7jQWgdqbJ0gj97OH9e9ZKDZtcnPuzMLX9R/3TZKtZqTzsZVDRZc65d1M7pCV8NlqYRskfC+88vFdcCgAeute51uJ+5CLBDMHIAq/pDUwk8C/e5YhjLs+l1B4M00uR0T0VOvwkZ/m6egL+VJoACVVRtA/g1WtgQbn2nkk5eQUq0V3BrkAGz7JNAJNSpVsMPXXN99W6HA0qIyBv7enmIf2WoM/Q+KyLNE/mfMNLp7WmFoTim2DXtQLEzWjzk4vmmp3Z5G32fYG49paPlYa1CWlz2nl8SgSBy7q/30FK9MzUeNgOA8/cfw9X4BTshG7cpB5bmECK5I5jaxCJDpSTrkO3ZYfas+Fz6DKj4v6EdkUYwkVD/jc1bxGOCBzQGrc4XMjOrroMR4OTA9tsbqyNGvMQ33zvDZ4YBNDCPooQO/Eu539w0E5LuyWKRQrhs8ZN+yZPxxgfEtLY6HmezlkedqADoi83FFC1wzWInZsAy0Mhr8q57DeY3lx05HZlK2OMr2fw2CPuWt/pR8shs9vKRfmYThHgkS4TtI/P7j60KWWw1Tr5i1mFyKmToUXEzM5xRGWLmyiBTCtVPsfqclrTUFabKtL5modXV01+Y2TxlDBoOuc6bWw40Zuh8c8rrh9QBMYZG0qS94/FgPkDaCZP24hceP8FKwOh7mtAYgB8HfhixQdViVXmQq+UkY
   order-generator-base:SET_VERIFIER_ADDR: 0x6135DC08D14EF8a44496B009e2181426628B8ebd
-#  order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
+  order-generator-base:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
   order-generator-base:TX_TIMEOUT: "300"
   order-generator-evm-requestor:AUTO_DEPOSIT: "0.015"
   order-generator-evm-requestor:ERROR_BALANCE_BELOW: "0.01"

--- a/infra/order-stream/Pulumi.l-prod-167000.yaml
+++ b/infra/order-stream/Pulumi.l-prod-167000.yaml
@@ -16,7 +16,7 @@ config:
     secure: v1:ZeO3S48SQkFZHvN8:jOZMm+SLAX5vG1be/cKzbjotY2Rm9HxiVLSB81h8ZS7dMPVanCDcMHsdtsWv1lvX14VkWgMZVATAqOJHO3d04p0b2B/WwCc+FzjevMmvo9IoHdbQRpCAoAK+Y2WtJWqd3Wb2Y7YrvPwNHg95Fg==
   order-stream:MIN_BALANCE_RAW: "5000000000000000000"
   order-stream:ORDER_STREAM_PING_TIME: "100"
-#  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-stream:PREMIUM_API_KEY:
     secure: v1:iX7m9D5ydjZcFKt0:s71WAhchrK+wAhTd6nrGGQLiXQL92A9Y0sEmVPBI
   order-stream:RDS_PASSWORD:
@@ -25,7 +25,7 @@ config:
     secure: v1:79I+DgIWJGlMS/hw:EVFuQkT27bXkxtRy93JlWL5I0FlZm46F5XiflA==
   order-stream:REDSHIFT_READONLY_PASSWORD:
     secure: v1:aMOgq5NjcVCacDtw:FWh6oh4shBfqsMAA9B9LOVPQiF03FMxnkTs07Q==
-#  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
+  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   order-stream:ETH_RPC_URL:
     secure: v1:+y+/MbljoYcpu9nM:VyFomiB90y1gw3H+YyB1xsJvpKNMjaSESETOA3rMvnOYMN/3mYrZq1wSJaTz
   order-stream:USE_GHCR: true

--- a/infra/order-stream/Pulumi.l-staging-167000.yaml
+++ b/infra/order-stream/Pulumi.l-staging-167000.yaml
@@ -14,7 +14,7 @@ config:
     secure: v1:9qM9PiQiLDwk7XRl:awC475v/s72GfjPjHnpg3ct9iC3USqZQmF/Itfv8ZuS8Ik70LceKmuMfSGkmUalJW8eOZ1sKYoPa2C4YjFXIfHSABrcvptQwlfdK0eBJhukpIsR/vn3NwuZt5SRzv/63foG3ArYp/Cgcfqub7w==
   order-stream:MIN_BALANCE_RAW: "5000000000000000000"
   order-stream:ORDER_STREAM_PING_TIME: "100"
-#  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  order-stream:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   order-stream:PREMIUM_API_KEY:
     secure: v1:XTaGKHuTJqkQIk0F:KwUYIPzyBU8VM1u6KKhXigolA24uGSNhnYivowB2
   order-stream:RDS_PASSWORD:
@@ -23,7 +23,7 @@ config:
     secure: v1:mtUljTgAgUqvqC18:M79Ps5yNnmLSeqirxl98Dg8UHOZ1IC3E2Xl6XQ==
   order-stream:REDSHIFT_READONLY_PASSWORD:
     secure: v1:JYjK1WFwQ3lsuVJh:6cuBP82TQgkvU1nFShPJyzdVJVuV0kzOzPq91w==
-#  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
+  order-stream:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
   order-stream:ETH_RPC_URL:
     secure: v1:f1BqdkYofm4y6DY0:h0BVuwZHHoVfg1TTHBS4rodxb2ULGGu6DHrGq2WyNF4j77UzH1aZD0+vGtUm
   order-stream:USE_GHCR: true

--- a/infra/slasher/Pulumi.l-prod-167000.yaml
+++ b/infra/slasher/Pulumi.l-prod-167000.yaml
@@ -14,14 +14,14 @@ config:
   slasher:INTERVAL: "15"
   slasher:LOG_LEVEL: boundless_slasher=trace,boundless_market=debug
   slasher:MAX_BLOCK_RANGE: "10000"
-#  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   slasher:PRIVATE_KEY:
     secure: v1:+QXGYTW4KS8noxpr:cNUAdu91W0se1vjGW8ZfkarEF7fnQutPGTBTLbpp0rkF14p7qvhWYABZjV90u85XxXFV4OVCPlPZz73GVhzOrB2jBk9nxXiwMpFUZilNqAs=
   slasher:RDS_PASSWORD:
     secure: v1:bW7q9pzUYnL0GvCU:wXVjChJ6K5noBsab44G/XNctpM8nvDfkiOTlhs2Gioo=
   slasher:RETRIES: "3"
   slasher:SKIP_ADDRESSES: ""
-#  slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
+  slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   slasher:START_BLOCK: "4819525"
   slasher:TX_TIMEOUT: "60"
   slasher:WARN_BALANCE_BELOW: "0.01"

--- a/infra/slasher/Pulumi.l-staging-167000.yaml
+++ b/infra/slasher/Pulumi.l-staging-167000.yaml
@@ -14,14 +14,14 @@ config:
   slasher:INTERVAL: "60"
   slasher:LOG_LEVEL: boundless_slasher=trace,boundless_market=debug
   slasher:MAX_BLOCK_RANGE: "500"
-#  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
+  slasher:PAGERDUTY_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-pagerduty-topic
   slasher:PRIVATE_KEY:
     secure: v1:yXQljDHAPNor+6Ns:RsXl3QtPJN3ox+rfzRG3t9yS/YhRHO79rrLXRRYZzNeTEH46r0ByslVErjdIhcioz7zpwS0+GUnmGm+T3FEdhuXVmAKlQcaOGh2hHXQt9eI=
   slasher:RDS_PASSWORD:
     secure: v1:kJZil9JvJEtcozvK:jd+bjASPhNuRh5MBed5G/g0yDo+dJwM7b5ruwwK9hYo=
   slasher:RETRIES: "5"
   slasher:SKIP_ADDRESSES: ""
-#  slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
+  slasher:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-staging-launch
   slasher:TX_TIMEOUT: "120"
   slasher:WARN_BALANCE_BELOW: "0.01"
   slasher:ETH_RPC_URL:


### PR DESCRIPTION
Uncomments the `PAGERDUTY_ALERTS_TOPIC_ARN` and `SLACK_ALERTS_TOPIC_ARN` config across all Taiko (chain `167000`) infra stacks so alerts now route to the same SNS topics as the other launch chains.
Changes
* Enables alert ARNs in `Pulumi.l-staging-167000.yaml` and `Pulumi.l-prod-167000.yaml` for `slasher`, `order-stream`, `order-generator`, `indexer`, and `distributor`.
* Staging uses `boundless-alerts-topic-staging-launch`, prod uses `boundless-alerts-topic-launch`, matching `84532` / `8453` / `11155111` stacks.
* Fixes misaligned indentation on the prod distributor entries (was nested under `ORDER_GENERATOR_KEYS`).