### PR TITLE
BM-2906: restore base-level min_mcycle_price / max_collateral on release prover

### DIFF
--- a/ansible/roles/prover/configs/broker/prod-mainnet-release/broker.toml
+++ b/ansible/roles/prover/configs/broker/prod-mainnet-release/broker.toml
@@ -1,6 +1,9 @@
 # Production base broker config (shared across all chains)
-# Per-chain fields (min_mcycle_price, max_collateral) are in broker.{chain_id}.toml
+# Per-chain fields (min_mcycle_price, max_collateral) are in broker.{chain_id}.toml.
+# Defaults below are required by the broker schema; per-chain overrides take precedence.
 [market]
+min_mcycle_price = "0.000000025"
+max_collateral = "200"
 lookback_blocks = 300
 peak_prove_khz = 11000
 priority_requestor_lists = [


### PR DESCRIPTION
 `prod-mainnet-release/broker.toml` was missing `min_mcycle_price` and `max_collateral` at the `[market]` base level. v2.0.0's `MarketConfig` schema requires both (no serde defaults), so the broker crash-looped on startup with:

      Error: Failed to load broker config
      1: TOML parse error at line 3, column 1

  The "TOML parse error" message is misleading — it's a serde missing-field error reported at the position of the `[market]` table.

  ## Root cause

  When the multichain refactor ([#BM-2906](https://github.com/boundless-xyz/boundless/pull/1939)) introduced the `prod-mainnet-release/` config dir, it moved `min_mcycle_price` and `max_collateral` to per-chain `broker.{chain_id}.toml` overrides and dropped them from the base file. The release prover stayed on v1.4.0 with the old single-chain layout (which had them in base), so the mismatch shipped silently until the v2.0.0 deploy actually invoked the new layout for the first time.

  The nightly broker.toml in `prod-mainnet-nightly/` keeps these fields in the base, which is why the nightly prover (running 2.1.0-alpha.0) was unaffected.