### PR TITLE
BM-3003: refactor(ops-skills): migrate credentials to Bitwarden CLI

### DIFF
--- a/.claude/skills/ops-indexer-query/SKILL.md
+++ b/.claude/skills/ops-indexer-query/SKILL.md
@@ -60,19 +60,19 @@ export ZKC_INDEXER_URL="https://d3ig5wxf8178te.cloudfront.net"
 
 ## Credentials
 
-First, try to read `network_secrets.toml` from the repo root. If it exists, extract the indexer API key for the selected environment from `[environments.<env>.indexer] api_key`. Also read `network_address_labels.json` (same directory) for translating addresses to human-readable labels in output.
-
-If `network_secrets.toml` is not present, recommend the user create it -- instructions and credentials are in the **Boundless runbook**. The API still works without a key, but they'll have lower rate limits.
-
-If `network_address_labels.json` is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**. The file is plain JSON (`{"0xaddr": "label", ...}`).
-
-When an API key is available:
+Load the indexer API key from Bitwarden via the shared helpers (full setup in [`../ops-query/references/bw-credentials.md`](../ops-query/references/bw-credentials.md)):
 
 ```bash
-export INDEXER_API_KEY="the-key"
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+bw_load_indexer "$ENV"      # e.g. prod_base, staging_taiko — matches the env keys in bw-credentials.md
 ```
 
-Include it in requests via the `x-api-key` header. Without an API key, omit the header.
+`bw_load_indexer` exports `INDEXER_API_KEY` if the corresponding Bitwarden item exists. If no item is found, the call is a no-op and the API still works -- just with lower rate limits.
+
+Also read `network_address_labels.json` from the repo root for translating addresses to human-readable labels in output. If it is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**. The file is plain JSON (`{"0xaddr": "label", ...}`).
+
+Include the API key in requests via the `x-api-key` header. Without an API key, omit the header.
 
 ## Known Addresses
 

--- a/.claude/skills/ops-logs-query/SKILL.md
+++ b/.claude/skills/ops-logs-query/SKILL.md
@@ -9,15 +9,15 @@ Query AWS CloudWatch Logs for Boundless services on prod/staging.
 
 ## Prerequisites
 
-1. **Read `network_secrets.toml`** from the repo root. Extract the AWS credentials for the target environment from `[aws.prod]` or `[aws.staging]` (`access_key_id`, `secret_access_key`). If the file is not present, recommend the user create it -- instructions and credentials are in the **Boundless runbook**.
-
-2. Export credentials before running any queries:
+Load AWS credentials from Bitwarden via the shared helpers (full setup in [`../ops-query/references/bw-credentials.md`](../ops-query/references/bw-credentials.md)):
 
 ```bash
-export AWS_ACCESS_KEY_ID="..."
-export AWS_SECRET_ACCESS_KEY="..."
-export AWS_DEFAULT_REGION="us-west-2"
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+bw_load_aws "$TIER"     # prod | staging
 ```
+
+`bw_load_aws` exports `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION=us-west-2`. If the Bitwarden item is missing, the call fails loud with the expected item name.
 
 ## Finding Log Groups
 

--- a/.claude/skills/ops-pipelines/SKILL.md
+++ b/.claude/skills/ops-pipelines/SKILL.md
@@ -19,17 +19,18 @@ to approve the production rollout.
 
 ## Setup
 
-Read `network_secrets.toml` from the repo root and extract `[aws.ops]`
-(`access_key_id`, `secret_access_key`). These are read-only and can query
-CodePipeline / CodeBuild / CloudWatch but cannot approve, start, or retry
-pipelines. If the file is missing, point the user at the **Boundless
-runbook**.
+Load the ops-account AWS credentials from Bitwarden via the shared helpers
+(full setup in
+[`../ops-query/references/bw-credentials.md`](../ops-query/references/bw-credentials.md)):
 
 ```bash
-export AWS_ACCESS_KEY_ID="..."
-export AWS_SECRET_ACCESS_KEY="..."
-export AWS_DEFAULT_REGION="us-west-2"
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+bw_load_aws ops
 ```
+
+These creds are read-only -- they can query CodePipeline / CodeBuild /
+CloudWatch but cannot approve, start, or retry pipelines.
 
 All Boundless pipelines live in `us-west-2` in account `968153779208`
 (BoundlessOps).

--- a/.claude/skills/ops-query/SKILL.md
+++ b/.claude/skills/ops-query/SKILL.md
@@ -11,7 +11,14 @@ Combine on-chain indexer data, off-chain broker telemetry, and CloudWatch servic
 
 Set up the data sources needed for the investigation. Not all sources are needed for every query -- use the ones relevant to the task.
 
-1. **Read `network_secrets.toml`** from the repo root. If it exists, it contains credentials for all environments (indexer API keys, telemetry DB URLs/passwords, AWS creds). Also read `network_address_labels.json` (same directory) for labelling addresses -- it is plain JSON (`{"0xaddr": "label", ...}`). If `network_secrets.toml` is not present, recommend the user create it -- instructions and credentials are in the **Boundless runbook**. If `network_address_labels.json` is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**.
+1. **Load credentials from Bitwarden.** All ops credentials (AWS keys, indexer API keys, telemetry DB URLs/passwords) live in the user's Bitwarden vault. Source the shared helpers and verify the vault is unlocked:
+
+   ```bash
+   source .claude/skills/ops-query/references/bw-credentials.sh
+   bw_ensure_ready || exit 1
+   ```
+
+   The sub-skills below pull only the credentials they need. If `bw_ensure_ready` fails, it prints install/unlock instructions -- follow those and re-run. Full setup, item schema, and troubleshooting live in [`references/bw-credentials.md`](references/bw-credentials.md). Also read `network_address_labels.json` from the repo root for labelling addresses -- it is plain JSON (`{"0xaddr": "label", ...}`). If `network_address_labels.json` is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**.
 
 2. **Read and follow the ops-indexer-query skill** at `.claude/skills/ops-indexer-query/SKILL.md` to set up indexer access (`MARKET_INDEXER_URL`, `ZKC_INDEXER_URL`, optional `INDEXER_API_KEY`, and the `indexer_get` helper function).
 

--- a/.claude/skills/ops-query/references/bw-credentials.md
+++ b/.claude/skills/ops-query/references/bw-credentials.md
@@ -1,0 +1,104 @@
+# Bitwarden credentials for the ops-* skills
+
+All credentials used by `ops-query`, `ops-indexer-query`, `ops-telemetry-query`, `ops-logs-query`, and `ops-pipelines` live in Bitwarden — one item per credential, looked up by exact name. There is no plaintext fallback on disk; if `bw` is missing or the vault is locked, the skills fail loud.
+
+## One-time setup
+
+1. **Install the CLI — pin v2026.2.0.** Newer versions (`2026.3.0`, `2026.4.1`) have a regression that breaks non-interactive use: see [Known issues](#known-issues).
+
+   ```bash
+   npm install -g @bitwarden/cli@2026.2.0
+   bw --version   # → 2026.2.0
+   ```
+
+   If you already have a newer `bw` installed (e.g. via Homebrew), remove it first:
+
+   ```bash
+   bw logout 2>/dev/null
+   brew uninstall bitwarden-cli 2>/dev/null
+   rm -rf "$HOME/Library/Application Support/Bitwarden CLI/"
+   ```
+
+2. **Log in.**
+
+   ```bash
+   bw login
+   ```
+
+   On macOS the encrypted local vault lives at `~/Library/Application Support/Bitwarden CLI/`. You only do this once per machine.
+
+## Per-shell setup
+
+Unlock the vault and export the session token before running any ops-* skill:
+
+```bash
+export BW_SESSION="$(bw unlock --raw)"
+```
+
+The session lives for the rest of that shell (configurable via `bw config server` / Bitwarden settings). All `bw get …` calls hit the encrypted local cache — no network round trip per read.
+
+Verify with:
+
+```bash
+bw status | jq -r .status   # → "unlocked"
+```
+
+## Sourcing pattern
+
+Every ops-* skill begins its credential step with:
+
+```bash
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+```
+
+Then it pulls only the credentials it needs:
+
+```bash
+bw_load_aws prod                    # AWS keys for the prod tier
+bw_load_indexer prod_base           # INDEXER_API_KEY (optional)
+bw_load_redshift_url prod_base      # REDSHIFT_URL
+```
+
+See `bw-credentials.sh` for the exact functions.
+
+## Bootstrap
+
+The items live in a **shared Bitwarden organization/collection** so the team only seeds them once. Two paths:
+
+- **Joining the team:** an admin grants you access to the collection. After `bw login` + `bw sync`, the items show up in your local vault — no further setup needed.
+- **One-time seeding (someone has to do this once):** with a local `network_secrets.toml` in hand, run the one-shot migration:
+
+  ```bash
+  bash .claude/skills/ops-query/references/bw-migrate-from-toml.sh
+  ```
+
+  It creates 17 items (8 indexer, 6 telemetry, 3 AWS: `prod`, `staging`, `dev`) into your personal vault. Move them into the shared collection via the Bitwarden web UI so the rest of the team gets them.
+
+  The 18th item — `boundless-ops-aws-ops` (BoundlessOps account, read-only) — is added directly to the shared collection by an admin from runbook credentials; the TOML does not contain it. Use a Login item with `username` = `AWS_ACCESS_KEY_ID` and `password` = `AWS_SECRET_ACCESS_KEY`.
+
+Verify with `bw list items --search boundless-ops- | jq '.[].name' | wc -l` — the expected count is 18.
+
+The full item schema (exact field names per item type) lives in [`bw-migrate-from-toml.sh`](bw-migrate-from-toml.sh) and the loader functions in [`bw-credentials.sh`](bw-credentials.sh) — those are the source of truth.
+
+## Troubleshooting
+
+- **`bw_ensure_ready` says "vault is locked"** — re-run `export BW_SESSION="$(bw unlock --raw)"`. The previous session probably expired or you opened a new shell.
+- **`bw get item` returns nothing** — the item name is wrong. Use `bw list items --search boundless-ops-` to see what's actually there. Names are case-sensitive.
+- **`bw status` shows `unauthenticated`** — you need `bw login` again. Happens after `bw logout` or master-password rotation.
+- **A custom field is missing** — Bitwarden lets you add fields via the web/desktop UI under "Custom fields"; pick **Text** for `db_url`, `chain`, `environment`, and **Hidden** for any secret you add.
+- **Stale data after a rotation** — run `bw sync` to fetch the latest vault contents from the server.
+
+## Known issues
+
+### bw CLI 2026.3.0 / 2026.4.1 break non-interactive use
+
+Upstream regression: `bw unlock` returns a session token but the vault state never persists as unlocked. Every subsequent `bw status` / `bw list` / `bw get` ignores `BW_SESSION` and re-prompts for the master password, breaking every automation (including these helpers and the migration script).
+
+Tracking: [bitwarden/clients#20703](https://github.com/bitwarden/clients/issues/20703).
+
+**Workaround:** pin to `2026.2.0` as shown in [One-time setup](#one-time-setup). Once a fixed release ships (anything > `2026.4.1` with the regression closed), `npm install -g @bitwarden/cli@<new-version>`.
+
+### `bw get item <name>` does fuzzy substring matching
+
+`bw get item boundless-ops-indexer-prod_base` matches both `prod_base` and `prod_base_sepolia`, returning a "More than one result was found" error. `bw-credentials.sh` works around this with `bw_get_by_name`, which does `bw list items --search` followed by a jq filter on the exact name. If you write any custom bw lookups, use the same pattern — never `bw get item <name>` directly.

--- a/.claude/skills/ops-query/references/bw-credentials.md
+++ b/.claude/skills/ops-query/references/bw-credentials.md
@@ -83,9 +83,9 @@ The full item schema (exact field names per item type) lives in [`bw-migrate-fro
 
 ## Troubleshooting
 
-- **`bw_ensure_ready` says "vault is locked"** — re-run `export BW_SESSION="$(bw unlock --raw)"`. The previous session probably expired or you opened a new shell.
+- **`bw_ensure_ready` says "vault is locked"** — exit Claude Code, then in the same shell run `export BW_SESSION="$(bw unlock --raw)"` and re-launch `claude`. The child process inherits `BW_SESSION`. (A no-restart "paste `!export BW_SESSION=…` into the prompt" path *seems* like it should work but doesn't: Claude Code's Bash tool spawns a fresh subprocess per call, so an export from the prompt's shell isn't visible to subsequent tool calls.)
+- **`bw_ensure_ready` says "not logged in"** — same recovery, but `bw login &&` before the export.
 - **`bw get item` returns nothing** — the item name is wrong. Use `bw list items --search boundless-ops-` to see what's actually there. Names are case-sensitive.
-- **`bw status` shows `unauthenticated`** — you need `bw login` again. Happens after `bw logout` or master-password rotation.
 - **A custom field is missing** — Bitwarden lets you add fields via the web/desktop UI under "Custom fields"; pick **Text** for `db_url`, `chain`, `environment`, and **Hidden** for any secret you add.
 - **Stale data after a rotation** — run `bw sync` to fetch the latest vault contents from the server.
 

--- a/.claude/skills/ops-query/references/bw-credentials.md
+++ b/.claude/skills/ops-query/references/bw-credentials.md
@@ -83,7 +83,7 @@ The full item schema (exact field names per item type) lives in [`bw-migrate-fro
 
 ## Troubleshooting
 
-- **`bw_ensure_ready` says "vault is locked"** — exit Claude Code, then in the same shell run `export BW_SESSION="$(bw unlock --raw)"` and re-launch `claude`. The child process inherits `BW_SESSION`. (A no-restart "paste `!export BW_SESSION=…` into the prompt" path *seems* like it should work but doesn't: Claude Code's Bash tool spawns a fresh subprocess per call, so an export from the prompt's shell isn't visible to subsequent tool calls.)
+- **`bw_ensure_ready` says "vault is locked"** — exit Claude Code, then in the same shell run `export BW_SESSION="$(bw unlock --raw)"` and re-launch `claude`. The child process inherits `BW_SESSION`. (A no-restart "paste `!export BW_SESSION=…` into the prompt" path _seems_ like it should work but doesn't: Claude Code's Bash tool spawns a fresh subprocess per call, so an export from the prompt's shell isn't visible to subsequent tool calls.)
 - **`bw_ensure_ready` says "not logged in"** — same recovery, but `bw login &&` before the export.
 - **`bw get item` returns nothing** — the item name is wrong. Use `bw list items --search boundless-ops-` to see what's actually there. Names are case-sensitive.
 - **A custom field is missing** — Bitwarden lets you add fields via the web/desktop UI under "Custom fields"; pick **Text** for `db_url`, `chain`, `environment`, and **Hidden** for any secret you add.

--- a/.claude/skills/ops-query/references/bw-credentials.sh
+++ b/.claude/skills/ops-query/references/bw-credentials.sh
@@ -1,0 +1,87 @@
+# Bitwarden-backed credential helpers for the ops-* skills.
+#
+# Usage from any ops-* skill:
+#   source .claude/skills/ops-query/references/bw-credentials.sh
+#   bw_ensure_ready || exit 1
+#   bw_load_aws prod                  # or staging | dev | ops
+#   bw_load_indexer prod_base         # exports INDEXER_API_KEY (optional)
+#   bw_load_redshift_url prod_base    # exports REDSHIFT_URL
+#
+# Item schema is documented in bw-credentials.md.
+#
+# All lookups go through `bw_get_by_name` because `bw get item <name>` does
+# fuzzy substring matching — `boundless-ops-indexer-prod_base` would also
+# match `boundless-ops-indexer-prod_base_sepolia`. We require an exact match.
+
+# Verify bw is installed and unlocked enough to read items. `bw status` is
+# unreliable on some recent versions (see GH bitwarden/clients#20703), so we
+# probe with a cheap real read instead. Fails loud; never prompts.
+bw_ensure_ready() {
+  if ! command -v bw >/dev/null 2>&1; then
+    echo "bw not installed. brew install bitwarden-cli" >&2
+    echo "Then: bw login && export BW_SESSION=\"\$(bw unlock --raw)\"" >&2
+    return 1
+  fi
+  if ! bw list items --search '__bw_ensure_ready_probe__' </dev/null >/dev/null 2>&1; then
+    echo "Bitwarden vault is locked or session is invalid. Run:" >&2
+    echo "  export BW_SESSION=\"\$(bw unlock --raw)\"" >&2
+    return 1
+  fi
+}
+
+# Fetch a single item by exact name. Echoes the item JSON on stdout.
+# Returns non-zero if zero or multiple items match.
+bw_get_by_name() {
+  local name="$1" items count id
+  items="$(bw list items --search "$name" 2>/dev/null)" || return 1
+  count="$(jq --arg n "$name" '[.[] | select(.name == $n)] | length' <<<"$items")"
+  case "${count:-0}" in
+    0) echo "No Bitwarden item named '$name'" >&2; return 1 ;;
+    1) ;;
+    *) echo "Multiple Bitwarden items named '$name' ($count) — please dedupe" >&2; return 1 ;;
+  esac
+  id="$(jq -r --arg n "$name" '.[] | select(.name == $n) | .id' <<<"$items")"
+  bw get item "$id"
+}
+
+# Read a named custom field from a Bitwarden item.
+bw_field() {
+  local item; item="$(bw_get_by_name "$1")" || return 1
+  jq -r --arg f "$2" '.fields[]? | select(.name==$f) | .value' <<<"$item"
+}
+
+# Export AWS credentials for a tier (prod | staging | dev | ops).
+bw_load_aws() {
+  local tier="$1" item
+  item="$(bw_get_by_name "boundless-ops-aws-${tier}")" || return 1
+  AWS_ACCESS_KEY_ID="$(jq -r '.login.username // ""' <<<"$item")"
+  AWS_SECRET_ACCESS_KEY="$(jq -r '.login.password // ""' <<<"$item")"
+  if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "Missing username/password on boundless-ops-aws-${tier}" >&2
+    return 1
+  fi
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  export AWS_DEFAULT_REGION="us-west-2"
+}
+
+# Export INDEXER_API_KEY for an env. No-op if the item doesn't exist
+# (the indexer works without a key, just with lower rate limits).
+bw_load_indexer() {
+  local item key
+  item="$(bw_get_by_name "boundless-ops-indexer-$1" 2>/dev/null)" || return 0
+  key="$(jq -r '.login.password // ""' <<<"$item")"
+  [ -n "$key" ] && export INDEXER_API_KEY="$key"
+}
+
+# Build and export REDSHIFT_URL for an env.
+bw_load_redshift_url() {
+  local env="$1" item db_url pw
+  item="$(bw_get_by_name "boundless-ops-telemetry-${env}")" || return 1
+  db_url="$(jq -r '.fields[]? | select(.name=="db_url") | .value' <<<"$item")"
+  pw="$(jq -r '.login.password // ""' <<<"$item")"
+  if [ -z "$db_url" ] || [ -z "$pw" ]; then
+    echo "boundless-ops-telemetry-${env} missing db_url field or password" >&2
+    return 1
+  fi
+  export REDSHIFT_URL="postgres://readonly:${pw}@${db_url}"
+}

--- a/.claude/skills/ops-query/references/bw-credentials.sh
+++ b/.claude/skills/ops-query/references/bw-credentials.sh
@@ -13,20 +13,46 @@
 # fuzzy substring matching — `boundless-ops-indexer-prod_base` would also
 # match `boundless-ops-indexer-prod_base_sepolia`. We require an exact match.
 
-# Verify bw is installed and unlocked enough to read items. `bw status` is
-# unreliable on some recent versions (see GH bitwarden/clients#20703), so we
-# probe with a cheap real read instead. Fails loud; never prompts.
+# Verify bw is installed and the vault is unlocked. Uses `bw status` (JSON)
+# rather than a `bw list` probe because a locked vault makes `bw` prompt for
+# the master password interactively; with stdin closed the readline call
+# crashes but `bw` still exits 0, so the probe would falsely report ready.
+# `bw status` is reliable on the pinned 2026.2.0; the regression referenced
+# in GH bitwarden/clients#20703 only affects 2026.3.x / 2026.4.x, which this
+# setup explicitly refuses to support.
 bw_ensure_ready() {
   if ! command -v bw >/dev/null 2>&1; then
-    echo "bw not installed. brew install bitwarden-cli" >&2
-    echo "Then: bw login && export BW_SESSION=\"\$(bw unlock --raw)\"" >&2
+    echo "bw not installed. Pin to 2026.2.0 (Homebrew ships a broken release):" >&2
+    echo "  npm install -g @bitwarden/cli@2026.2.0" >&2
+    echo "Then: bw login" >&2
     return 1
   fi
-  if ! bw list items --search '__bw_ensure_ready_probe__' </dev/null >/dev/null 2>&1; then
-    echo "Bitwarden vault is locked or session is invalid. Run:" >&2
-    echo "  export BW_SESSION=\"\$(bw unlock --raw)\"" >&2
-    return 1
+  # Note: zsh reserves `status` as a read-only alias for $?, so use a
+  # different name when sourcing in either bash or zsh.
+  local vault_state; vault_state="$(bw status 2>/dev/null | jq -r '.status // "unknown"')"
+  case "$vault_state" in
+    unlocked) return 0 ;;
+    locked|unauthenticated) ;;
+    *) echo "bw status returned '$vault_state'. Try \`bw login\` in a terminal and re-run." >&2; return 1 ;;
+  esac
+
+  # Locked and unauthenticated share the same recovery flow; the only
+  # difference is whether the user needs `bw login` first.
+  # Note: a no-restart "paste !export BW_SESSION=… into the prompt" path
+  # does NOT work here. Claude Code's Bash tool spawns a fresh subprocess
+  # for each call, so an export from the prompt's shell isn't visible to
+  # subsequent tool calls. BW_SESSION must be in the parent shell's
+  # environment when `claude` launches, so the subprocesses inherit it.
+  local prefix=""
+  if [ "$vault_state" = "unauthenticated" ]; then
+    echo "Bitwarden is not logged in. Exit Claude Code, then in the same shell run:" >&2
+    prefix="bw login && "
+  else
+    echo "Bitwarden vault is locked. Exit Claude Code, then in the same shell run:" >&2
   fi
+  echo "  ${prefix}export BW_SESSION=\"\$(bw unlock --raw)\"" >&2
+  echo "Re-launch \`claude\` so the child process inherits BW_SESSION." >&2
+  return 1
 }
 
 # Fetch a single item by exact name. Echoes the item JSON on stdout.

--- a/.claude/skills/ops-query/references/bw-migrate-from-toml.sh
+++ b/.claude/skills/ops-query/references/bw-migrate-from-toml.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# One-shot migration from network_secrets.toml → Bitwarden items.
+# Idempotent — re-running skips items that already exist.
+#
+# Requires: bw (unlocked), jq, python3 (3.11+ for tomllib).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./bw-credentials.sh
+source "${SCRIPT_DIR}/bw-credentials.sh"
+
+# Locate the TOML by walking up from cwd.
+find_toml() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "${dir}/network_secrets.toml" ]; then
+      echo "${dir}/network_secrets.toml"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+TOML="$(find_toml)" || {
+  echo "network_secrets.toml not found in any parent of $PWD" >&2
+  exit 1
+}
+echo "Reading: $TOML"
+
+command -v python3 >/dev/null 2>&1 || {
+  echo "python3 not found — required to parse TOML" >&2
+  exit 1
+}
+command -v jq >/dev/null 2>&1 || {
+  echo "jq not found — required to build payloads" >&2
+  exit 1
+}
+
+bw_ensure_ready || exit 1
+
+# Convert the TOML to JSON via stdlib tomllib (Python 3.11+).
+TOML_JSON="$(python3 - "$TOML" <<'PY'
+import json, sys, tomllib
+with open(sys.argv[1], "rb") as f:
+    print(json.dumps(tomllib.load(f)))
+PY
+)" || {
+  echo "Failed to parse $TOML — needs Python 3.11+ (tomllib)" >&2
+  exit 1
+}
+
+CREATED=0
+SKIPPED=0
+
+item_exists() {
+  # `bw get item <name>` does fuzzy substring matching, which causes false
+  # positives across similarly-named items (e.g. prod_base vs
+  # prod_base_sepolia). Filter the search results by exact name in jq.
+  local name="$1" count
+  count="$(bw list items --search "$name" 2>/dev/null \
+    | jq --arg n "$name" '[.[] | select(.name == $n)] | length')"
+  [ "${count:-0}" -ge 1 ]
+}
+
+# Build a Bitwarden Login-item JSON payload.
+# Args: name, username, password, [field_name field_value]...
+login_payload() {
+  local name="$1" username="$2" password="$3"
+  shift 3
+  local fields="[]"
+  while [ $# -gt 0 ]; do
+    fields=$(jq -c --arg n "$1" --arg v "$2" '. + [{name: $n, value: $v, type: 0}]' <<<"$fields")
+    shift 2
+  done
+  jq -n \
+    --arg name "$name" \
+    --arg u "$username" \
+    --arg p "$password" \
+    --argjson fields "$fields" \
+    '{
+      organizationId: null,
+      folderId: null,
+      type: 1,
+      name: $name,
+      notes: null,
+      favorite: false,
+      fields: $fields,
+      login: {username: $u, password: $p, uris: [], totp: null},
+      secureNote: null,
+      card: null,
+      identity: null,
+      reprompt: 0
+    }'
+}
+
+create_item() {
+  local name="$1" payload="$2"
+  if item_exists "$name"; then
+    echo "  exists, skipping: $name"
+    SKIPPED=$((SKIPPED + 1))
+    return 0
+  fi
+  echo "$payload" | bw encode | bw create item >/dev/null
+  echo "  created: $name"
+  CREATED=$((CREATED + 1))
+}
+
+# ── AWS ──────────────────────────────────────────────────────────────────────
+for tier in $(jq -r '.aws // {} | keys[]' <<<"$TOML_JSON"); do
+  name="boundless-ops-aws-${tier}"
+  echo "AWS: $name"
+  ak="$(jq -r --arg t "$tier" '.aws[$t].access_key_id' <<<"$TOML_JSON")"
+  sk="$(jq -r --arg t "$tier" '.aws[$t].secret_access_key' <<<"$TOML_JSON")"
+  create_item "$name" "$(login_payload "$name" "$ak" "$sk")"
+done
+
+# ── Indexer ──────────────────────────────────────────────────────────────────
+for env in $(jq -r '.environments // {} | to_entries[] | select(.value.indexer) | .key' <<<"$TOML_JSON"); do
+  name="boundless-ops-indexer-${env}"
+  echo "Indexer: $name"
+  api_key="$(jq -r --arg e "$env" '.environments[$e].indexer.api_key' <<<"$TOML_JSON")"
+  chain="$(jq -r --arg e "$env" '.environments[$e].chain // ""' <<<"$TOML_JSON")"
+  environment="$(jq -r --arg e "$env" '.environments[$e].environment // ""' <<<"$TOML_JSON")"
+  create_item "$name" "$(login_payload "$name" "" "$api_key" chain "$chain" environment "$environment")"
+done
+
+# ── Telemetry ────────────────────────────────────────────────────────────────
+for env in $(jq -r '.environments // {} | to_entries[] | select(.value.telemetry) | .key' <<<"$TOML_JSON"); do
+  name="boundless-ops-telemetry-${env}"
+  echo "Telemetry: $name"
+  db_url="$(jq -r --arg e "$env" '.environments[$e].telemetry.db_url' <<<"$TOML_JSON")"
+  pw="$(jq -r --arg e "$env" '.environments[$e].telemetry.readonly_password' <<<"$TOML_JSON")"
+  chain="$(jq -r --arg e "$env" '.environments[$e].chain // ""' <<<"$TOML_JSON")"
+  environment="$(jq -r --arg e "$env" '.environments[$e].environment // ""' <<<"$TOML_JSON")"
+  create_item "$name" "$(login_payload "$name" "readonly" "$pw" db_url "$db_url" chain "$chain" environment "$environment")"
+done
+
+echo
+echo "Summary: created $CREATED, skipped $SKIPPED (already exists)"

--- a/.claude/skills/ops-telemetry-query/SKILL.md
+++ b/.claude/skills/ops-telemetry-query/SKILL.md
@@ -14,36 +14,17 @@ The UNLOAD per env happened at various times during 2026-04-24; treating all of 
 
 ## Prerequisites
 
-Before running any queries, check if `REDSHIFT_URL` is already exported in the shell.
+Before running any queries, check if `REDSHIFT_URL` is already exported in the shell. If not, load it from Bitwarden via the shared helpers (full setup in [`../ops-query/references/bw-credentials.md`](../ops-query/references/bw-credentials.md)):
 
-If not, try to read `network_secrets.toml` from the repo root. If it exists, extract the telemetry credentials for the selected environment from `[environments.<env>.telemetry]`:
+```bash
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+bw_load_redshift_url "$ENV"     # e.g. prod_base, staging_taiko
+```
 
-- `db_url` -- the Redshift hostname:port/database?sslmode path
-- `readonly_password` -- the readonly user password
+`bw_load_redshift_url` reads `db_url` and the readonly password from the `boundless-ops-telemetry-<env>` item and exports a fully-formed `postgres://readonly:<password>@<db_url>` URL. If the item is missing, the call fails loud and prints which item to add.
 
-Construct the connection string: `postgres://readonly:<password>@<db_url>`
-
-Also read `network_address_labels.json` (same directory) for translating addresses to human-readable labels in output.
-
-If `network_secrets.toml` is not present, recommend the user create it -- instructions and credentials are in the **Boundless runbook**. Alternatively, they can provide credentials directly:
-
-1. The Redshift **endpoint** (hostname or full connection string)
-2. The **readonly password**
-
-They can either:
-
-- Export them as env vars: `export REDSHIFT_ENDPOINT="..."` and `export REDSHIFT_PASSWORD="..."`
-- Provide them directly in the chat
-
-If `network_address_labels.json` is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**. The file is plain JSON (`{"0xaddr": "label", ...}`).
-
-The user may provide a full `postgres://...` URL or just a hostname. Normalize to a valid connection string:
-
-- If the URL is missing `/telemetry` at the end of the path, append it
-- If the URL is missing `?sslmode=require`, append it
-- If only a hostname is given, construct: `postgres://readonly:<password>@<hostname>:5439/telemetry?sslmode=require`
-
-Export the result as `REDSHIFT_URL` before running queries.
+Also read `network_address_labels.json` from the repo root for translating addresses to human-readable labels in output. If it is not present, recommend the user create it -- the canonical address mapping is in the **Boundless runbook**. The file is plain JSON (`{"0xaddr": "label", ...}`).
 
 ## Routing by Time Window
 
@@ -78,20 +59,21 @@ Parquet column names and types match the Redshift typed views exactly (Redshift 
 
 ### Credentials
 
-Read AWS creds from `network_secrets.toml` at the repo root:
+Load AWS creds from Bitwarden via the shared helpers:
 
-- `[aws.prod]` for any `prod_*` env
-- `[aws.staging]` for any `staging_*` env
+```bash
+source .claude/skills/ops-query/references/bw-credentials.sh
+bw_ensure_ready || exit 1
+bw_load_aws prod       # for any prod_* env  (or `staging` for staging_*)
+```
 
-Both have `s3:GetObject` on their respective buckets. Region is `us-west-2`.
+Both tiers have `s3:GetObject` on their respective buckets. Region is `us-west-2`.
 
 ### Running a query
 
 Mirror the psql heredoc pattern. Install `httpfs` once per `duckdb` invocation, set the creds, then `read_parquet` the glob. Heredoc keeps zsh from mangling `!=`.
 
 ```bash
-AWS_ACCESS_KEY_ID=<from network_secrets.toml> \
-AWS_SECRET_ACCESS_KEY=<from network_secrets.toml> \
 duckdb <<SQL
 INSTALL httpfs; LOAD httpfs;
 SET s3_region='us-west-2';
@@ -120,8 +102,8 @@ When rewriting a Redshift query for the archive path, watch for these:
 ### Fail-loud rules
 
 - If the user asks for a pre-cutover window on an env not in the bucket table → stop and say the archive doesn't exist for that env.
-- If DuckDB returns `HTTP 403` / AccessDenied → stop and report the bucket name and which `[aws.*]` profile was used; do not silently retry.
-- If `network_secrets.toml` is missing the needed `[aws.*]` block → stop and ask the user.
+- If DuckDB returns `HTTP 403` / AccessDenied → stop and report the bucket name and which AWS tier (`bw_load_aws prod` vs `staging`) was loaded; do not silently retry.
+- If `bw_load_aws` or `bw_load_redshift_url` fails → stop, surface the missing Bitwarden item name printed by the helper, and ask the user to add it (see [`../ops-query/references/bw-credentials.md`](../ops-query/references/bw-credentials.md)).
 
 ## Known Addresses
 


### PR DESCRIPTION
## Summary

Replace the gitignored `network_secrets.toml` with the Bitwarden CLI as the single source of truth for credentials used by the `ops-query` umbrella skill and its four sub-skills (`ops-indexer-query`, `ops-telemetry-query`, `ops-logs-query`, `ops-pipelines`).

Why:

- No plaintext secrets on disk.
- Rotations propagate automatically (next `bw sync` picks up the new value).
- A leaked laptop = one revoked Bitwarden session, not 18 keys to rotate everywhere.
- Per-credential access control and audit already exist in Bitwarden — we get sharing for free via a shared organization/collection.

## Changes

**New files (under `.claude/skills/ops-query/references/`)**

- `bw-credentials.sh` — sourced bash helpers: `bw_ensure_ready`, `bw_load_aws`, `bw_load_indexer`, `bw_load_redshift_url`. All lookups go through `bw_get_by_name` (exact-name match via `bw list items --search` + jq), working around bw's fuzzy `bw get item` matching where e.g. `prod_base` also matches `prod_base_sepolia`.
- `bw-credentials.md` — install (npm-pinned to `2026.2.0`), per-shell unlock, bootstrap (one-time team seed + shared vault), troubleshooting, and a **Known Issues** section flagging the v2026.3.0/4.1 regression that breaks non-interactive bw use ([bitwarden/clients#20703](https://github.com/bitwarden/clients/issues/20703)).
- `bw-migrate-from-toml.sh` — idempotent one-shot migration. Reads `network_secrets.toml`, creates 17 items (8 indexer + 6 telemetry + 3 AWS). The 18th item `boundless-ops-aws-ops` is added to the shared collection separately by an admin from runbook credentials.

**SKILL.md updates** — each credential-loading step collapses to the same pattern:

\`\`\`bash
source .claude/skills/ops-query/references/bw-credentials.sh
bw_ensure_ready || exit 1
bw_load_aws prod          # or bw_load_indexer prod_base, bw_load_redshift_url prod_base, etc.
\`\`\`

Plaintext TOML fallback paths are removed entirely — the skills fail loud with install/unlock instructions if `bw` is missing or locked.

## Bitwarden item schema (18 items)

| Group | Count | Name pattern | Fields |
| --- | --- | --- | --- |
| AWS | 4 | `boundless-ops-aws-<prod\|staging\|dev\|ops>` | username = access key id, password = secret |
| Indexer | 8 | `boundless-ops-indexer-<env>` | password = API key (+ `chain`, `environment` text fields) |
| Telemetry | 6 | `boundless-ops-telemetry-<env>` | username = `readonly`, password, + `db_url` / `chain` / `environment` |

## Rollout

1. One team member runs `bash .claude/skills/ops-query/references/bw-migrate-from-toml.sh` against their local TOML and moves the resulting items into the shared `Boundless Ops` collection (or equivalent).
2. Admin adds `boundless-ops-aws-ops` to the same collection.
3. Everyone else just needs collection access — `bw sync` makes the items appear locally.

## Out of scope

`ops-check-balances` still references `network_secrets.toml` for QuikNode private RPC keys (`[networks.<chain>.rpc]`). Those blocks don't exist in the current TOML; tracked as a follow-up.

## Test plan

- [ ] `bw_load_aws prod && aws sts get-caller-identity` returns the prod account
- [ ] `bw_load_aws ops && aws codepipeline list-pipelines` works
- [ ] `bw_load_indexer prod_base && curl -H "x-api-key: $INDEXER_API_KEY" "$MARKET_INDEXER_URL/v1/market/requests?limit=1"` returns data
- [ ] `bw_load_redshift_url prod_base && psql "$REDSHIFT_URL" -c 'SELECT 1'` returns one row
- [ ] With vault locked, `bw_ensure_ready` exits non-zero and prints the unlock instructions
- [ ] Run one pre-built investigation (e.g. `market-summary` on `prod_base`) end-to-end with no `network_secrets.toml` reads