### PR TITLE
BM-2939: Tear down legacy bento compose project on prover-stack hosts

### DIFF
--- a/ansible/roles/prover/tasks/main.yml
+++ b/ansible/roles/prover/tasks/main.yml
@@ -168,3 +168,31 @@
   ansible.builtin.command:
     cmd: docker system prune -af
   changed_when: true
+
+# When the host is configured for the new prover-compose stack (i.e.
+# prover_stack != "legacy"), tear down any leftover containers from the legacy
+# `bento` compose project. Both compose files publish redis on host port 6379,
+# so a stale `bento-redis-1` from a previous setup will block `prover-redis-1`
+# from starting on every subsequent restart, with the failure invisible above
+# the docker layer.
+- name: Detect legacy bento compose containers
+  ansible.builtin.command:
+    cmd: docker ps -aq --filter label=com.docker.compose.project=bento
+  register: prover_legacy_bento_containers
+  changed_when: false
+  when: prover_stack | default('') != 'legacy'
+
+- name: Tear down legacy bento compose project
+  ansible.builtin.command:
+    cmd: >-
+      docker compose -f {{ prover_dir }}/compose.yml
+      --profile broker --profile miner --profile caddy
+      down --remove-orphans
+    chdir: "{{ prover_dir }}"
+  when:
+    - prover_stack | default('') != 'legacy'
+    - prover_legacy_bento_containers.stdout | default('') | length > 0
+  notify: Restart Bento
+
+- name: Flush queued handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
On prover-stack hosts (i.e. `prover_stack != "legacy"`), Ansible now detects and tears down any leftover containers from the legacy `bento` compose project before flushing handlers to start the new stack. Both compose files publish redis on host port 6379, so a stale `bento-*` container silently blocks `prover-redis-1` from starting on every restart (`Type=oneshot` + `--no-block` makes systemd report success regardless). 
  
Root cause of the 2026-05-01 incident where four nightly provers ran ~30h on pre-#1963 code despite multiple "successful" deploys.