### PR TITLE
BM-2961: prioritize aggregator stages, make commitment-reaper timeout configurable

### DIFF
--- a/crates/boundless-market/src/prover_utils/config.rs
+++ b/crates/boundless-market/src/prover_utils/config.rs
@@ -167,6 +167,10 @@ pub mod defaults {
         1
     }
 
+    pub const fn max_commitment_duration_secs() -> u64 {
+        14400
+    }
+
     pub const fn max_order_expiry_secs() -> Option<u64> {
         None
     }
@@ -531,6 +535,12 @@ pub struct MarketConfig {
     /// Maximum number of concurrent proofs that can be processed at once
     #[serde(default = "defaults::max_concurrent_proofs")]
     pub max_concurrent_proofs: u32,
+    /// Maximum time (in seconds) an order may hold a slot in the OrderCommitter
+    /// `in_flight` map before its slot is reaped as stale. Acts as a backstop
+    /// against leaked slots; raise it for prover clusters where legitimate
+    /// proves regularly exceed the default.
+    #[serde(default = "defaults::max_commitment_duration_secs")]
+    pub max_commitment_duration_secs: u64,
     /// Optional cache directory for storing downloaded images and inputs
     ///
     /// If not set, files will be re-downloaded every time
@@ -648,6 +658,7 @@ impl Default for MarketConfig {
             collateral_balance_warn_threshold: None,
             collateral_balance_error_threshold: None,
             max_concurrent_proofs: defaults::max_concurrent_proofs(),
+            max_commitment_duration_secs: defaults::max_commitment_duration_secs(),
             cache_dir: None,
             ipfs_gateway_fallback: defaults::ipfs_gateway(),
             assessor_default_image_url: defaults::assessor_default_image_url(),

--- a/crates/boundless-market/src/prover_utils/prover.rs
+++ b/crates/boundless-market/src/prover_utils/prover.rs
@@ -146,6 +146,26 @@ pub trait Prover {
     #[allow(unused)]
     async fn compress(&self, proof_id: &str) -> Result<String, ProverError>;
 
+    /// Start and wait for a STARK proving job at High priority. Subtasks
+    /// inherit the parent job's priority via taskdb. Default falls back to
+    /// the regular flow for backends that don't support priority.
+    #[allow(unused)]
+    async fn prove_and_monitor_stark_high(
+        &self,
+        image_id: &str,
+        input_id: &str,
+        assumptions: Vec<String>,
+    ) -> Result<ProofResult, ProverError> {
+        self.prove_and_monitor_stark(image_id, input_id, assumptions).await
+    }
+
+    /// Compress a STARK proof to Groth16 at High priority. Default falls back
+    /// to the regular flow for backends that don't support priority.
+    #[allow(unused)]
+    async fn compress_high(&self, proof_id: &str) -> Result<String, ProverError> {
+        self.compress(proof_id).await
+    }
+
     /// Get the compressed (Groth16) receipt.
     #[allow(unused)]
     async fn get_compressed_receipt(&self, proof_id: &str) -> Result<Option<Vec<u8>>, ProverError>;

--- a/crates/broker/src/aggregator/service.rs
+++ b/crates/broker/src/aggregator/service.rs
@@ -167,9 +167,6 @@ impl AggregatorService {
             .await
             .context("Failed to upload set-builder input")?;
 
-        // TODO: we should run this on a different stream in the prover
-        // aka make a few different priority streams for each level of the proving
-
         // TODO: Need to set a timeout here to handle stuck or even just alert on delayed proving if
         // the proving cluster is overloaded
 
@@ -185,7 +182,7 @@ impl AggregatorService {
             || async {
                 let proof_res = self
                     .prover
-                    .prove_and_monitor_stark(
+                    .prove_and_monitor_stark_high(
                         &self.set_builder_guest_id.to_string(),
                         &input_id,
                         assumption_ids.clone(),
@@ -306,7 +303,7 @@ impl AggregatorService {
 
         let proof_res = self
             .prover
-            .prove_and_monitor_stark(&self.assessor_guest_id.to_string(), &input_id, vec![])
+            .prove_and_monitor_stark_high(&self.assessor_guest_id.to_string(), &input_id, vec![])
             .await
             .context("Failed to prove assesor stark")?;
 
@@ -765,7 +762,7 @@ impl AggregatorService {
                 retry_count,
                 sleep_ms,
                 || async {
-                    let proof_id = self.prover.compress(&aggregation_proof_id).await?;
+                    let proof_id = self.prover.compress_high(&aggregation_proof_id).await?;
                     provers::verify_groth16_receipt(&self.prover, &proof_id).await?;
                     Ok::<String, provers::ProverError>(proof_id)
                 },

--- a/crates/broker/src/order_committer/service.rs
+++ b/crates/broker/src/order_committer/service.rs
@@ -59,7 +59,6 @@ use super::types::CommitmentComplete;
 
 const MIN_CAPACITY_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_PROVING_BATCH_SIZE: usize = 10;
-const DEFAULT_MAX_COMMITMENT_DURATION_SECS: u64 = 7200;
 
 /// Singleton service that manages global proving capacity across all chains.
 ///
@@ -135,6 +134,7 @@ impl OrderCommitter {
         })?;
         Ok(CommitterConfig {
             max_concurrent_proofs: cfg.market.max_concurrent_proofs as usize,
+            max_commitment_duration_secs: cfg.market.max_commitment_duration_secs,
             peak_prove_khz: cfg.market.peak_prove_khz,
             additional_proof_cycles: cfg.market.additional_proof_cycles,
             batch_buffer_time_secs: cfg.batcher.block_deadline_buffer_secs,
@@ -531,7 +531,7 @@ impl BrokerService for OrderCommitter {
 
                     Self::reap_stale_capacity(
                         &mut in_flight,
-                        DEFAULT_MAX_COMMITMENT_DURATION_SECS,
+                        committer_config.max_commitment_duration_secs,
                     );
                 }
 

--- a/crates/broker/src/order_committer/state.rs
+++ b/crates/broker/src/order_committer/state.rs
@@ -28,6 +28,7 @@ pub(super) struct InFlightOrder {
 
 pub(super) struct CommitterConfig {
     pub(super) max_concurrent_proofs: usize,
+    pub(super) max_commitment_duration_secs: u64,
     pub(super) peak_prove_khz: Option<u64>,
     pub(super) additional_proof_cycles: u64,
     pub(super) batch_buffer_time_secs: u64,

--- a/crates/broker/src/provers/bonsai.rs
+++ b/crates/broker/src/provers/bonsai.rs
@@ -47,6 +47,11 @@ pub struct Bonsai {
     status_poll_ms: u64,
     status_poll_retry_count: u64,
     prover_type: ProverType,
+    // Used for direct HTTP submission with priority — the SDK's `ProofReq`/`SnarkReq`
+    // omit the priority field, so we hit the API ourselves for High-priority paths.
+    api_url: String,
+    api_key: String,
+    http: reqwest::Client,
 }
 
 impl Bonsai {
@@ -89,6 +94,45 @@ impl Bonsai {
             status_poll_ms,
             status_poll_retry_count,
             prover_type,
+            api_url: api_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            http: reqwest::Client::new(),
+        })
+    }
+
+    /// POST `body` to `{api_url}{path}` with the broker's api key and decode
+    /// `{ "uuid": String }` from the response. Used by the High-priority paths
+    /// because the SDK's request types omit the priority field.
+    async fn submit_high(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<String, ProverError> {
+        let url = format!("{}{}", self.api_url, path);
+        let res = self
+            .http
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| {
+            ProverError::ProverInternalError(format!("submit_high {path}: {e}"))
+        })?;
+        if !res.status().is_success() {
+            let status = res.status();
+            let text = res.text().await.unwrap_or_default();
+            return Err(ProverError::ProverInternalError(format!(
+                "submit_high {path} {status}: {text}"
+            )));
+        }
+        let parsed: serde_json::Value = res.json().await.map_err(|e| {
+            ProverError::ProverInternalError(format!("submit_high {path} decode: {e}"))
+        })?;
+        parsed.get("uuid").and_then(|v| v.as_str()).map(|s| s.to_string()).ok_or_else(|| {
+            ProverError::ProverInternalError(format!(
+                "submit_high {path}: missing 'uuid' in response"
+            ))
         })
     }
 
@@ -588,6 +632,51 @@ impl Prover for Bonsai {
             .context(format!("Failed to compress proof {proof_id:?}"))?;
 
         Ok(proof_id.uuid)
+    }
+
+    async fn prove_and_monitor_stark_high(
+        &self,
+        image_id: &str,
+        input_id: &str,
+        assumptions: Vec<String>,
+    ) -> Result<ProofResult, ProverError> {
+        // JSON shape matches `StarkApiReq` in prover/crates/api/src/lib.rs.
+        let body = serde_json::json!({
+            "img": image_id,
+            "input": input_id,
+            "assumptions": assumptions,
+            "execute_only": false,
+            "priority": "high",
+        });
+        let proof_id = self
+            .retry(
+                || async { self.submit_high("/sessions/create", &body).await },
+                "create session high",
+            )
+            .await?;
+        tracing::debug!("Created session for prove stark (high priority): {proof_id}");
+        self.wait_for_stark(&proof_id).await
+    }
+
+    async fn compress_high(&self, proof_id: &str) -> Result<String, ProverError> {
+        // JSON shape matches `SnarkApiReq` in prover/crates/api/src/lib.rs.
+        let body = serde_json::json!({
+            "session_id": proof_id,
+            "priority": "high",
+        });
+        let snark_uuid = self
+            .retry(|| async { self.submit_high("/snark/create", &body).await }, "create snark high")
+            .await?;
+        let snark_id = SnarkId { uuid: snark_uuid };
+        let poller = StatusPoller {
+            poll_sleep_ms: self.status_poll_ms,
+            retry_counts: self.status_poll_retry_count,
+        };
+        poller
+            .poll_with_retries_snark_id(&snark_id, &self.client)
+            .await
+            .context(format!("Failed to compress proof (high) {snark_id:?}"))?;
+        Ok(snark_id.uuid)
     }
 
     async fn get_compressed_receipt(&self, proof_id: &str) -> Result<Option<Vec<u8>>, ProverError> {


### PR DESCRIPTION
  - **Run aggregator stages at High priority.** Adds default-implemented `Prover::prove_and_monitor_stark_high` and `Prover::compress_high` trait methods (they fall back to the regular flow for backends that don't support priority), and uses them in `AggregatorService` for the set-builder STARK, assessor STARK, and Groth16 compression. The Bonsai impl hits the API directly (`/sessions/create`, `/snark/create`) because the SDK's `ProofReq`/`SnarkReq` types don't expose the `priority` field — taskdb propagates priority to subtasks. (`crates/boundless-market/src/prover_utils/prover.rs`,
  `crates/broker/src/aggregator/service.rs`, `crates/broker/src/provers/bonsai.rs`)
  - **Make `OrderCommitter` stale-slot reaper timeout configurable.** Replaces the hardcoded `DEFAULT_MAX_COMMITMENT_DURATION_SECS = 7200` with a new `market.max_commitment_duration_secs` field in `MarketConfig` (default raised to **14400s / 4h**). Acts as a backstop against leaked `in_flight` slots; clusters whose
   legitimate proves regularly exceed the default can raise it. (`crates/boundless-market/src/prover_utils/config.rs`, `crates/broker/src/order_committer/{service,state}.rs`)

  ## Motivation

  Aggregator stages (set-builder, assessor, compress) are on the critical path for fulfillment; every locked order is blocked on them. Running them at the same priority as user proofs lets large mining/market workloads queue ahead and stretch fulfillment latency. Pinning them to High keeps batch closure responsive even under heavy proving load.

  The commitment-duration backstop being hardcoded at 2h was occasionally tripping legitimate long-running proves on slower clusters; making it config-driven (with a more permissive 4h default) avoids spurious slot reaps without losing the leak protection.