### PR TITLE
BM-3011: Remove SEV1 alarms on OGs and order-generator log errors

### DIFF
--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -309,19 +309,6 @@ export const alarmConfig: ChainStageAlarms = {
                 datapointsToAlarm: 2,
                 comparisonOperator: "LessThanThreshold"
               }
-            },
-            {
-              description: "less than 50% success rate for six 30 minute periods within 4 hours from og_offchain",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 1800
-              },
-              alarmConfig: {
-                threshold: 0.50,
-                evaluationPeriods: 8,
-                datapointsToAlarm: 6,
-                comparisonOperator: "LessThanThreshold"
-              }
             }
           ],
           expiredRequests: []
@@ -359,24 +346,7 @@ export const alarmConfig: ChainStageAlarms = {
               }
             }
           ],
-          successRate: [
-            // Onchain orders are large orders that can take variable lengths of time to fulfill,
-            // so we set a more lenient success rate threshold, since there may be periods where
-            // fewer proofs get fulfilled due to variant proof lengths.
-            {
-              description: "less than 50% success rate for two consecutive hours from og_onchain",
-              severity: Severity.SEV1,
-              metricConfig: {
-                period: 3600
-              },
-              alarmConfig: {
-                threshold: 0.50,
-                evaluationPeriods: 2,
-                datapointsToAlarm: 2,
-                comparisonOperator: "LessThanThreshold"
-              }
-            }
-          ],
+          successRate: [],
           expiredRequests: []
         },
         {

--- a/infra/order-generator/components/order-generator.ts
+++ b/infra/order-generator/components/order-generator.ts
@@ -491,34 +491,6 @@ export class OrderGenerator extends pulumi.ComponentResource {
       alarmActions,
     });
 
-    // 7 errors within 1 hour in the order generator triggers a SEV1 alarm.
-    // Eth Sepolia is unreliable, so don't SEV1 on it.
-    if (!isStaging && args.chainId !== '11155111') {
-      new aws.cloudwatch.MetricAlarm(`${serviceName}-error-alarm-${Severity.SEV1}`, {
-        name: `${serviceName}-log-err-${Severity.SEV1}`,
-        metricQueries: [
-          {
-            id: 'm1',
-            metric: {
-              namespace: `Boundless/Services/${serviceName}`,
-              metricName: `${serviceName}-log-err`,
-              period: 60,
-              stat: 'Sum',
-            },
-            returnData: true,
-          },
-        ],
-        threshold: 1,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold',
-        evaluationPeriods: 60,
-        datapointsToAlarm: 7,
-        treatMissingData: 'notBreaching',
-        alarmDescription: `Order generator ${name} log ERROR level 7 times within an hour`,
-        actionsEnabled: true,
-        alarmActions,
-      });
-    }
-
     // 10 or more transaction confirmation errors within 1 hour triggers a SEV2 alarm.
     new aws.cloudwatch.MetricAlarm(`${serviceName}-tx-conf-error-alarm-${Severity.SEV2}`, {
       name: `${serviceName}-log-tx-conf-err-${Severity.SEV2}`,
@@ -570,33 +542,5 @@ export class OrderGenerator extends pulumi.ComponentResource {
       alarmActions,
     });
 
-    // A single error in the order generator causes the process to exit.
-    // SEV1 alarm if we see 4 errors in 30 mins.
-    // Eth Sepolia is unreliable, so don't SEV1 on it.
-    if (!isStaging && args.chainId !== '11155111') {
-      new aws.cloudwatch.MetricAlarm(`${serviceName}-fatal-alarm-${Severity.SEV1}`, {
-        name: `${serviceName}-log-fatal-${Severity.SEV1}`,
-        metricQueries: [
-          {
-            id: 'm1',
-            metric: {
-              namespace: `Boundless/Services/${serviceName}`,
-              metricName: `${serviceName}-log-fatal`,
-              period: 60,
-              stat: 'Sum',
-            },
-            returnData: true,
-          },
-        ],
-        threshold: 1,
-        comparisonOperator: 'GreaterThanOrEqualToThreshold',
-        evaluationPeriods: 30,
-        datapointsToAlarm: 4,
-        treatMissingData: 'notBreaching',
-        alarmDescription: `Order generator ${name} FATAL (task exited) 4 times within 30 mins`,
-        actionsEnabled: true,
-        alarmActions,
-      });
-    }
   }
 }


### PR DESCRIPTION
Drops SEV1 alarms on the order generators (success rate) and the OG service (ERROR + FATAL log alarms). SEV2 versions remain.

Changes
* infra/indexer/alarmConfig.ts — remove SEV1 success-rate alarms on og_offchain and og_onchain (Base prod)
* infra/order-generator/components/order-generator.ts — remove SEV1 alarms on log ERROR (7/hr) and log FATAL (4/30min)
