### PR TITLE
BM-3004: fix(indexer-api): demote tower TraceLayer on_failure to WARN

### DIFF
--- a/crates/lambdas/indexer-api/src/handler.rs
+++ b/crates/lambdas/indexer-api/src/handler.rs
@@ -24,7 +24,7 @@ use serde_json::json;
 use std::{env, sync::Arc};
 use tower_http::{
     cors::{Any, CorsLayer},
-    trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer},
+    trace::{DefaultMakeSpan, DefaultOnFailure, DefaultOnResponse, TraceLayer},
 };
 use tracing::Level;
 
@@ -54,10 +54,13 @@ pub fn create_app(state: Arc<AppState>) -> Router {
     // Configure CORS
     let cors = CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any);
 
-    // Configure request/response tracing
+    // Configure request/response tracing. Demote on_failure to WARN so a single 5xx response
+    // (already logged at ERROR via `handle_error`) does not produce a second ERROR line and
+    // double-trigger the SEV2 log-err alarm.
     let trace_layer = TraceLayer::new_for_http()
         .make_span_with(DefaultMakeSpan::new().level(Level::DEBUG))
-        .on_response(DefaultOnResponse::new().level(Level::DEBUG));
+        .on_response(DefaultOnResponse::new().level(Level::DEBUG))
+        .on_failure(DefaultOnFailure::new().level(Level::WARN));
 
     // Build the router
     Router::new()


### PR DESCRIPTION
## Summary

The prod 167000 indexer-api `SEV2-log-err` alarm fired on 2026-05-20 08:29 UTC on a single failed HTTP request. Root cause:

- A 5xx response produces **two** ERROR log lines:
  1. `tracing::error!(...)` inside `handle_error` in `handler.rs:168`
  2. The implicit ERROR emitted by `tower_http::trace::TraceLayer`'s default `on_failure` callback
- The alarm threshold is **2 errors in 20 min** — so a single failure is enough to page.

This change explicitly configures `on_failure` at `WARN`, leaving the rich application-level ERROR (`error = ?err`, `caller`) intact while removing the redundant tower-side ERROR.

## Change

`crates/lambdas/indexer-api/src/handler.rs`:

```rust
let trace_layer = TraceLayer::new_for_http()
    .make_span_with(DefaultMakeSpan::new().level(Level::DEBUG))
    .on_response(DefaultOnResponse::new().level(Level::DEBUG))
    .on_failure(DefaultOnFailure::new().level(Level::WARN));   // new
```

## Observed event

```
2026-05-20T08:23:32Z  ERROR  Request failed at market.rs:1825
                              error: SQL error PoolTimedOut: pool timed out while waiting for an open connection
2026-05-20T08:23:32Z  ERROR  response failed  classification=503 Service Unavailable  latency=5001 ms
```

The underlying failure is a rare sqlx `PoolTimedOut` (per-Lambda pool: `max_connections=3`, `acquire_timeout=5s`). Only **1 such event in the last 7 days** — DB itself is healthy. That is being left as-is; this PR is only about alarm noise.

## Out of scope (followups to consider)

Other axum services use `TraceLayer::new_for_http()` without an explicit `on_failure` level and could have the same alarm behavior if they grow similar SEV2 log-err alarms:

- `crates/order-stream/src/lib.rs:543`
- `crates/executor/src/main.rs:64`

Not touched here because we have not observed the same alarm noise on those services yet.

## Test plan

- [ ] After deploy, manually trigger a 5xx (e.g. invalid query forcing a DB error) on staging and confirm exactly one ERROR log line per request.
- [ ] Confirm the SEV2-log-err alarm metric only increments by 1 (not 2) per failed request.