### PR TITLE
BM-2951: pin cargo-binstall to v1.17.9 for rustc 1.89 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install nextest
         run: cargo binstall -y cargo-nextest@0.9.128
@@ -266,6 +269,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install lychee
         run: cargo binstall -y lychee@0.15.1
@@ -327,6 +333,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install dprint
         run: cargo binstall -y dprint@0.47.2

--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -107,6 +107,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install cargo-sort
         run: cargo binstall -y cargo-sort@2

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -78,6 +78,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: Install cargo-sort
         run: cargo binstall -y cargo-sort@2

--- a/justfile
+++ b/justfile
@@ -289,6 +289,7 @@ cargo-update:
 update-lockfiles:
     cargo fetch
     cd bento && cargo fetch
+    cd prover && cargo fetch
     cd crates/guest/assessor/assessor-guest && cargo fetch
     cd crates/guest/util/echo && cargo fetch
     cd crates/guest/util/identity && cargo fetch

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.5.0-alpha.0"
+version = "2.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.5.0-alpha.0"
+version = "2.1.0-alpha.0"
 dependencies = [
  "alloy",
  "alloy-chains",


### PR DESCRIPTION
  CI is currently failing on every PR opened recently at the `install cargo-binstall` step:

  rustc 1.89.0 is not supported by the following packages:
      cargo-platform@0.3.3 requires rustc 1.91

  cargo-binstall v1.19.x (released 2026-05-03 and 2026-05-06) pulls in `cargo-platform@0.3.3`, which bumped its MSRV to rustc 1.91. Our `rust-toolchain.toml` is pinned to 1.89, so the install fails before any project code is touched.

  This pins all 5 `baptiste0928/cargo-install@v3` steps to **v1.17.9** — the most recent release before v1.19.0 (cargo-binstall skipped the v1.18.x line) and the last version before the cargo-platform MSRV bump.