### PR TITLE
BM-2947: Reduce Taiko OG frequency: prod 1/hr, staging 1/2hr

### DIFF
--- a/infra/order-generator/Pulumi.l-prod-167000.yaml
+++ b/infra/order-generator/Pulumi.l-prod-167000.yaml
@@ -11,7 +11,7 @@ config:
     secure: v1:v0CqkVuF6OQo6w3I:Ie40GUu+YUdbHL/SdIJeEIjvJs0wY+kkVX379/uaqcbTLHFpaTVeTdR0wglkUt2D3k2mXZ/1yXjV9DzpJxhjDZ8ezWiL3iZKnUu4xgllKllOC+t6znOMyWSjH1djCDAw5sAUKgrRhC/k9OfeDg==
   order-generator-base:INDEXER_URL:
     secure: v1:TU3/Yju/3FP9d/fY:ccwXwEIySoHl0Gnzf4g49Cvd2aSylHhvxwFjk1eytjBJo2KueszIhrAUJM+jOUXqwl2wIjk=
-  order-generator-base:INTERVAL: "1800"
+  order-generator-base:INTERVAL: "3600"
   order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "15000000000000000000"
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -29,7 +29,7 @@ config:
   order-generator-evm-requestor:ERROR_BALANCE_BELOW: "0.005"
   order-generator-evm-requestor:EXEC_RATE_KHZ: "1000"
   order-generator-evm-requestor:INPUT_MAX_MCYCLES: "3000"
-  order-generator-evm-requestor:INTERVAL: "600"
+  order-generator-evm-requestor:INTERVAL: "3600"
   order-generator-evm-requestor:LOCK_TIMEOUT: "2100"
   order-generator-evm-requestor:MAX_OUTSTANDING_REQUESTS: "15"
   order-generator-evm-requestor:MAX_PRICE_CAP: "0.0075"
@@ -47,7 +47,7 @@ config:
   order-generator-offchain:EXEC_RATE_KHZ: "1000"
   order-generator-offchain:INPUT_MAX_MCYCLES: "2000"
   order-generator-offchain:INPUT_MIN_MCYCLES: "1000"
-  order-generator-offchain:INTERVAL: "1800"
+  order-generator-offchain:INTERVAL: "3600"
   order-generator-offchain:LOCK_TIMEOUT: "1500"
   order-generator-offchain:MAX_OUTSTANDING_REQUESTS: "15"
   order-generator-offchain:MAX_PRICE_CAP: "0.0001"
@@ -63,7 +63,7 @@ config:
   order-generator-onchain:EXEC_RATE_KHZ: "1000"
   order-generator-onchain:INPUT_MAX_MCYCLES: "4000"
   order-generator-onchain:INPUT_MIN_MCYCLES: "1000"
-  order-generator-onchain:INTERVAL: "1800"
+  order-generator-onchain:INTERVAL: "3600"
   order-generator-onchain:LOCK_TIMEOUT: "2100"
   order-generator-onchain:MAX_OUTSTANDING_REQUESTS: "15"
   order-generator-onchain:MAX_PRICE_CAP: "0.0001"
@@ -74,7 +74,7 @@ config:
   order-generator-onchain:SECONDS_PER_MCYCLE: "7"
   order-generator-onchain:TIMEOUT: "1800"
   order-generator-onchain:WARN_BALANCE_BELOW: "0.01"
-  order-generator-random-requestor:COUNT: "5"
+  order-generator-random-requestor:COUNT: "1"
   order-generator-random-requestor:ERROR_BALANCE_BELOW: "0.005"
   order-generator-random-requestor:INPUT_MAX_MCYCLES: "200"
   order-generator-random-requestor:INTERVAL: "600"

--- a/infra/order-generator/Pulumi.l-staging-167000.yaml
+++ b/infra/order-generator/Pulumi.l-staging-167000.yaml
@@ -12,7 +12,7 @@ config:
     secure: v1:7PLcXIEjgrqam2dS:xe1rESzWS1cuvaenW4BN50XWB8BUNdGOFc9H7sxXdp+nxWOvVDMh8cpzs8daz5DSPf5D3591f6+1G2DMQL8ysLidB4Gnnq7OKCU2bbbbj7koTz9f86WJunY9KImLT1sITi/bXCdkqCNReuw0Iw==
   order-generator-base:INDEXER_URL:
     secure: v1:89O26wmmlPr/+0Ad:Njr55N9i8S2pJMiVlmxgK0snx9n13ACWnleShjGTpPT4ougeEZ6rG2Z+aqYmxC4eNjdkVdo=
-  order-generator-base:INTERVAL: "900"
+  order-generator-base:INTERVAL: "7200"
   order-generator-base:IPFS_GATEWAY_URL: https://gateway.beboundless.cloud
   order-generator-base:LOCK_COLLATERAL_RAW: "5000000000000000000"
   order-generator-base:LOCK_TIMEOUT: "900"
@@ -45,7 +45,7 @@ config:
   order-generator-offchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-offchain:EXEC_RATE_KHZ: "500"
   order-generator-offchain:INPUT_MAX_MCYCLES: "10"
-  order-generator-offchain:INTERVAL: "1800"
+  order-generator-offchain:INTERVAL: "7200"
   order-generator-offchain:LOCK_TIMEOUT: "900"
   order-generator-offchain:PRIVATE_KEY:
     secure: v1:p4IhT/U8smWcYeRL:roi/EfqIqgP1UZmtGLNaA4LMkoa1WzW8vnmCVAcsz9WD2IgBmM40Q2KryQ1VVmkyBHE4d2/AMaMq+HWh+GR3Y/vW5qxksExOTDjrBXOO6jo=
@@ -57,7 +57,7 @@ config:
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "500"
   order-generator-onchain:INPUT_MAX_MCYCLES: "10"
-  order-generator-onchain:INTERVAL: "1800"
+  order-generator-onchain:INTERVAL: "7200"
   order-generator-onchain:LOCK_TIMEOUT: "900"
   order-generator-onchain:PRIVATE_KEY:
     secure: v1:pQMFkeTtuUKffOsy:uMi6cYMUnzxqi7ErlSWki49wLRhhKBAjwcHvBUqxHwiZoepNZCgZHZmPRqiZnl7ZqNhALvU6CTNH84xTEQc2CN4+SM36xzdaM40fSmH9b8A=


### PR DESCRIPTION
Slows down Taiko (chain 167000) order-generator traffic on prod and staging.

Changes
* Prod: all OG INTERVALs to 3600 (offchain/onchain 1800->3600, evm-requestor 600->3600, base 1800->3600)
* Prod: random-requestor COUNT 5 -> 1 (one request per 24h schedule, was firing 5)
* Staging: all OG INTERVALs to 7200 (offchain/onchain 1800->7200, base 900->7200, evm-requestor already 7200)