### PR TITLE
BM-2983: Add Taiko (Papaya) requestor to standard priority and allowed lists

### DIFF
--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -257,6 +257,14 @@
       "description": "",
       "tags": [],
       "extensions": {}
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -191,6 +191,20 @@
           "estimatedMaxInputSizeMB": 550
         }
       }
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 100,
+          "estimatedMcycleCountMax": 3500,
+          "estimatedMaxInputSizeMB": 10
+        }
+      }
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -200,9 +200,9 @@
       "tags": [],
       "extensions": {
         "requestEstimates": {
-          "estimatedMcycleCountMin": 100,
-          "estimatedMcycleCountMax": 3500,
-          "estimatedMaxInputSizeMB": 10
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
         }
       }
     }


### PR DESCRIPTION
## Summary
- Adds a new Taiko Mainnet (chainId 167000) requestor `0x64e356256d87e5f7b36eb35eb62442386591c294` to the internal allowed list
- Adds the same address as `Anonymous Customer (Papaya)` to the standard priority list (expected proving work is <4 MHz, so it belongs on the standard list rather than the large/XL lists)
- Uses request estimates `mcycleMin=100`, `mcycleMax=3500`, `maxInputSizeMB=10`

## Test plan
- [ ] JSON validates (`jq empty` on both files)
- [ ] Allowed list still parses in broker startup
- [ ] Standard priority list still parses in broker startup
- [ ] Address is observed in priority queue once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)