### PR TITLE
BM-2990: Retry eth_getTransactionByHash and expose underlying error detail

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -9,15 +9,16 @@ disable-model-invocation: true
 ## Instructions
 
 1. Look at the staged, unstaged, and untracked changes with `git diff`
-2. If no changes to examples/ directory, run `just check-main`. Else run `just check`.
+2. Run `forge build` before the cargo check step. Rust crates that bind to Solidity contracts (e.g. `boundless-test-utils` referencing `VeZKC`) fail to compile until the contract artifacts exist. Skipping this produces misleading "undeclared type" errors that look like real bugs.
+3. If no changes to examples/ directory, run `just check-main`. Else run `just check`.
    1. If fails, propose fixes and wait for approval
-3. If there are untracked files, do not add them to the commit, but warn the user
-4. Write a clear commit message based on what changed (use commit message style below)
-5. Commit and push to the current branch
-6. Check if an existing PR exists. Ignore warnings about GraphQL: Projects (classic) being deprecated.
+4. If there are untracked files, do not add them to the commit, but warn the user
+5. Write a clear commit message based on what changed (use commit message style below)
+6. Commit and push to the current branch
+7. Check if an existing PR exists. Ignore warnings about GraphQL: Projects (classic) being deprecated.
    1. If not, do not submit the PR, but use `gh pr create --web --title <title> --body <body>` to open the create PR page with title/description (use PR Title/Description Guidelines below)
    2. Else update the description with the new changes.
-7. Do not submit the PR. Just return the PR creation page URL when done
+8. Do not submit the PR. Just return the PR creation page URL when done
 
 ## Commit message style
 

--- a/crates/indexer/src/bin/market-indexer-backfill.rs
+++ b/crates/indexer/src/bin/market-indexer-backfill.rs
@@ -216,7 +216,7 @@ async fn main() -> Result<()> {
     );
 
     if let Err(err) = backfill_service.run().await {
-        bail!("FATAL: Error running backfill: {err}");
+        bail!("FATAL: Error running backfill: {err:#}");
     }
 
     tracing::info!("Backfill completed successfully");

--- a/crates/indexer/src/bin/market-indexer.rs
+++ b/crates/indexer/src/bin/market-indexer.rs
@@ -223,7 +223,7 @@ async fn main() -> Result<()> {
     if args.end_block.is_some() {
         tracing::info!("Running indexer once (end-block specified)");
         if let Err(err) = indexer_service.run(args.start_block, args.end_block).await {
-            bail!("FATAL: Error running the indexer: {err}");
+            bail!("FATAL: Error running the indexer: {err:#}");
         }
         tracing::info!("Indexer completed successfully");
         return Ok(());
@@ -231,7 +231,7 @@ async fn main() -> Result<()> {
 
     // Otherwise, run in the normal loop (existing behavior)
     if let Err(err) = indexer_service.run(args.start_block, None).await {
-        bail!("FATAL: Error running the indexer: {err}");
+        bail!("FATAL: Error running the indexer: {err:#}");
     }
 
     Ok(())

--- a/crates/indexer/src/market/service/chain_data.rs
+++ b/crates/indexer/src/market/service/chain_data.rs
@@ -20,7 +20,7 @@ use super::{
 use crate::db::market::{IndexerDb, TxMetadata};
 use crate::market::ServiceError;
 use alloy::eips::{BlockId, BlockNumberOrTag};
-use alloy::network::{AnyNetwork, Ethereum};
+use alloy::network::{AnyNetwork, Ethereum, Network};
 use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, Log};
@@ -29,6 +29,36 @@ use broker::futures_retry::retry;
 use futures_util::future::try_join_all;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
+
+/// Fetch a single transaction by hash, retrying when the RPC returns either no
+/// transaction or a transaction with `block_number = null`.
+async fn get_transaction_with_retry<P>(
+    provider: P,
+    tx_hash: B256,
+) -> Result<<Ethereum as Network>::TransactionResponse, anyhow::Error>
+where
+    P: Provider<Ethereum>,
+{
+    retry(
+        TX_FETCH_RETRY_COUNT,
+        TX_FETCH_RETRY_SLEEP_MS,
+        || async {
+            let tx = provider
+                .get_transaction_by_hash(tx_hash)
+                .await?
+                .ok_or_else(|| anyhow!("transaction {} not found by RPC", hex::encode(tx_hash)))?;
+            if tx.block_number.is_none() {
+                return Err(anyhow!(
+                    "transaction {} returned without block_number",
+                    hex::encode(tx_hash)
+                ));
+            }
+            Ok(tx)
+        },
+        "get_transaction_by_hash",
+    )
+    .await
+}
 
 impl<P, ANP> IndexerService<P, ANP>
 where
@@ -416,26 +446,9 @@ where
                 .map(|&tx_hash| {
                     let provider = self.boundless_market.instance().provider();
                     async move {
-                        let tx = retry(
-                            TX_FETCH_RETRY_COUNT,
-                            TX_FETCH_RETRY_SLEEP_MS,
-                            || async {
-                                let tx = provider.get_transaction_by_hash(tx_hash).await?;
-                                let tx = tx.ok_or_else(|| {
-                                    anyhow!("transaction {} not found by RPC", hex::encode(tx_hash))
-                                })?;
-                                if tx.block_number.is_none() {
-                                    return Err(anyhow!(
-                                        "transaction {} returned without block_number",
-                                        hex::encode(tx_hash)
-                                    ));
-                                }
-                                Ok(tx)
-                            },
-                            "get_transaction_by_hash",
-                        )
-                        .await
-                        .map_err(ServiceError::Error)?;
+                        let tx = get_transaction_with_retry(provider, tx_hash)
+                            .await
+                            .map_err(ServiceError::Error)?;
                         Ok::<_, ServiceError>((tx_hash, tx))
                     }
                 })
@@ -515,21 +528,22 @@ where
 
         // Step 4: Build final map from tx_hash to TxMetadata and update service map
         for (tx_hash, tx) in tx_map {
-            let bn = tx.block_number.context(anyhow!(
-                "block_number missing on transaction {} after eth_getTransactionByHash",
-                hex::encode(tx_hash)
-            ))?;
-            let tx_index = tx.transaction_index.context(anyhow!(
-                "Transaction index not found for transaction {}",
-                hex::encode(tx_hash)
-            ))?;
+            let bn = tx.block_number.with_context(|| {
+                format!(
+                    "block_number missing on transaction {} after eth_getTransactionByHash",
+                    hex::encode(tx_hash)
+                )
+            })?;
+            let tx_index = tx.transaction_index.with_context(|| {
+                format!("Transaction index not found for transaction {}", hex::encode(tx_hash))
+            })?;
 
             // Get timestamp from service block_timestamps map
             let ts = self
                 .block_num_to_timestamp
                 .get(&bn)
                 .copied()
-                .context(anyhow!("Block {} timestamp not found in map", bn))?;
+                .with_context(|| format!("Block {} timestamp not found in map", bn))?;
 
             let from = tx.inner.signer();
             let meta = TxMetadata::new(tx_hash, from, bn, ts, tx_index);

--- a/crates/indexer/src/market/service/chain_data.rs
+++ b/crates/indexer/src/market/service/chain_data.rs
@@ -42,24 +42,46 @@ where
 {
     for attempt in 0..=TX_FETCH_RETRY_COUNT {
         let tx_opt = provider.get_transaction_by_hash(tx_hash).await?;
-        if let Some(tx) = tx_opt {
+        if let Some(tx) = &tx_opt {
             if tx.block_number.is_some() {
-                return Ok(tx);
+                return Ok(tx_opt.unwrap());
             }
         }
-        if attempt == TX_FETCH_RETRY_COUNT {
-            return Err(ServiceError::Error(anyhow!(
-                "transaction {} not found or without block_number after {} retries",
-                hex::encode(tx_hash),
-                TX_FETCH_RETRY_COUNT
-            )));
+        let is_last_attempt = attempt == TX_FETCH_RETRY_COUNT;
+        match &tx_opt {
+            Some(tx) if is_last_attempt => {
+                return Err(ServiceError::Error(anyhow!(
+                    "transaction {} returned without block_number after {} retries; response: {:?}",
+                    hex::encode(tx_hash),
+                    TX_FETCH_RETRY_COUNT,
+                    tx
+                )));
+            }
+            Some(tx) => {
+                tracing::warn!(
+                    "get_transaction_by_hash for {} returned tx with null block_number, retry {}/{}; response: {:?}",
+                    hex::encode(tx_hash),
+                    attempt + 1,
+                    TX_FETCH_RETRY_COUNT,
+                    tx
+                );
+            }
+            None if is_last_attempt => {
+                return Err(ServiceError::Error(anyhow!(
+                    "transaction {} not found by RPC after {} retries",
+                    hex::encode(tx_hash),
+                    TX_FETCH_RETRY_COUNT
+                )));
+            }
+            None => {
+                tracing::warn!(
+                    "get_transaction_by_hash for {} returned no tx, retry {}/{}",
+                    hex::encode(tx_hash),
+                    attempt + 1,
+                    TX_FETCH_RETRY_COUNT
+                );
+            }
         }
-        tracing::warn!(
-            "get_transaction_by_hash for {} returned no tx or no block_number, retry {}/{}",
-            hex::encode(tx_hash),
-            attempt + 1,
-            TX_FETCH_RETRY_COUNT
-        );
         tokio::time::sleep(Duration::from_millis(TX_FETCH_RETRY_SLEEP_MS)).await;
     }
     unreachable!()

--- a/crates/indexer/src/market/service/chain_data.rs
+++ b/crates/indexer/src/market/service/chain_data.rs
@@ -25,39 +25,44 @@ use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, Log};
 use anyhow::{anyhow, Context};
-use broker::futures_retry::retry;
 use futures_util::future::try_join_all;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-/// Fetch a single transaction by hash, retrying when the RPC returns either no
-/// transaction or a transaction with `block_number = null`.
+/// Fetch a single transaction by hash, retrying only when the RPC call
+/// succeeded but returned either no transaction or a transaction with
+/// `block_number = null`. Real transport errors propagate immediately so the
+/// outer loop's exponential backoff can handle them.
 async fn get_transaction_with_retry<P>(
     provider: P,
     tx_hash: B256,
-) -> Result<<Ethereum as Network>::TransactionResponse, anyhow::Error>
+) -> Result<<Ethereum as Network>::TransactionResponse, ServiceError>
 where
     P: Provider<Ethereum>,
 {
-    retry(
-        TX_FETCH_RETRY_COUNT,
-        TX_FETCH_RETRY_SLEEP_MS,
-        || async {
-            let tx = provider
-                .get_transaction_by_hash(tx_hash)
-                .await?
-                .ok_or_else(|| anyhow!("transaction {} not found by RPC", hex::encode(tx_hash)))?;
-            if tx.block_number.is_none() {
-                return Err(anyhow!(
-                    "transaction {} returned without block_number",
-                    hex::encode(tx_hash)
-                ));
+    for attempt in 0..=TX_FETCH_RETRY_COUNT {
+        let tx_opt = provider.get_transaction_by_hash(tx_hash).await?;
+        if let Some(tx) = tx_opt {
+            if tx.block_number.is_some() {
+                return Ok(tx);
             }
-            Ok(tx)
-        },
-        "get_transaction_by_hash",
-    )
-    .await
+        }
+        if attempt == TX_FETCH_RETRY_COUNT {
+            return Err(ServiceError::Error(anyhow!(
+                "transaction {} not found or without block_number after {} retries",
+                hex::encode(tx_hash),
+                TX_FETCH_RETRY_COUNT
+            )));
+        }
+        tracing::warn!(
+            "get_transaction_by_hash for {} returned no tx or no block_number, retry {}/{}",
+            hex::encode(tx_hash),
+            attempt + 1,
+            TX_FETCH_RETRY_COUNT
+        );
+        tokio::time::sleep(Duration::from_millis(TX_FETCH_RETRY_SLEEP_MS)).await;
+    }
+    unreachable!()
 }
 
 impl<P, ANP> IndexerService<P, ANP>
@@ -446,9 +451,7 @@ where
                 .map(|&tx_hash| {
                     let provider = self.boundless_market.instance().provider();
                     async move {
-                        let tx = get_transaction_with_retry(provider, tx_hash)
-                            .await
-                            .map_err(ServiceError::Error)?;
+                        let tx = get_transaction_with_retry(provider, tx_hash).await?;
                         Ok::<_, ServiceError>((tx_hash, tx))
                     }
                 })

--- a/crates/indexer/src/market/service/chain_data.rs
+++ b/crates/indexer/src/market/service/chain_data.rs
@@ -14,7 +14,8 @@
 
 use super::{
     IndexerService, TransactionFetchStrategy, BLOCK_QUERY_SLEEP, GET_BLOCK_BY_NUMBER_CHUNK_SIZE,
-    GET_BLOCK_RECEIPTS_CHUNK_SIZE, MARKET_EVENT_SIGNATURES,
+    GET_BLOCK_RECEIPTS_CHUNK_SIZE, MARKET_EVENT_SIGNATURES, TX_FETCH_RETRY_COUNT,
+    TX_FETCH_RETRY_SLEEP_MS,
 };
 use crate::db::market::{IndexerDb, TxMetadata};
 use crate::market::ServiceError;
@@ -24,6 +25,7 @@ use alloy::primitives::{Address, B256};
 use alloy::providers::Provider;
 use alloy::rpc::types::{Filter, Log};
 use anyhow::{anyhow, Context};
+use broker::futures_retry::retry;
 use futures_util::future::try_join_all;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
@@ -414,7 +416,26 @@ where
                 .map(|&tx_hash| {
                     let provider = self.boundless_market.instance().provider();
                     async move {
-                        let tx = provider.get_transaction_by_hash(tx_hash).await?;
+                        let tx = retry(
+                            TX_FETCH_RETRY_COUNT,
+                            TX_FETCH_RETRY_SLEEP_MS,
+                            || async {
+                                let tx = provider.get_transaction_by_hash(tx_hash).await?;
+                                let tx = tx.ok_or_else(|| {
+                                    anyhow!("transaction {} not found by RPC", hex::encode(tx_hash))
+                                })?;
+                                if tx.block_number.is_none() {
+                                    return Err(anyhow!(
+                                        "transaction {} returned without block_number",
+                                        hex::encode(tx_hash)
+                                    ));
+                                }
+                                Ok(tx)
+                            },
+                            "get_transaction_by_hash",
+                        )
+                        .await
+                        .map_err(ServiceError::Error)?;
                         Ok::<_, ServiceError>((tx_hash, tx))
                     }
                 })
@@ -423,18 +444,8 @@ where
             let start = std::time::Instant::now();
             let results = try_join_all(futures).await?;
             tracing::debug!("Got {} transactions in {:?}", results.len(), start.elapsed());
-            for (tx_hash, tx_result) in results {
-                match tx_result {
-                    Some(tx) => {
-                        tx_map.insert(tx_hash, tx);
-                    }
-                    None => {
-                        return Err(ServiceError::Error(anyhow!(
-                            "Transaction {} not found",
-                            hex::encode(tx_hash)
-                        )));
-                    }
-                }
+            for (tx_hash, tx) in results {
+                tx_map.insert(tx_hash, tx);
             }
         }
 
@@ -504,7 +515,10 @@ where
 
         // Step 4: Build final map from tx_hash to TxMetadata and update service map
         for (tx_hash, tx) in tx_map {
-            let bn = tx.block_number.context("block number not found")?;
+            let bn = tx.block_number.context(anyhow!(
+                "block_number missing on transaction {} after eth_getTransactionByHash",
+                hex::encode(tx_hash)
+            ))?;
             let tx_index = tx.transaction_index.context(anyhow!(
                 "Transaction index not found for transaction {}",
                 hex::encode(tx_hash)

--- a/crates/indexer/src/market/service/mod.rs
+++ b/crates/indexer/src/market/service/mod.rs
@@ -64,6 +64,10 @@ const MONTHLY_AGGREGATION_RECOMPUTE_MONTHS: u64 = 2;
 const GET_BLOCK_RECEIPTS_CHUNK_SIZE: usize = 250;
 const GET_BLOCK_BY_NUMBER_CHUNK_SIZE: usize = 250;
 const BLOCK_QUERY_SLEEP: u64 = 1;
+/// Retry count for per-tx `eth_getTransactionByHash` when the RPC returns
+/// either no transaction or a transaction with `block_number = null`.
+pub(super) const TX_FETCH_RETRY_COUNT: u64 = 2;
+pub(super) const TX_FETCH_RETRY_SLEEP_MS: u64 = 1000;
 
 /// Event signatures for market events that are indexed.
 const MARKET_EVENT_SIGNATURES: &[B256] = &[
@@ -100,22 +104,22 @@ type AnyNetworkProvider = FillProvider<
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
-    #[error("Database error: {0}")]
+    #[error("Database error: {0:?}")]
     DatabaseError(#[from] DbError),
 
-    #[error("Database query error in {1}: {0}")]
+    #[error("Database query error in {1}: {0:?}")]
     DatabaseQueryError(DbError, String),
 
-    #[error("Boundless market error: {0}")]
+    #[error("Boundless market error: {0:?}")]
     BoundlessMarketError(#[from] MarketError),
 
-    #[error("RPC error: {0}")]
+    #[error("RPC error: {0:?}")]
     RpcError(#[from] RpcError<TransportErrorKind>),
 
-    #[error("Event query error: {0}")]
+    #[error("Event query error: {0:?}")]
     EventQueryError(#[from] alloy::contract::Error),
 
-    #[error("Error: {0}")]
+    #[error("Error: {0:#}")]
     Error(#[from] anyhow::Error),
 
     #[error("Maximum retries reached")]


### PR DESCRIPTION
Add a retry to getTransactionByHash to help with transient issues we are seeing.
Also changing the errors so it logs the actual underlying error we are getting from the RPC provider. Then we can send that to Taiko.

Changes
* Wrap each `get_transaction_by_hash` call in a retry (2 retries, 1s apart) that treats a missing tx or `block_number = null` as retryable
* Add the tx hash to the defensive `block_number` context message so the error identifies the offending transaction
* Switch `ServiceError` Display to use `{0:#}` for the anyhow variant (walks the source chain) and `{0:?}` for non-anyhow variants (`RpcError`, `MarketError`, `EventQueryError`, `DbError`) so their inner detail surfaces
* Change the top-level `bail!` in market-indexer / backfill to `{err:#}` so the chain reaches the FATAL line
* Note `forge build` as a prerequisite in the pr skill, so the cargo check step doesn't spurious-fail on Solidity-bound crates