### PR TITLE
BM-2932: Stop persisting Skipped orders, drop accumulated rows

### DIFF
--- a/crates/broker/migrations/3_drop_skipped_orders.sql
+++ b/crates/broker/migrations/3_drop_skipped_orders.sql
@@ -1,0 +1,4 @@
+-- Skipped orders are no longer persisted: the broker stopped reading them
+-- ages ago, and accumulated rows have caused multi-hundred-thousand-row
+-- bloat that slows json_set UPDATE statements on busy provers.
+DELETE FROM orders WHERE data->>'status' = 'Skipped';

--- a/crates/broker/src/db/mod.rs
+++ b/crates/broker/src/db/mod.rs
@@ -30,8 +30,8 @@ use thiserror::Error;
 
 use crate::{
     errors::{impl_coded_debug, CodedError},
-    proving_order_from_request, skipped_order_from_request, AggregationState, Batch, BatchStatus,
-    FulfillmentType, Order, OrderRequest, OrderStatus, ProofRequest,
+    proving_order_from_request, AggregationState, Batch, BatchStatus, FulfillmentType, Order,
+    OrderRequest, OrderStatus, ProofRequest,
 };
 use tracing::instrument;
 use url::Url;
@@ -130,7 +130,6 @@ pub struct AggregationOrder {
 
 #[async_trait]
 pub trait BrokerDb {
-    async fn insert_skipped_request(&self, order_request: &OrderRequest) -> Result<(), DbError>;
     async fn insert_accepted_request(
         &self,
         order_request: &OrderRequest,
@@ -318,36 +317,16 @@ impl SqliteDb {
         Ok(res as usize)
     }
 
-    /// Insert an order into the database using ON CONFLICT to handle duplicates safely.
-    /// Always ignores duplicates - used for skipped requests.
-    async fn insert_order_ignore_duplicates(&self, order: &Order) -> Result<(), DbError> {
+    /// Insert an accepted order. Errors with [`DbError::DuplicateOrderId`] if a row already
+    /// exists for the same order id (any status), so duplicate accepts surface loudly to the
+    /// caller. We never persist Skipped rows, so there is no Skipped → Accepted upgrade path.
+    async fn insert_accepted_order(&self, order: &Order) -> Result<(), DbError> {
         let result =
             sqlx::query("INSERT INTO orders (id, data) VALUES ($1, $2) ON CONFLICT(id) DO NOTHING")
                 .bind(order.id())
                 .bind(sqlx::types::Json(&order))
                 .execute(&self.pool)
                 .await?;
-
-        if result.rows_affected() == 0 {
-            tracing::debug!("Order {} already exists in the database", order.id());
-        }
-
-        Ok(())
-    }
-
-    /// Insert an accepted order, overwriting only if the existing order is skipped.
-    /// Returns true if inserted/updated, false if ignored due to existing non-skipped order.
-    async fn insert_accepted_order(&self, order: &Order) -> Result<(), DbError> {
-        let result = sqlx::query(
-            r#"INSERT INTO orders (id, data) VALUES ($1, $2) 
-               ON CONFLICT(id) DO UPDATE SET 
-                   data = excluded.data 
-               WHERE orders.data->>'status' = 'Skipped'"#,
-        )
-        .bind(order.id())
-        .bind(sqlx::types::Json(&order))
-        .execute(&self.pool)
-        .await?;
 
         if result.rows_affected() == 0 {
             return Err(DbError::DuplicateOrderId(order.id()));
@@ -384,12 +363,12 @@ impl BrokerDb for SqliteDb {
     #[cfg(test)]
     #[instrument(level = "trace", skip_all, fields(id = %format!("{}", order.id())))]
     async fn add_order(&self, order: &Order) -> Result<(), DbError> {
-        self.insert_order_ignore_duplicates(order).await
-    }
-
-    #[instrument(level = "trace", skip_all, fields(id = %format!("{}", order_request.id())))]
-    async fn insert_skipped_request(&self, order_request: &OrderRequest) -> Result<(), DbError> {
-        self.insert_order_ignore_duplicates(&skipped_order_from_request(order_request)).await
+        sqlx::query("INSERT INTO orders (id, data) VALUES ($1, $2) ON CONFLICT(id) DO NOTHING")
+            .bind(order.id())
+            .bind(sqlx::types::Json(&order))
+            .execute(&self.pool)
+            .await?;
+        Ok(())
     }
 
     #[instrument(level = "trace", skip_all, fields(id = %format!("{}", order_request.id())))]
@@ -1137,7 +1116,6 @@ mod tests {
     };
     use risc0_aggregation::GuestState;
     use risc0_zkvm::sha::Digest;
-    use tracing_test::traced_test;
 
     fn create_order_request() -> OrderRequest {
         let mut request = OrderRequest::new(
@@ -1257,16 +1235,6 @@ mod tests {
 
         let db_order = db.get_order(&order.id()).await.unwrap().unwrap();
         assert_eq!(db_order.status, OrderStatus::Done);
-    }
-
-    #[sqlx::test]
-    async fn skip_order(pool: SqlitePool) {
-        let db: DbObj = Arc::new(SqliteDb::from(pool).await.unwrap());
-        let order = create_order_request();
-
-        db.insert_skipped_request(&order).await.unwrap();
-        let db_order = db.get_order(&order.id()).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
     }
 
     #[sqlx::test]
@@ -1707,22 +1675,11 @@ mod tests {
     }
 
     #[sqlx::test]
-    #[traced_test]
     async fn insert_duplicate_orders_conflict_handling(pool: SqlitePool) {
         let db: DbObj = Arc::new(SqliteDb::from(pool).await.unwrap());
 
-        // Skipped request ignores duplicates
+        // First accept of a fresh order succeeds.
         let order_request = create_order_request();
-        db.insert_skipped_request(&order_request).await.unwrap();
-
-        let stored_order = db.get_order(&order_request.id()).await.unwrap().unwrap();
-        assert_eq!(stored_order.status, OrderStatus::Skipped);
-
-        // Try to insert the same skipped request again - should be ignored
-        db.insert_skipped_request(&order_request).await.unwrap();
-        assert!(logs_contain("already exists"));
-
-        // Accepted request can overwrite skipped order
         let accepted_order =
             db.insert_accepted_request(&order_request, U256::from(100)).await.unwrap();
         assert_eq!(accepted_order.status, OrderStatus::PendingProving);
@@ -1732,10 +1689,9 @@ mod tests {
         assert_eq!(stored_order.status, OrderStatus::PendingProving);
         assert_eq!(stored_order.lock_price, Some(U256::from(100)));
 
-        // Accepted request errors on non-skipped duplicate
+        // Second accept of the same order errors and leaves the row untouched.
         assert!(db.insert_accepted_request(&order_request, U256::from(200)).await.is_err());
 
-        // Verify the stored order still has the original lock price (wasn't updated)
         let stored_order = db.get_order(&order_request.id()).await.unwrap().unwrap();
         assert_eq!(
             stored_order.lock_price,
@@ -1743,7 +1699,7 @@ mod tests {
             "Lock price should not be updated"
         );
 
-        // New order (different ID) should work normally
+        // A different order id is accepted normally.
         let mut different_request = create_order_request();
         different_request.request.id = U256::from(999);
 

--- a/crates/broker/src/lib.rs
+++ b/crates/broker/src/lib.rs
@@ -454,10 +454,6 @@ pub(crate) fn order_from_request(order_request: &OrderRequest, status: OrderStat
     }
 }
 
-pub(crate) fn skipped_order_from_request(order_request: &OrderRequest) -> Order {
-    order_from_request(order_request, OrderStatus::Skipped)
-}
-
 pub(crate) fn proving_order_from_request(order_request: &OrderRequest, lock_price: U256) -> Order {
     let mut order = order_from_request(order_request, OrderStatus::PendingProving);
     order.lock_price = Some(lock_price);

--- a/crates/broker/src/order_locker.rs
+++ b/crates/broker/src/order_locker.rs
@@ -425,14 +425,6 @@ where
             }
         };
 
-        if let Err(e) = self.db.insert_skipped_request(order).await {
-            tracing::error!(
-                "Failed to skip order ({}): {} - {e:?}",
-                skip_commit_reason,
-                order.id()
-            );
-        }
-
         let no_load = estimate_proving_time_no_load(order.total_cycles, config);
         let monitor_wait =
             order.priced_at_timestamp.map(|t| now_timestamp().saturating_sub(t) * 1000);
@@ -661,11 +653,6 @@ where
                                 Some(&skip_reason),
                                 Some(lock_submitted_at),
                             );
-                            if let Err(e) = self.db.insert_skipped_request(order).await {
-                                tracing::error!(
-                                    "Failed to set DB failure state for order: {order_id} - {e:?}"
-                                );
-                            }
                             self.send_completion(order, CommitmentOutcome::Skipped);
                         }
                     }
@@ -1270,8 +1257,7 @@ pub(crate) mod tests {
 
         assert!(result.is_empty());
 
-        let order = ctx.db.get_order(&expired_order_id).await.unwrap().unwrap();
-        assert_eq!(order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&expired_order_id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1302,11 +1288,8 @@ pub(crate) mod tests {
 
         assert!(result.is_empty());
 
-        let order = ctx.db.get_order(&order_1_id).await.unwrap().unwrap();
-        assert_eq!(order.status, OrderStatus::Skipped);
-
-        let order = ctx.db.get_order(&order_2_id).await.unwrap().unwrap();
-        assert_eq!(order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_1_id).await.unwrap().is_none());
+        assert!(ctx.db.get_order(&order_2_id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1340,8 +1323,7 @@ pub(crate) mod tests {
 
         assert!(result.is_empty());
 
-        let order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1538,12 +1520,9 @@ pub(crate) mod tests {
         let capacity_result = CapacityResult { orders: valid_orders, meta: HashMap::new() };
         ctx.monitor.lock_and_prove_orders(&capacity_result, &OrderLockerConfig::default(), 0).await;
 
-        let skipped_order = ctx.db.get_order(&order_id).await.unwrap();
-        assert!(skipped_order.is_some(), "Order should be in database");
-        assert_eq!(
-            skipped_order.unwrap().status,
-            OrderStatus::Skipped,
-            "Order should be skipped due to insufficient collateral balance"
+        assert!(
+            ctx.db.get_order(&order_id).await.unwrap().is_none(),
+            "Order should not be persisted after being skipped"
         );
 
         assert!(

--- a/crates/broker/src/order_pricer.rs
+++ b/crates/broker/src/order_pricer.rs
@@ -277,11 +277,6 @@ where
                 result = self.price_order(&mut order) => result,
                 _ = cancel_token.cancelled() => {
                     tracing::info!("Order pricing cancelled during pricing for order {order_id}");
-
-                    // Add the cancelled order to the database as skipped
-                    if let Err(e) = self.db.insert_skipped_request(&order).await {
-                        tracing::error!("Failed to add cancelled order to database: {e}");
-                    }
                     return Ok(false);
                 }
             };
@@ -406,10 +401,6 @@ where
                     .context("Failed to send to order_result_tx")?;
                 Ok::<_, OrderPricerErr>(true)
             } else {
-                self.db
-                    .insert_skipped_request(&order)
-                    .await
-                    .context("Failed to add skipped order to database")?;
                 Ok(false)
             }
         };
@@ -832,7 +823,7 @@ pub(crate) mod tests {
         chain_monitor::ChainMonitorService,
         db::SqliteDb,
         provers::{DefaultProver, ProofResult, Prover, ProverError},
-        FulfillmentType, OrderStatus,
+        FulfillmentType,
     };
     use alloy::{
         network::EthereumWallet,
@@ -1181,8 +1172,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("predicate check failed"));
     }
@@ -1209,8 +1199,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("unsupported selector requirement"));
     }
@@ -1240,8 +1229,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("estimated") && logs_contain("lock and fulfill order"));
     }
@@ -1335,8 +1323,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("estimated") && logs_contain("lock and fulfill order"));
     }
@@ -1402,8 +1389,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("estimated") && logs_contain("lock and fulfill order"));
     }
@@ -1467,8 +1453,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("estimated") && logs_contain("lock and fulfill order"));
     }
@@ -1529,8 +1514,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(
             logs_contain("after accounting for journal costs")
@@ -1559,8 +1543,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("is not in allow requestors"));
     }
@@ -1587,8 +1570,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
 
         assert!(logs_contain("is in deny_requestor_addresses"));
     }
@@ -1685,10 +1667,7 @@ pub(crate) mod tests {
         let order_id = order.id();
         assert!(!ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await);
 
-        assert_eq!(
-            ctx.db.get_order(&order_id).await.unwrap().unwrap().status,
-            OrderStatus::Skipped
-        );
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
         assert!(logs_contain("collateral requirement exceeds max_collateral config"));
     }
 
@@ -1758,10 +1737,7 @@ pub(crate) mod tests {
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(!locked);
 
-        assert_eq!(
-            ctx.db.get_order(&order_id).await.unwrap().unwrap().status,
-            OrderStatus::Skipped
-        );
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
         assert!(logs_contain("journal larger than set limit"));
     }
 
@@ -1843,8 +1819,7 @@ pub(crate) mod tests {
             "Skipping order {order_id} due to intentional execution limit of"
         )));
 
-        let db_order = ctx.db.get_order(&order_id).await.unwrap().unwrap();
-        assert_eq!(db_order.status, OrderStatus::Skipped);
+        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
  - Skipped order rows in broker.db were a vestigial negative cache: no production code path reads them. Pricer and locker wrote one on every rejected order, and the only consumer was an ON CONFLICT … WHERE status='Skipped' clause in insert_accepted_request that allowed upgrades — a path nothing actually depends on being persistent.
  - Over time the rows accumulated into the hundreds of thousands per prover and dominated the table. The release prover hit 789K Skipped rows out of 793K total, producing sustained slow-statement warnings on json_set UPDATE queries and stalling order processing for ~4 days until a manual DELETE + VACUUM brought it back.
  - Telemetry already records skip outcomes and reasons independently of the DB write, so observability is unchanged.