### PR TITLE
BM-2989: Raise bento-down alarm to 2h to match broker graceful shutdown

### DIFF
--- a/.claude/skills/ops-logs-query/SKILL.md
+++ b/.claude/skills/ops-logs-query/SKILL.md
@@ -257,6 +257,7 @@ A deployment cycle looks like:
 2. `"Image ghcr.io/boundless-xyz/boundless/broker:<tag> Pulling"` — new image pulled (the tag contains the git commit, e.g. `nightly-3b8a71f`)
 3. `"Container bento-broker-1 Created"` / `"Starting"` — new containers come up
 4. Optionally: `"dependency failed to start: container ... is unhealthy"` — a container failed its healthcheck, cascading to broker failure
+5. If `"Starting Docker Compose"` is missing or far behind `"Stopping Docker Compose"`, the broker **may be in graceful shutdown drain** — search `?"starting graceful shutdown" ?"in-progress orders to complete" ?"Cancelling critical tasks"`. The broker waits up to 2h (`SHUTDOWN_GRACE_PERIOD_SECS`) for committed orders before exiting; during this window `bento_active=0` and `channel closed` errors from the chain monitor are **expected**, not an outage.
 
 Deployments are significant events -- they restart the broker (causing a brief gap in telemetry and fulfillments even when healthy) and deploy new code that could introduce bugs or behavior changes. Always note when a deployment occurred relative to the issue being investigated.
 

--- a/crates/broker/src/broker.rs
+++ b/crates/broker/src/broker.rs
@@ -928,6 +928,7 @@ impl Broker {
         critical_cancel_token: CancellationToken,
     ) -> Result<(), anyhow::Error> {
         // 2 hour max to shutdown time, to avoid indefinite shutdown time.
+        // If you change this, ensure you update any alarms/metrics that depend on it.
         const SHUTDOWN_GRACE_PERIOD_SECS: u32 = 2 * 60 * 60;
         const SLEEP_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 

--- a/infra/cw-monitoring/nodeConfig.ts
+++ b/infra/cw-monitoring/nodeConfig.ts
@@ -106,15 +106,21 @@ export interface MonitoredNode {
 // ── Bento service down ──────────────────────────────────────────────────────
 // Vector publishes bento_active gauge (0 or 1). Missing data = breaching
 // because the node may have lost connectivity or Vector stopped.
+//
+// Threshold matches the broker's SHUTDOWN_GRACE_PERIOD_SECS (2 hours, see
+// `broker.rs`): during a deploy that coincides with long in-flight proofs,
+// the systemd unit can stay in `deactivating` for the full grace period
+// while the broker waits for committed orders to drain. Alarming below 2h
+// would page on a healthy graceful shutdown.
 
 const PROD_BENTO_DOWN: AlarmConfig[] = [
     {
         severity: Severity.SEV2,
-        description: "bento service down for 4 consecutive 15-min periods (1 hour)",
+        description: "bento service down for 8 consecutive 15-min periods (2 hours)",
         metricConfig: { period: 900 },
         alarmConfig: {
-            evaluationPeriods: 4,
-            datapointsToAlarm: 4,
+            evaluationPeriods: 8,
+            datapointsToAlarm: 8,
             threshold: 1,
             comparisonOperator: "LessThanThreshold",
             treatMissingData: "breaching",
@@ -134,15 +140,16 @@ const PROD_BENTO_DOWN: AlarmConfig[] = [
     },
 ];
 
-// Staging deploys frequently and nodes restart — longer window, lower severity.
+// Staging deploys frequently and nodes restart — same 2-hour threshold as prod
+// so a graceful shutdown waiting on in-flight orders doesn't page.
 const STAGING_BENTO_DOWN: AlarmConfig[] = [
     {
         severity: Severity.SEV2,
-        description: "bento service down for 4 consecutive 15-min periods (1 hour)",
+        description: "bento service down for 8 consecutive 15-min periods (2 hours)",
         metricConfig: { period: 900 },
         alarmConfig: {
-            evaluationPeriods: 4,
-            datapointsToAlarm: 4,
+            evaluationPeriods: 8,
+            datapointsToAlarm: 8,
             threshold: 1,
             comparisonOperator: "LessThanThreshold",
             treatMissingData: "breaching",


### PR DESCRIPTION
Bumps the SEV2 `bento-down` alarm from 1h to 2h (8 × 15-min datapoints) so a healthy graceful shutdown — where the broker waits up to `SHUTDOWN_GRACE_PERIOD_SECS` (2h) for in-flight committed orders to drain — does not page. 

Changes
* Bento-down alarm threshold raised from 4×15min (1h) to 8×15min (2h) for prod and staging; 3h escalation alarm kept as is.
* Adds a note to the ops-logs-query skill so future on-call diagnoses look for the `"in-progress orders to complete"` log before treating `bento_active=0` + `channel closed` errors as an outage