### PR TITLE
BM-2980: Add Mango requestor entries for additional chain

### DIFF
--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -249,6 +249,14 @@
       "description": "",
       "tags": [],
       "extensions": {}
+    },
+    {
+      "address": "0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e",
+      "chainId": 167000,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -45,6 +45,20 @@
           "estimatedMaxInputSizeMB": 550
         }
       }
+    },
+    {
+      "address": "0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e",
+      "chainId": 167000,
+      "name": "Mango",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Adds the Mango requestor address to the allowed list and large priority list for an additional chain (id 167000).

Changes
* Adds `0x382bba7d7bc9ae86c5de3e16c4ca96bcc0a3478e` to `boundless-allowed-list.json` for chainId 167000
* Adds the same address as `Mango` to `boundless-priority-list.large.json` for chainId 167000 with the same request estimates as the existing entry