### PR TITLE
BM-2938: nit: remove arg name mem leak on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ broker = { path = "crates/broker" }
 bs58 = "0.5"
 bytemuck = "1.16"
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4.5", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env", "string"] }
 clap_complete = "4.5"
 distributor = { path = "crates/distributor" }
 futures-util = "0.3"

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -135,12 +135,10 @@ fn discover_chain_ids_from_argv() -> BTreeSet<u64> {
 /// Add dynamic clap args for a single chain ID.
 fn register_chain_args(mut cmd: clap::Command, chain_id: u64) -> clap::Command {
     for def in CHAIN_ARG_DEFS {
-        // Leak the arg name string since clap requires &'static str for Arg::new/long.
-        // Runs once at startup so the leak is negligible.
-        let arg_name: &'static str = format!("{}-{chain_id}", def.name).leak();
+        let arg_name: String = format!("{}-{chain_id}", def.name);
         let action = if def.append { ArgAction::Append } else { ArgAction::Set };
         cmd = cmd.arg(
-            Arg::new(arg_name)
+            Arg::new(&arg_name)
                 .long(arg_name)
                 .action(action)
                 .help(format!("{} for chain {chain_id}", def.help)),


### PR DESCRIPTION
Super insignificant change, but I saw this code and couldn't help myself but to remove this leaked memory