### PR TITLE
BM-2984: Add Papaya requestor to standard priority and allowed lists

### DIFF
--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -260,6 +260,14 @@
     },
     {
       "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
       "chainId": 167000,
       "name": "Allowed Requestor",
       "description": "",

--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -257,6 +257,14 @@
       "description": "",
       "tags": [],
       "extensions": {}
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -59,6 +59,34 @@
           "estimatedMaxInputSizeMB": 550
         }
       }
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -191,20 +191,6 @@
           "estimatedMaxInputSizeMB": 550
         }
       }
-    },
-    {
-      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
-      "chainId": 167000,
-      "name": "Anonymous Customer (Papaya)",
-      "description": "",
-      "tags": [],
-      "extensions": {
-        "requestEstimates": {
-          "estimatedMcycleCountMin": 170,
-          "estimatedMcycleCountMax": 10000,
-          "estimatedMaxInputSizeMB": 550
-        }
-      }
     }
   ]
 }

--- a/requestor-lists/boundless-priority-list.standard.json
+++ b/requestor-lists/boundless-priority-list.standard.json
@@ -191,6 +191,20 @@
           "estimatedMaxInputSizeMB": 550
         }
       }
+    },
+    {
+      "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a new chainId 167000 requestor `0x64e356256d87e5f7b36eb35eb62442386591c294` to the internal allowed list
- Adds the same address as `Anonymous Customer (Papaya)` to the standard priority list
- Request estimates copied from the existing Mango entry: `mcycleMin=170`, `mcycleMax=10000`, `maxInputSizeMB=550`

## Test plan
- [ ] JSON validates (`jq empty` on both files)
- [ ] Allowed list still parses in broker startup
- [ ] Standard priority list still parses in broker startup
- [ ] Address is observed in priority queue once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)