### PR TITLE
BM-2981: boundless-market: encode GuestEnv::stdin as MessagePack bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2 0.10.9",
  "siwe",
@@ -9834,6 +9835,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ risc0-zkp = { version = "3.0.3" }
 risc0-zkvm = { version = "3.0.4", default-features = false }
 rmp-serde = { version = "1.3" }
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 serde_yaml = "0.9"
 sha2 = { version = "0.10" }

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -2071,6 +2071,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6694,7 +6695,7 @@ dependencies = [
  "security-framework 3.3.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6991,6 +6992,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true, optional = true }
 risc0-zkvm = { workspace = true, features = ["std"] }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/boundless-market/src/input.rs
+++ b/crates/boundless-market/src/input.rs
@@ -87,6 +87,7 @@ pub struct GuestEnv {
     /// be provided directly). When the guest calls `env::read_slice` these are the bytes that will
     /// be read. If the guest uses `env::read`, this should be encoded using the default RISC Zero
     /// codec. [GuestEnvBuilder::write] will encode the data given using the default codec.
+    #[serde(with = "serde_bytes")]
     pub stdin: Vec<u8>,
 }
 
@@ -270,6 +271,42 @@ mod tests {
 
         let decoded_env = GuestEnv::decode(&env.encode()?)?;
         assert_eq!(env, decoded_env);
+        Ok(())
+    }
+
+    #[test]
+    fn test_stdin_wire_compat() -> Result<(), Error> {
+        // Pre-patch shape of GuestEnv (no #[serde(with = "serde_bytes")]) with
+        // its own encode/decode mirroring GuestEnv's, so the test reads as a
+        // symmetric cross-decode.
+        #[derive(Serialize, Deserialize)]
+        struct LegacyGuestEnv {
+            stdin: Vec<u8>,
+        }
+        impl LegacyGuestEnv {
+            fn encode(&self) -> Result<Vec<u8>, Error> {
+                let mut encoded = Vec::<u8>::new();
+                encoded.push(Version::V1.into());
+                encoded.extend_from_slice(&rmp_serde::to_vec_named(&self)?);
+                Ok(encoded)
+            }
+            fn decode(bytes: &[u8]) -> Result<Self, Error> {
+                Ok(rmp_serde::from_read(&bytes[1..])?)
+            }
+        }
+
+        let payload: Vec<u8> = (0..=255u8).collect();
+
+        // Legacy wire -> current decoder.
+        let legacy_wire = LegacyGuestEnv { stdin: payload.clone() }.encode()?;
+        assert_eq!(legacy_wire[8], 0xdc, "legacy form: MessagePack array16 marker");
+        assert_eq!(GuestEnv::decode(&legacy_wire)?.stdin, payload);
+
+        // Current wire -> legacy decoder.
+        let current_wire = GuestEnv::builder().write_slice(&payload).build_vec()?;
+        assert_eq!(current_wire[8], 0xc5, "current form: MessagePack bin16 marker");
+        assert_eq!(LegacyGuestEnv::decode(&current_wire)?.stdin, payload);
+
         Ok(())
     }
 }

--- a/examples/blake3-groth16/Cargo.lock
+++ b/examples/blake3-groth16/Cargo.lock
@@ -2156,6 +2156,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6867,7 +6868,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7183,6 +7184,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/composition/Cargo.lock
+++ b/examples/composition/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6879,7 +6880,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7195,6 +7196,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/counter-with-callback/Cargo.lock
+++ b/examples/counter-with-callback/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6877,7 +6878,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7193,6 +7194,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6877,7 +6878,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7193,6 +7194,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/request-stream/Cargo.lock
+++ b/examples/request-stream/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6229,7 +6230,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6527,6 +6528,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/smart-contract-requestor/Cargo.lock
+++ b/examples/smart-contract-requestor/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6876,7 +6877,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7192,6 +7193,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Annotate `GuestEnv::stdin` with `#[serde(with = "serde_bytes")]` so it encodes as a MessagePack `bin` blob instead of an array of tagged integers.
- Up to 2x reduction in `GuestEnv` payload size, with no `GuestEnv` version bump and no wire-format break.
- Adds a `test_stdin_wire_compat` unit test covering both cross-decode directions.

## Why the size drops

`Vec<u8>` does not serialize as a byte blob by default. Serde calls `serialize_seq`, so `rmp_serde::to_vec_named` writes a MessagePack array of integers. Each byte gets a type tag: 1 byte on the wire for values < `0x80`, 2 bytes (`0xcc` marker + value) for the rest.

`serde_bytes` calls `serialize_bytes` instead. The MessagePack `bin` family is a length prefix plus the raw bytes, 1:1 with the input.

1 KiB pseudo-random payload (SHA-256 hash chain, 47% bytes with high bit set):

| encoding | size |
|---|---|
| array of u8 (current) | 1518 B (1.48x) |
| bin (this PR)         | 1035 B (1.01x) |

## Why this is wire-compatible

No `GuestEnv` version bump. Existing encoded payloads keep parsing through the new code, and unupgraded provers keep parsing payloads from new clients. Both decoder shapes accept both wire shapes:

- rmp-serde's default `Vec<u8>` deserializer implements visitors for both `seq` (array form) and `bytes` (bin form). A struct without the annotation parses either.
- `serde_bytes`'s deserializer implements both visitors too. A struct with the annotation parses either.

The new `test_stdin_wire_compat` exercises both cross-decode directions and asserts the MessagePack type marker on each side so the property cannot silently regress.

## Verified on Base mainnet

A client built against this PR branch submitted an order, a production prover (unmodified `boundless-market`) locked, executed, and fulfilled it on-chain:

- request_id: `0x466acfc0f27bba9fbb7a8508f576527e81e83bd1f6ec666`
- prover: `0x51f85e9263ab7f69ed2476c6ba51f90091f94c0f`
- created to locked: 1 min 33 s
- created to fulfilled: 2 min 31 s