### PR TITLE
BM-2962: fix(broker): clean up multi-chain RPC initialization

### DIFF
--- a/crates/broker/src/args.rs
+++ b/crates/broker/src/args.rs
@@ -158,7 +158,10 @@ pub struct CoreArgs {
 /// Parsed per-chain configuration resolved from environment variables and CLI args.
 #[derive(Debug, Clone)]
 pub struct ChainArgs {
-    pub chain_id: u64,
+    /// Configured chain ID, or [`None`] for the legacy single-chain config path —
+    /// in which case the actual ID is resolved by calling `provider.get_chain_id()`
+    /// at startup.
+    pub chain_id: Option<u64>,
     pub rpc_urls: Vec<Url>,
     pub private_key: PrivateKeySigner,
     pub config_override_path: Option<PathBuf>,

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -40,6 +40,30 @@ struct ChainArgDef {
     append: bool,
 }
 
+/// Merge a primary URL with an iterator of additional URLs into a deduplicated `Vec<Url>`.
+///
+/// Empty-after-trim entries are skipped. `err_label` is included in the parse-error context
+/// (e.g. `"PROVER_RPC_URL(S)_8453"`).
+fn merge_rpc_urls<'a>(
+    primary: Option<&'a str>,
+    list: impl IntoIterator<Item = &'a str>,
+    err_label: &'a str,
+) -> Result<Vec<Url>> {
+    let mut all_urls: Vec<Url> = Vec::new();
+    for s in primary.into_iter().chain(list) {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let url = Url::parse(trimmed)
+            .with_context(|| format!("Invalid URL in {err_label}: {trimmed}"))?;
+        if !all_urls.contains(&url) {
+            all_urls.push(url);
+        }
+    }
+    Ok(all_urls)
+}
+
 const CHAIN_ARG_DEFS: &[ChainArgDef] = &[
     ChainArgDef { name: "rpc-url", help: "RPC endpoint (repeat for failover)", append: true },
     ChainArgDef { name: "private-key", help: "Wallet key", append: false },
@@ -263,24 +287,47 @@ async fn main() -> Result<()> {
     let mut chain_pipelines = Vec::new();
     let mut _config_watchers: Vec<ConfigWatcher> = Vec::new();
 
-    if discovered_chains.is_empty() {
-        let private_key = args
-            .private_key
-            .clone()
-            .or_else(|| std::env::var("PRIVATE_KEY").ok().and_then(|key| key.parse().ok()))
-            .context(
-                "Private key not provided. Set PROVER_PRIVATE_KEY or PRIVATE_KEY environment variable",
-            )?;
+    for chain_args in &discovered_chains {
+        match chain_args.chain_id {
+            None => tracing::info!(
+                rpc_urls = ?chain_args.rpc_urls,
+                provenance = "legacy single-chain",
+                "Starting pipeline (chain ID will be resolved from RPC)"
+            ),
+            Some(id) => tracing::info!(
+                configured_chain_id = id,
+                rpc_urls = ?chain_args.rpc_urls,
+                provenance = "per-chain",
+                "Starting pipeline for chain"
+            ),
+        }
 
-        let rpc_urls = collect_rpc_urls(args.rpc_url.clone(), args.rpc_urls.clone())?;
+        // Legacy mode (no chain) has no config override (chain_id is unknown until provider is built);
+        // per-chain pipelines may have an explicit override path.
+        let chain_config_watcher = match chain_args.chain_id {
+            None => ConfigWatcher::new(&args.config_file)
+                .await
+                .context("Failed to load broker config")?,
+            Some(id) => ConfigWatcher::new_with_chain_override(
+                &args.config_file,
+                chain_args.config_override_path.as_deref(),
+                Some(id),
+            )
+            .await
+            .with_context(|| format!("Failed to load config for chain {id}"))?,
+        };
 
-        let config = base_config_watcher.config.clone();
+        let config = chain_config_watcher.config.clone();
         let (provider, any_provider, gas_priority_mode) =
-            build_chain_provider(&rpc_urls, &private_key, &args, &config)?;
+            build_chain_provider(&chain_args.rpc_urls, &chain_args.private_key, &args, &config)?;
         let provider = Arc::new(provider);
 
         let chain_id = provider.get_chain_id().await.context("Failed to get chain ID")?;
-        let deployment = resolve_deployment(args.deployment.as_ref(), chain_id)?;
+        let deployment = chain_args
+            .deployment
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(|| resolve_deployment(args.deployment.as_ref(), chain_id))?;
         tracing::info!(chain_id, %deployment, "Using deployment configuration");
 
         let db_url = broker_sqlite_url_for_chain(&args.db_url, chain_id)
@@ -301,7 +348,7 @@ async fn main() -> Result<()> {
                     "Pre-depositing {deposit_amount} stake tokens into the market contract"
                 );
                 market
-                    .deposit_collateral_with_permit(*deposit_amount, &private_key)
+                    .deposit_collateral_with_permit(*deposit_amount, &chain_args.private_key)
                     .await
                     .context("Failed to deposit to market")?;
             }
@@ -312,79 +359,13 @@ async fn main() -> Result<()> {
             any_provider,
             config,
             gas_priority_mode,
-            private_key,
+            private_key: chain_args.private_key.clone(),
             chain_id,
             deployment,
             db,
         });
-    } else {
-        for chain_args in &discovered_chains {
-            tracing::info!(
-                chain_id = chain_args.chain_id,
-                rpc_urls = ?chain_args.rpc_urls,
-                "Starting pipeline for chain"
-            );
 
-            let chain_config_watcher = ConfigWatcher::new_with_chain_override(
-                &args.config_file,
-                chain_args.config_override_path.as_deref(),
-                Some(chain_args.chain_id),
-            )
-            .await
-            .with_context(|| format!("Failed to load config for chain {}", chain_args.chain_id))?;
-
-            let config = chain_config_watcher.config.clone();
-            let (provider, any_provider, gas_priority_mode) = build_chain_provider(
-                &chain_args.rpc_urls,
-                &chain_args.private_key,
-                &args,
-                &config,
-            )?;
-            let provider = Arc::new(provider);
-
-            let chain_id = provider.get_chain_id().await.context("Failed to get chain ID")?;
-            let deployment = chain_args
-                .deployment
-                .clone()
-                .map(Ok)
-                .unwrap_or_else(|| resolve_deployment(args.deployment.as_ref(), chain_id))?;
-            tracing::info!(chain_id, %deployment, "Using deployment configuration");
-
-            let db_url = broker_sqlite_url_for_chain(&args.db_url, chain_id)
-                .map_err(|e| anyhow::anyhow!("invalid broker database URL: {e}"))?;
-            let db = Arc::new(
-                SqliteDb::new(&db_url).await.context("Failed to open per-chain sqlite database")?,
-            );
-
-            if !args.listen_only {
-                if let Some(deposit_amount) = args.deposit_amount.as_ref() {
-                    let market = BoundlessMarketService::new_for_broker(
-                        deployment.boundless_market_address,
-                        provider.clone(),
-                        provider.default_signer_address(),
-                    );
-                    tracing::info!(
-                        chain_id,
-                        "Pre-depositing {deposit_amount} stake tokens into the market contract"
-                    );
-                    market
-                        .deposit_collateral_with_permit(*deposit_amount, &chain_args.private_key)
-                        .await
-                        .context("Failed to deposit to market")?;
-                }
-            }
-
-            chain_pipelines.push(ChainPipeline {
-                provider,
-                any_provider,
-                config,
-                gas_priority_mode,
-                private_key: chain_args.private_key.clone(),
-                chain_id,
-                deployment,
-                db,
-            });
-
+        if chain_args.chain_id.is_some() {
             _config_watchers.push(chain_config_watcher);
         }
     }
@@ -394,59 +375,6 @@ async fn main() -> Result<()> {
     broker.start_service(chain_pipelines).await.context("Broker service failed")?;
 
     Ok(())
-}
-
-/// Collect and deduplicate RPC URLs from the single-chain args.
-/// Returns a list with the primary URL first, followed by any additional failover URLs.
-fn collect_rpc_urls(rpc_url: Option<String>, rpc_urls: Vec<String>) -> Result<Vec<Url>> {
-    let mut all_rpc_urls: Vec<Url> = Vec::new();
-
-    if let Some(url_str) = rpc_url {
-        if !url_str.is_empty() {
-            let url =
-                Url::parse(&url_str).context("Invalid PROVER_RPC_URL environment variable")?;
-            if !all_rpc_urls.contains(&url) {
-                all_rpc_urls.push(url);
-            }
-        }
-    }
-
-    for url_str in rpc_urls {
-        let url_str = url_str.trim();
-        if !url_str.is_empty() {
-            let url =
-                Url::parse(url_str).context("Invalid PROVER_RPC_URLS environment variable")?;
-            if !all_rpc_urls.contains(&url) {
-                all_rpc_urls.push(url);
-            }
-        }
-    }
-
-    if all_rpc_urls.is_empty() {
-        if let Ok(rpc_url_env) = std::env::var("RPC_URL") {
-            if !rpc_url_env.is_empty() {
-                let url =
-                    Url::parse(&rpc_url_env).context("Invalid RPC_URL environment variable")?;
-                all_rpc_urls.push(url);
-                tracing::info!("Using RPC_URL environment variable (PROVER_RPC_URL not set)");
-            }
-        }
-    }
-
-    if all_rpc_urls.is_empty() {
-        all_rpc_urls.push(
-            Url::parse("https://base.gateway.tenderly.co")
-                .expect("hardcoded Tenderly URL is valid"),
-        );
-    }
-
-    if all_rpc_urls.is_empty() {
-        anyhow::bail!(
-            "No RPC URLs provided. Please set at least one using PROVER_RPC_URL or PROVER_RPC_URLS environment variables"
-        );
-    }
-
-    Ok(all_rpc_urls)
 }
 
 /// Build per-chain Deployment objects from the PerChainArgs address fields.
@@ -507,10 +435,14 @@ fn build_chain_deployments(
 ///
 /// Chains are discovered from two sources (CLI args take priority):
 /// 1. `--rpc-url-{chain_id}` CLI args
-/// 2. `PROVER_RPC_URL_{chain_id}` environment variables
+/// 2. `PROVER_RPC_URL_{chain_id}` / `PROVER_RPC_URLS_{chain_id}` environment variables
 ///
-/// Returns an empty vec if no per-chain configuration is found (falls back to
-/// single-chain mode in main).
+/// If neither source yields anything, falls back to the legacy single-chain config
+/// (`PROVER_RPC_URL` / `PROVER_RPC_URLS`, `PROVER_PRIVATE_KEY`, etc.) and returns a
+/// single `ChainArgs` with `chain_id = None`; the actual ID is resolved by
+/// `provider.get_chain_id()` at startup.
+///
+/// Errors if no RPC URL is configured anywhere.
 fn discover_chains(args: &CoreArgs, per_chain: &mut PerChainArgs) -> Result<Vec<ChainArgs>> {
     let mut chain_urls: BTreeMap<u64, Vec<Url>> = BTreeMap::new();
     for (chain_id, urls) in per_chain.rpc_urls.drain() {
@@ -518,8 +450,7 @@ fn discover_chains(args: &CoreArgs, per_chain: &mut PerChainArgs) -> Result<Vec<
     }
 
     // Discover chain IDs referenced by either PROVER_RPC_URL_{chain_id} or
-    // PROVER_RPC_URLS_{chain_id}, then combine both forms per chain — same
-    // semantics as collect_rpc_urls() for single-chain mode.
+    // PROVER_RPC_URLS_{chain_id}, then combine both forms per chain.
     let mut env_chain_ids: BTreeSet<u64> = BTreeSet::new();
     for (key, value) in std::env::vars() {
         if value.trim().is_empty() {
@@ -539,39 +470,23 @@ fn discover_chains(args: &CoreArgs, per_chain: &mut PerChainArgs) -> Result<Vec<
         if chain_urls.contains_key(&chain_id) {
             continue;
         }
-        let mut urls: Vec<Url> = Vec::new();
-
-        if let Ok(primary) = std::env::var(format!("PROVER_RPC_URL_{chain_id}")) {
-            let trimmed = primary.trim();
-            if !trimmed.is_empty() {
-                urls.push(
-                    Url::parse(trimmed)
-                        .with_context(|| format!("Invalid PROVER_RPC_URL_{chain_id}"))?,
-                );
-            }
-        }
-
-        if let Ok(extra_urls) = std::env::var(format!("PROVER_RPC_URLS_{chain_id}")) {
-            for url_str in extra_urls.split(',') {
-                let url_str = url_str.trim();
-                if url_str.is_empty() {
-                    continue;
-                }
-                let url = Url::parse(url_str)
-                    .with_context(|| format!("Invalid URL in PROVER_RPC_URLS_{chain_id}"))?;
-                if !urls.contains(&url) {
-                    urls.push(url);
-                }
-            }
-        }
-
+        let primary_env = std::env::var(format!("PROVER_RPC_URL_{chain_id}")).ok();
+        let extra_env = std::env::var(format!("PROVER_RPC_URLS_{chain_id}")).ok();
+        let label = format!("PROVER_RPC_URL(S)_{chain_id}");
+        let urls = merge_rpc_urls(
+            primary_env.as_deref(),
+            extra_env.as_deref().into_iter().flat_map(|s| s.split(',')),
+            &label,
+        )?;
         if !urls.is_empty() {
             chain_urls.insert(chain_id, urls);
         }
     }
 
     if chain_urls.is_empty() {
-        return Ok(Vec::new());
+        // No per-chain configuration: synthesize a single legacy ChainArgs whose
+        // actual chain_id will be resolved at startup via provider.get_chain_id().
+        return Ok(vec![synthesize_legacy_chain(args)?]);
     }
 
     let mut chain_deployments = build_chain_deployments(per_chain)?;
@@ -607,7 +522,7 @@ fn discover_chains(args: &CoreArgs, per_chain: &mut PerChainArgs) -> Result<Vec<
         let deployment = chain_deployments.remove(&chain_id);
 
         chains.push(ChainArgs {
-            chain_id,
+            chain_id: Some(chain_id),
             rpc_urls,
             private_key,
             config_override_path,
@@ -625,6 +540,55 @@ fn discover_chains(args: &CoreArgs, per_chain: &mut PerChainArgs) -> Result<Vec<
     Ok(chains)
 }
 
+/// Build a single `ChainArgs` from the legacy single-chain CLI/env vars.
+///
+/// The `chain_id` is left as `None` — `main()` resolves it via `provider.get_chain_id()`
+/// once the provider is built. Errors if no RPC URL or private key is configured.
+fn synthesize_legacy_chain(args: &CoreArgs) -> Result<ChainArgs> {
+    let mut rpc_urls = merge_rpc_urls(
+        args.rpc_url.as_deref(),
+        args.rpc_urls.iter().map(String::as_str),
+        "PROVER_RPC_URL(S)",
+    )?;
+
+    // Legacy fallback: honor RPC_URL when PROVER_RPC_URL is unset.
+    if rpc_urls.is_empty() {
+        if let Ok(rpc_url_env) = std::env::var("RPC_URL") {
+            let trimmed = rpc_url_env.trim();
+            if !trimmed.is_empty() {
+                let url = Url::parse(trimmed).context("Invalid RPC_URL environment variable")?;
+                rpc_urls.push(url);
+                tracing::info!("Using RPC_URL environment variable (PROVER_RPC_URL not set)");
+            }
+        }
+    }
+
+    if rpc_urls.is_empty() {
+        anyhow::bail!(
+            "No RPC URLs configured. Set one of: \
+             PROVER_RPC_URL / PROVER_RPC_URLS (single-chain), \
+             PROVER_RPC_URL_{{id}} / PROVER_RPC_URLS_{{id}} (per-chain env), \
+             or --rpc-url-{{id}} (per-chain CLI)"
+        );
+    }
+
+    let private_key = args
+        .private_key
+        .clone()
+        .or_else(|| std::env::var("PRIVATE_KEY").ok().and_then(|key| key.parse().ok()))
+        .context(
+            "Private key not provided. Set PROVER_PRIVATE_KEY or PRIVATE_KEY environment variable",
+        )?;
+
+    Ok(ChainArgs {
+        chain_id: None,
+        rpc_urls,
+        private_key,
+        config_override_path: None,
+        deployment: args.deployment.clone(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -637,39 +601,40 @@ mod tests {
         "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
 
     #[test]
-    fn primary_url_is_first() {
-        let result = collect_rpc_urls(
-            Some("http://primary.example.com".to_string()),
-            vec![
-                "http://secondary.example.com".to_string(),
-                "http://tertiary.example.com".to_string(),
-            ],
-        )
-        .unwrap();
+    fn merge_rpc_urls_primary_is_first() {
+        let extras = ["http://secondary.example.com", "http://tertiary.example.com"];
+        let result =
+            merge_rpc_urls(Some("http://primary.example.com"), extras, "test-label").unwrap();
         assert_eq!(result[0].as_str(), "http://primary.example.com/");
+        assert_eq!(result.len(), 3);
     }
 
     #[test]
-    fn deduplicates_urls() {
-        let result = collect_rpc_urls(
-            Some("http://node.example.com".to_string()),
-            vec!["http://node.example.com".to_string()],
-        )
-        .unwrap();
+    fn merge_rpc_urls_deduplicates() {
+        let extras = ["http://node.example.com"];
+        let result = merge_rpc_urls(Some("http://node.example.com"), extras, "test-label").unwrap();
         assert_eq!(result.len(), 1);
     }
 
     #[test]
-    fn falls_back_to_tenderly_when_empty() {
-        // No URLs supplied via args or RPC_URL env: the Tenderly Base fallback is injected.
-        let _lock = ENV_LOCK.lock().unwrap();
-        std::env::remove_var("RPC_URL");
-        let result = collect_rpc_urls(None, vec![]).unwrap();
+    fn merge_rpc_urls_skips_empty_entries() {
+        let extras = ["", "   ", "http://node.example.com"];
+        let result = merge_rpc_urls(Some(""), extras, "test-label").unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].as_str(), "https://base.gateway.tenderly.co/");
+        assert_eq!(result[0].as_str(), "http://node.example.com/");
     }
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Clear every env var that `synthesize_legacy_chain` / `discover_chains` consult,
+    /// so legacy-path tests aren't affected by leakage from the developer's outer env.
+    fn clear_legacy_env_vars() {
+        std::env::remove_var("PROVER_RPC_URL");
+        std::env::remove_var("PROVER_RPC_URLS");
+        std::env::remove_var("PROVER_PRIVATE_KEY");
+        std::env::remove_var("PRIVATE_KEY");
+        std::env::remove_var("RPC_URL");
+    }
 
     fn default_args() -> CoreArgs {
         CoreArgs {
@@ -713,14 +678,60 @@ mod tests {
     }
 
     #[test]
-    fn discover_chains_empty_when_no_per_chain_vars() {
+    fn discover_chains_errors_when_nothing_configured() {
         let _lock = ENV_LOCK.lock().unwrap();
         clear_chain_env_vars();
+        clear_legacy_env_vars();
 
         let args = default_args();
         let mut per_chain = PerChainArgs::default();
+        let err = discover_chains(&args, &mut per_chain).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("No RPC URLs configured"), "expected URL-missing error, got: {msg}");
+    }
+
+    #[test]
+    fn discover_chains_synthesizes_legacy_chain_from_args() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_chain_env_vars();
+        clear_legacy_env_vars();
+
+        let mut args = default_args();
+        args.rpc_url = Some("http://primary.example.com".to_string());
+        args.rpc_urls = vec!["http://backup.example.com".to_string()];
+        args.private_key = Some(TEST_PRIVATE_KEY_0.parse().unwrap());
+
+        let mut per_chain = PerChainArgs::default();
         let chains = discover_chains(&args, &mut per_chain).unwrap();
-        assert!(chains.is_empty());
+        assert_eq!(chains.len(), 1, "legacy synthesis should yield exactly one ChainArgs");
+        assert_eq!(
+            chains[0].chain_id, None,
+            "legacy chain leaves chain_id unset; real ID is resolved at startup"
+        );
+        assert_eq!(chains[0].rpc_urls.len(), 2);
+        assert_eq!(chains[0].rpc_urls[0].as_str(), "http://primary.example.com/");
+        assert_eq!(chains[0].rpc_urls[1].as_str(), "http://backup.example.com/");
+        assert_eq!(chains[0].private_key, TEST_PRIVATE_KEY_0.parse().unwrap());
+    }
+
+    #[test]
+    fn discover_chains_legacy_falls_back_to_rpc_url_env() {
+        // Legacy compat: when PROVER_RPC_URL is unset, RPC_URL is honored.
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_chain_env_vars();
+        clear_legacy_env_vars();
+
+        std::env::set_var("RPC_URL", "http://legacy-rpc.example.com");
+        let mut args = default_args();
+        args.private_key = Some(TEST_PRIVATE_KEY_0.parse().unwrap());
+
+        let mut per_chain = PerChainArgs::default();
+        let chains = discover_chains(&args, &mut per_chain).unwrap();
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].chain_id, None);
+        assert_eq!(chains[0].rpc_urls[0].as_str(), "http://legacy-rpc.example.com/");
+
+        clear_legacy_env_vars();
     }
 
     #[test]
@@ -738,9 +749,9 @@ mod tests {
         let mut per_chain = PerChainArgs::default();
         let chains = discover_chains(&args, &mut per_chain).unwrap();
         assert_eq!(chains.len(), 2);
-        assert_eq!(chains[0].chain_id, 1);
+        assert_eq!(chains[0].chain_id, Some(1));
         assert_eq!(chains[0].rpc_urls[0].as_str(), "http://eth.example.com/");
-        assert_eq!(chains[1].chain_id, 8453);
+        assert_eq!(chains[1].chain_id, Some(8453));
         assert_eq!(chains[1].rpc_urls[0].as_str(), "http://base.example.com/");
 
         clear_chain_env_vars();
@@ -763,9 +774,9 @@ mod tests {
 
         let mut per_chain = PerChainArgs::default();
         let chains = discover_chains(&args, &mut per_chain).unwrap();
-        assert_eq!(chains[0].chain_id, 1);
+        assert_eq!(chains[0].chain_id, Some(1));
         assert_eq!(chains[0].private_key, chain_key.parse().unwrap());
-        assert_eq!(chains[1].chain_id, 8453);
+        assert_eq!(chains[1].chain_id, Some(8453));
         assert_eq!(chains[1].private_key, global_key.parse().unwrap());
 
         clear_chain_env_vars();
@@ -816,7 +827,7 @@ mod tests {
         let mut per_chain = PerChainArgs::default();
         let chains = discover_chains(&args, &mut per_chain).unwrap();
         assert_eq!(chains.len(), 1);
-        assert_eq!(chains[0].chain_id, 8453);
+        assert_eq!(chains[0].chain_id, Some(8453));
         assert_eq!(chains[0].rpc_urls.len(), 2);
         assert_eq!(chains[0].rpc_urls[0].as_str(), "http://backup1.example.com/");
         assert_eq!(chains[0].rpc_urls[1].as_str(), "http://backup2.example.com/");

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -314,34 +314,16 @@ async fn main() -> Result<()> {
     let mut _config_watchers: Vec<ConfigWatcher> = Vec::new();
 
     for chain_args in &discovered_chains {
-        match chain_args.chain_id {
-            None => tracing::info!(
-                rpc_urls = ?chain_args.rpc_urls,
-                provenance = "legacy single-chain",
-                "Starting pipeline (chain ID will be resolved from RPC)"
-            ),
-            Some(id) => tracing::info!(
-                configured_chain_id = id,
-                rpc_urls = ?chain_args.rpc_urls,
-                provenance = "per-chain",
-                "Starting pipeline for chain"
-            ),
-        }
-
-        // Legacy mode (no chain) has no config override (chain_id is unknown until provider is built);
-        // per-chain pipelines may have an explicit override path.
-        let chain_config_watcher = match chain_args.chain_id {
-            None => ConfigWatcher::new(&args.config_file)
-                .await
-                .context("Failed to load broker config")?,
-            Some(id) => ConfigWatcher::new_with_chain_override(
-                &args.config_file,
-                chain_args.config_override_path.as_deref(),
-                Some(id),
-            )
-            .await
-            .with_context(|| format!("Failed to load config for chain {id}"))?,
-        };
+        let chain_config_watcher = ConfigWatcher::new_with_chain_override(
+            &args.config_file,
+            chain_args.config_override_path.as_deref(), // None with legacy single-chain config
+            chain_args.chain_id,
+        )
+        .await
+        .with_context(|| match chain_args.chain_id {
+            Some(id) => format!("Failed to load config for chain {id}"),
+            None => "Failed to load broker config".to_string(),
+        })?;
 
         let config = chain_config_watcher.config.clone();
         let (provider, any_provider, gas_priority_mode) =
@@ -349,6 +331,18 @@ async fn main() -> Result<()> {
         let provider = Arc::new(provider);
 
         let chain_id = provider.get_chain_id().await.context("Failed to get chain ID")?;
+        if let Some(configured) = chain_args.chain_id {
+            anyhow::ensure!(
+                configured == chain_id,
+                "Configured chain ID {configured} does not match RPC-reported chain ID {chain_id}. \
+                 Check that the RPC URL for chain {configured} actually points at chain {configured}."
+            );
+        }
+
+        let rpc_urls: Vec<&str> = chain_args.rpc_urls.iter().map(Url::as_str).collect();
+        let provenance =
+            if chain_args.chain_id.is_some() { "per-chain" } else { "legacy single-chain" };
+        tracing::info!(chain_id, ?rpc_urls, provenance, "Starting pipeline for chain");
         let deployment = chain_args
             .deployment
             .clone()

--- a/crates/broker/src/bin/broker.rs
+++ b/crates/broker/src/bin/broker.rs
@@ -127,27 +127,54 @@ struct PerChainArgs {
 
 /// Scan raw CLI args and env vars to discover which chain IDs are referenced.
 fn discover_chain_ids_from_argv() -> BTreeSet<u64> {
-    let mut chain_ids = BTreeSet::new();
+    let mut chain_ids = scan_chain_ids_from_args(std::env::args());
+    chain_ids.extend(scan_chain_ids_from_env(std::env::vars()));
+    chain_ids
+}
 
-    for arg in std::env::args() {
+/// Extract chain IDs referenced by `--{flag}-{chain_id}` CLI args.
+///
+/// Accepts both two-token (`--rpc-url-8453 URL`) and equals-joined
+/// (`--rpc-url-8453=URL`) invocations; clap accepts either form, so the
+/// discovery pass must too.
+fn scan_chain_ids_from_args<I, S>(args: I) -> BTreeSet<u64>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut chain_ids = BTreeSet::new();
+    for arg in args {
+        let arg = arg.as_ref();
         for def in CHAIN_ARG_DEFS {
             let prefix = format!("--{}-", def.name);
             let Some(rest) = arg.strip_prefix(&prefix) else {
                 continue;
             };
-            if let Ok(chain_id) = rest.parse::<u64>() {
+            let head = rest.split('=').next().unwrap_or(rest);
+            if let Ok(chain_id) = head.parse::<u64>() {
                 chain_ids.insert(chain_id);
             }
         }
     }
+    chain_ids
+}
 
-    for (key, value) in std::env::vars() {
-        if value.trim().is_empty() {
+/// Extract chain IDs referenced by `PROVER_RPC_URL[S]_{chain_id}` env vars.
+fn scan_chain_ids_from_env<I, K, V>(vars: I) -> BTreeSet<u64>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut chain_ids = BTreeSet::new();
+    for (key, value) in vars {
+        if value.as_ref().trim().is_empty() {
             continue;
         }
         // Match either PROVER_RPC_URL_{chain_id} (primary) or
         // PROVER_RPC_URLS_{chain_id} (failover list). Try the longer prefix
         // first so PROVER_RPC_URLS_8453 doesn't get parsed as suffix "S_8453".
+        let key = key.as_ref();
         let Some(suffix) =
             key.strip_prefix("PROVER_RPC_URLS_").or_else(|| key.strip_prefix("PROVER_RPC_URL_"))
         else {
@@ -157,7 +184,6 @@ fn discover_chain_ids_from_argv() -> BTreeSet<u64> {
             chain_ids.insert(chain_id);
         }
     }
-
     chain_ids
 }
 
@@ -846,6 +872,46 @@ mod tests {
         assert!(ids.contains(&167000));
 
         clear_chain_env_vars();
+    }
+
+    #[test]
+    fn scan_chain_ids_from_args_handles_space_form() {
+        let argv = ["broker", "--rpc-url-8453", "https://base.example.com"];
+        let ids = scan_chain_ids_from_args(argv);
+        assert!(ids.contains(&8453), "space-separated --rpc-url-{{id}} form must register chain");
+    }
+
+    #[test]
+    fn scan_chain_ids_from_args_handles_equals_form() {
+        // Regression: previously `--rpc-url-8453=URL` was parsed as suffix "8453=URL"
+        // and failed u64::parse, so the chain was never registered. clap then errored
+        // with "unexpected argument '--rpc-url-8453' found".
+        let argv = ["broker", "--rpc-url-8453=https://base.example.com"];
+        let ids = scan_chain_ids_from_args(argv);
+        assert!(ids.contains(&8453), "--rpc-url-{{id}}=URL form must register chain");
+    }
+
+    #[test]
+    fn scan_chain_ids_from_args_picks_up_multiple_chains_and_flags() {
+        let argv = [
+            "broker",
+            "--rpc-url-1=https://eth.example.com",
+            "--private-key-8453",
+            "0xKEY",
+            "--market-address-167000=0xMARKET",
+        ];
+        let ids = scan_chain_ids_from_args(argv);
+        assert!(ids.contains(&1));
+        assert!(ids.contains(&8453));
+        assert!(ids.contains(&167000));
+        assert_eq!(ids.len(), 3);
+    }
+
+    #[test]
+    fn scan_chain_ids_from_args_ignores_non_numeric_suffix() {
+        let argv = ["broker", "--rpc-url-foo=URL", "--unrelated-8453"];
+        let ids = scan_chain_ids_from_args(argv);
+        assert!(ids.is_empty());
     }
 
     #[test]

--- a/crates/broker/src/test_utils.rs
+++ b/crates/broker/src/test_utils.rs
@@ -43,7 +43,7 @@ pub struct BrokerBuilder {
     args: CoreArgs,
     config_file: NamedTempFile,
     db_dir: tempfile::TempDir,
-    rpc_url: Url,
+    rpc_urls: Vec<Url>,
 }
 
 impl BrokerBuilder {
@@ -82,11 +82,19 @@ impl BrokerBuilder {
             version_registry_address: Some(ctx.version_registry_address),
             force_version_check: false,
         };
-        Self { args, config_file, db_dir, rpc_url }
+        Self { args, config_file, db_dir, rpc_urls: vec![rpc_url] }
     }
 
     pub fn with_db_url(mut self, db_url: String) -> Self {
         self.args.db_url = db_url;
+        self
+    }
+
+    /// Override the RPC URL list used to build the provider stack — useful for
+    /// exercising the [`SequentialFallbackLayer`](crate::sequential_fallback) path
+    /// from integration tests.
+    pub fn with_rpc_urls(mut self, rpc_urls: Vec<Url>) -> Self {
+        self.rpc_urls = rpc_urls;
         self
     }
 
@@ -105,7 +113,7 @@ impl BrokerBuilder {
         let config_watcher = ConfigWatcher::new(self.config_file.path()).await?;
         let config = config_watcher.config.clone();
         let (provider, any_provider, gas_priority_mode) =
-            crate::build_chain_provider(&[self.rpc_url], &ctx.prover_signer, &self.args, &config)?;
+            crate::build_chain_provider(&self.rpc_urls, &ctx.prover_signer, &self.args, &config)?;
         let provider = Arc::new(provider);
         let chain_id = provider.get_chain_id().await?;
         let deployment = resolve_deployment(self.args.deployment.as_ref(), chain_id)?;


### PR DESCRIPTION
## Summary

Multi-chain RPC initialization in the broker had three issues:

1. **Two parallel control-flow paths.** `main()` had a single-chain "fallback" branch (deprecated `args.rpc_url` / `args.rpc_urls`) and a per-chain branch, each with duplicate URL-merging, provider construction, and pipeline wiring.
2. **`--rpc-url-{id}=URL` CLI form silently rejected.** The pre-clap chain-id discovery scanner only handled the space-separated form. The equals form left `"8453=URL"` as the suffix, failed `u64::parse`, and clap then errored with `unexpected argument '--rpc-url-8453' found`.
3. **No chain-ID cross-check.** `provider.get_chain_id()` was treated as authoritative, so a mistyped URL (`--rpc-url-8453=https://taiko.drpc.org`) silently ran on whatever chain the RPC reported, using that chain's deployment, DB shard, and config.

## What changed

### `refactor(broker): unify single-chain and per-chain RPC initialization`

- Collapse the two `main()` branches into one loop over `Vec<ChainArgs>`.
- New `merge_rpc_urls` helper shared by per-chain env merging and legacy synthesis (dedup, skip empty entries).
- `synthesize_legacy_chain` builds one `ChainArgs` from the legacy single-chain CLI/env vars; `chain_id` becomes `Option<u64>` (`None` = legacy, resolved at startup via `provider.get_chain_id()`).
- Drop the hardcoded `https://base.gateway.tenderly.co` fallback. With nothing configured, the broker now errors clearly naming `PROVER_RPC_URL`, `PROVER_RPC_URL_{id}`, and `PROVER_RPC_URLS_{id}` instead of silently defaulting to a public Base endpoint.
- `BrokerBuilder` now holds `Vec<Url>`; `new_test` signature preserved, `with_rpc_urls()` added for fallback-layer test coverage.

### `fix(broker): register chains from --rpc-url-{id}=URL CLI form`

- Split the suffix on `=` before parsing the chain id, so both `--rpc-url-8453 URL` and `--rpc-url-8453=URL` register the chain identically.
- Extract `scan_chain_ids_from_args` / `scan_chain_ids_from_env` so the CLI scan can be unit-tested without mutating the process env.

### `fix(broker): validate chain ID against RPC; collapse setup-loop matches`

- `anyhow::ensure!` that the configured chain id matches `provider.get_chain_id()`; clear error message on mismatch.
- Collapse two `match chain_args.chain_id` arms — `ConfigWatcher::new_with_chain_override` already accepts `Option<u64>`, and the "Starting pipeline" log moves below `get_chain_id()` so a single `tracing::info!` reports the resolved id and provenance.
- Format `rpc_urls` as `Vec<&str>` via `Url::as_str()` so the log prints `["https://foo/"]` instead of dumping the full `Url` debug struct.

## Example output

Successful per-chain startup:

```
INFO broker: Starting pipeline for chain chain_id=167000 rpc_urls=["https://taiko.drpc.org/"] provenance="per-chain"
INFO broker::args: Configuring chain with single RPC URL: https://taiko.drpc.org/
INFO broker: Using deployment configuration chain_id=167000 deployment=market=0xb3f5C7B4379052EADE8C7f3fa6da37Fb871DA28B set_verifier=0x6135DC08D14EF8a44496B009e2181426628B8ebd verifier_router=0x607d196b43abc5d9BE3c7Fb8e336Ca82fec18C45 collateral_token=0xC284A781072442cC1882a8Db4573990B7B49DaC4 chain_id=167000 order_stream=https://taiko-mainnet.boundless.network
```

Mistyped chain id now fails loudly at startup instead of silently running on the wrong chain:

```
$ broker --listen-only '--rpc-url-8453=https://taiko.drpc.org'
Error: Configured chain ID 8453 does not match RPC-reported chain ID 167000. Check that the RPC URL for chain 8453 actually points at chain 8453.
```