### PR TITLE
BM-3012: Enable requestor priority levels when ranking orders

### DIFF
--- a/crates/broker/src/order_committer/service.rs
+++ b/crates/broker/src/order_committer/service.rs
@@ -47,7 +47,7 @@ use crate::{
     config::ConfigLock,
     now_timestamp,
     order_locker::OrderCommitmentMeta,
-    prioritization::prioritize_orders_to_commit,
+    prioritization::{prioritize_orders_to_commit, DEFAULT_PRIORITY_LEVEL},
     requestor_monitor::PriorityRequestors,
     task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest, OrderStateChange,
@@ -143,10 +143,24 @@ impl OrderCommitter {
         })
     }
 
-    fn collect_priority_addresses(&self, static_addresses: Option<Vec<Address>>) -> Vec<Address> {
-        let mut merged = static_addresses.unwrap_or_default();
+    /// Builds the priority-level map: static `priority_requestor_addresses` entries
+    /// at [`DEFAULT_PRIORITY_LEVEL`], merged with remote-list entries (which may carry
+    /// an explicit level). When an address appears in both, the higher level wins.
+    fn collect_priority_levels(
+        &self,
+        static_addresses: Option<Vec<Address>>,
+    ) -> HashMap<Address, i32> {
+        let mut merged: HashMap<Address, i32> = HashMap::new();
+        for address in static_addresses.unwrap_or_default() {
+            merged.insert(address, DEFAULT_PRIORITY_LEVEL);
+        }
         for pr in self.priority_requestors.values() {
-            merged.extend(pr.dynamic_addresses());
+            for (address, level) in pr.dynamic_levels() {
+                merged
+                    .entry(address)
+                    .and_modify(|existing| *existing = (*existing).max(level))
+                    .or_insert(level);
+            }
         }
         merged
     }
@@ -214,7 +228,7 @@ impl OrderCommitter {
         pending_orders: &mut Vec<Box<OrderRequest>>,
         in_flight: &mut HashMap<String, InFlightOrder>,
         committer_config: &CommitterConfig,
-        priority_addresses: &[Address],
+        priority_levels: &HashMap<Address, i32>,
     ) {
         if pending_orders.is_empty() {
             return;
@@ -246,12 +260,10 @@ impl OrderCommitter {
             .saturating_sub(in_flight.len())
             .min(MAX_PROVING_BATCH_SIZE);
 
-        let priority_ref =
-            if priority_addresses.is_empty() { None } else { Some(priority_addresses) };
         let mut selected = prioritize_orders_to_commit(
             &mut ready,
             committer_config.order_commitment_priority,
-            priority_ref,
+            Some(priority_levels),
             available_capacity,
             committer_config.peak_prove_khz,
         );
@@ -415,8 +427,8 @@ impl BrokerService for OrderCommitter {
         tracing::info!("Starting order committer");
 
         let mut committer_config = self.read_config().map_err(SupervisorErr::Fault)?;
-        let mut priority_addresses =
-            self.collect_priority_addresses(committer_config.priority_addresses.take());
+        let mut priority_levels =
+            self.collect_priority_levels(committer_config.priority_addresses.take());
 
         let mut priced_order_rx = self.priced_order_rx.lock().await;
         let mut proving_completion_rx = self.proving_completion_rx.lock().await;
@@ -526,8 +538,8 @@ impl BrokerService for OrderCommitter {
                     }
 
                     committer_config = new_config;
-                    priority_addresses = self
-                        .collect_priority_addresses(committer_config.priority_addresses.take());
+                    priority_levels = self
+                        .collect_priority_levels(committer_config.priority_addresses.take());
 
                     Self::reap_stale_capacity(
                         &mut in_flight,
@@ -545,7 +557,7 @@ impl BrokerService for OrderCommitter {
                 &mut pending_orders,
                 &mut in_flight,
                 &committer_config,
-                &priority_addresses,
+                &priority_levels,
             );
         }
 

--- a/crates/broker/src/order_evaluator/service.rs
+++ b/crates/broker/src/order_evaluator/service.rs
@@ -23,7 +23,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     channels::SharedReceiver,
     config::ConfigLock,
-    prioritization::prioritize_orders_to_evaluate,
+    prioritization::{prioritize_orders_to_evaluate, DEFAULT_PRIORITY_LEVEL},
     requestor_monitor::PriorityRequestors,
     task::{BrokerService, SupervisorErr},
     FulfillmentType, OrderRequest, OrderStateChange,
@@ -86,13 +86,24 @@ impl OrderEvaluator {
         ))
     }
 
-    fn collect_priority_addresses(
+    /// Builds the priority-level map: static `priority_requestor_addresses` entries
+    /// at [`DEFAULT_PRIORITY_LEVEL`], merged with remote-list entries (which may carry
+    /// an explicit level). When an address appears in both, the higher level wins.
+    fn collect_priority_levels(
         &self,
         static_addresses: Option<Vec<alloy::primitives::Address>>,
-    ) -> Vec<alloy::primitives::Address> {
-        let mut merged = static_addresses.unwrap_or_default();
+    ) -> HashMap<alloy::primitives::Address, i32> {
+        let mut merged: HashMap<alloy::primitives::Address, i32> = HashMap::new();
+        for address in static_addresses.unwrap_or_default() {
+            merged.insert(address, DEFAULT_PRIORITY_LEVEL);
+        }
         for pr in self.priority_requestors.values() {
-            merged.extend(pr.dynamic_addresses());
+            for (address, level) in pr.dynamic_levels() {
+                merged
+                    .entry(address)
+                    .and_modify(|existing| *existing = (*existing).max(level))
+                    .or_insert(level);
+            }
         }
         merged
     }
@@ -119,19 +130,17 @@ impl OrderEvaluator {
         in_flight: &mut HashMap<String, Instant>,
         max_concurrent_preflights: usize,
         priority_mode: boundless_market::prover_utils::config::OrderPricingPriority,
-        priority_addresses: &[alloy::primitives::Address],
+        priority_levels: &HashMap<alloy::primitives::Address, i32>,
     ) {
         if pending_orders.is_empty() || in_flight.len() >= max_concurrent_preflights {
             return;
         }
 
         let available_capacity = max_concurrent_preflights - in_flight.len();
-        let priority_ref =
-            if priority_addresses.is_empty() { None } else { Some(priority_addresses) };
         let selected = prioritize_orders_to_evaluate(
             pending_orders,
             priority_mode,
-            priority_ref,
+            Some(priority_levels),
             available_capacity,
         );
 
@@ -210,7 +219,7 @@ impl BrokerService for OrderEvaluator {
 
         let (mut max_concurrent_preflights, mut priority_mode, static_addresses) =
             self.read_config().map_err(SupervisorErr::Fault)?;
-        let mut priority_addresses = self.collect_priority_addresses(static_addresses);
+        let mut priority_levels = self.collect_priority_levels(static_addresses);
 
         let mut order_rx = self.new_order_rx.lock().await;
         let mut pricing_completion_rx = self.pricing_completion_rx.lock().await;
@@ -315,8 +324,7 @@ impl BrokerService for OrderEvaluator {
                         );
                         priority_mode = new_priority;
                     }
-                    priority_addresses =
-                        self.collect_priority_addresses(new_static_addresses);
+                    priority_levels = self.collect_priority_levels(new_static_addresses);
 
                     Self::reap_stale_capacity(
                         &mut in_flight,
@@ -337,7 +345,7 @@ impl BrokerService for OrderEvaluator {
                 &mut in_flight,
                 max_concurrent_preflights,
                 priority_mode,
-                &priority_addresses,
+                &priority_levels,
             );
         }
 

--- a/crates/broker/src/requestor_monitor/types.rs
+++ b/crates/broker/src/requestor_monitor/types.rs
@@ -26,7 +26,7 @@ use std::{
 use alloy::primitives::Address;
 use requestor_lists::{Extensions, RequestorEntry, RequestorList};
 
-use crate::config::ConfigLock;
+use crate::{config::ConfigLock, prioritization::DEFAULT_PRIORITY_LEVEL};
 
 /// Cached entry that tracks both the requestor data and its source URL
 #[derive(Clone, Debug)]
@@ -96,9 +96,28 @@ impl PriorityRequestors {
         self.get_requestor_entry(address).is_some()
     }
 
-    /// Returns all dynamically-registered priority addresses (from remote lists).
-    pub fn dynamic_addresses(&self) -> Vec<Address> {
-        self.requestors.read().map(|r| r.keys().copied().collect()).unwrap_or_default()
+    /// Returns all dynamically-registered priority requestors (from remote lists)
+    /// mapped to their priority level. Entries without a `priority` extension fall
+    /// back to [`DEFAULT_PRIORITY_LEVEL`].
+    pub fn dynamic_levels(&self) -> HashMap<Address, i32> {
+        self.requestors
+            .read()
+            .map(|requestors| {
+                requestors
+                    .iter()
+                    .map(|(address, cached)| {
+                        let level = cached
+                            .entry
+                            .extensions
+                            .priority
+                            .as_ref()
+                            .map(|priority| priority.level)
+                            .unwrap_or(DEFAULT_PRIORITY_LEVEL);
+                        (*address, level)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     /// Update the priority requestors from a list

--- a/crates/broker/src/shared/prioritization.rs
+++ b/crates/broker/src/shared/prioritization.rs
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{BTreeMap, HashMap};
+
 use crate::{
     config::{OrderCommitmentPriority, OrderPricingPriority},
     FulfillmentType, OrderRequest,
 };
 
-use alloy::primitives::{utils::format_ether, U256};
+use alloy::primitives::{utils::format_ether, Address, U256};
 use rand::seq::SliceRandom;
 use rand::Rng;
+
+/// Priority level applied to a priority requestor that carries no explicit level,
+/// i.e. a static-config `priority_requestor_addresses` entry or a remote requestor
+/// list entry without a `priority` extension. Higher levels (up to 100) outrank it;
+/// lower levels rank below it.
+pub(crate) const DEFAULT_PRIORITY_LEVEL: i32 = 50;
 
 /// Unified priority mode for both pricing and commitment
 #[derive(Debug, Clone, Copy)]
@@ -64,26 +72,46 @@ impl UnifiedPriorityMode {
     }
 }
 
+/// Sorts `orders` in place: priority requestors first, everyone else last.
+///
+/// `priority_levels` maps a priority requestor address to its priority level
+/// (0-100, higher wins). Priority orders are split into tiers by level, highest
+/// level first; within a tier they are sorted by `mode`. This means a higher
+/// level always outranks a lower one regardless of the configured priority mode.
+/// Regular (non-priority) orders are sorted by `mode` and always rank last.
 fn sort_orders_by_priority_and_mode<T>(
     orders: &mut Vec<T>,
-    priority_addresses: Option<&[alloy::primitives::Address]>,
+    priority_levels: Option<&HashMap<Address, i32>>,
     mode: UnifiedPriorityMode,
 ) where
     T: AsRef<OrderRequest>,
 {
-    let Some(addresses) = priority_addresses else {
+    let Some(levels) = priority_levels.filter(|m| !m.is_empty()) else {
         sort_by_mode(orders, mode);
         return;
     };
 
-    let (mut priority_orders, mut regular_orders): (Vec<T>, Vec<T>) = orders
+    let (priority_orders, mut regular_orders): (Vec<T>, Vec<T>) = orders
         .drain(..)
-        .partition(|order| addresses.contains(&order.as_ref().request.client_address()));
+        .partition(|order| levels.contains_key(&order.as_ref().request.client_address()));
 
-    sort_by_mode(&mut priority_orders, mode);
     sort_by_mode(&mut regular_orders, mode);
 
-    orders.extend(priority_orders);
+    // Group priority orders into descending level tiers. BTreeMap keyed by
+    // Reverse(level) iterates highest level first.
+    let mut tiers: BTreeMap<std::cmp::Reverse<i32>, Vec<T>> = BTreeMap::new();
+    for order in priority_orders {
+        let level = levels
+            .get(&order.as_ref().request.client_address())
+            .copied()
+            .unwrap_or(DEFAULT_PRIORITY_LEVEL);
+        tiers.entry(std::cmp::Reverse(level)).or_default().push(order);
+    }
+
+    for (_, mut tier) in tiers {
+        sort_by_mode(&mut tier, mode);
+        orders.extend(tier);
+    }
     orders.extend(regular_orders);
 }
 
@@ -215,14 +243,14 @@ where
 pub(crate) fn prioritize_orders_to_evaluate(
     orders: &mut Vec<Box<OrderRequest>>,
     priority_mode: OrderPricingPriority,
-    priority_addresses: Option<&[alloy::primitives::Address]>,
+    priority_levels: Option<&HashMap<Address, i32>>,
     capacity: usize,
 ) -> Vec<Box<OrderRequest>> {
     if orders.is_empty() || capacity == 0 {
         return Vec::new();
     }
 
-    sort_orders_by_priority_and_mode(orders, priority_addresses, priority_mode.into());
+    sort_orders_by_priority_and_mode(orders, priority_levels, priority_mode.into());
 
     let take_count = std::cmp::min(capacity, orders.len());
     orders.drain(..take_count).collect()
@@ -236,7 +264,7 @@ pub(crate) fn prioritize_orders_to_evaluate(
 pub(crate) fn prioritize_orders_to_commit(
     orders: &mut Vec<Box<OrderRequest>>,
     priority_mode: OrderCommitmentPriority,
-    priority_addresses: Option<&[alloy::primitives::Address]>,
+    priority_levels: Option<&HashMap<Address, i32>>,
     capacity: usize,
     peak_prove_khz: Option<u64>,
 ) -> Vec<Box<OrderRequest>> {
@@ -245,7 +273,7 @@ pub(crate) fn prioritize_orders_to_commit(
     }
 
     let mode = UnifiedPriorityMode::from_commitment_priority(priority_mode, peak_prove_khz);
-    sort_orders_by_priority_and_mode(orders, priority_addresses, mode);
+    sort_orders_by_priority_and_mode(orders, priority_levels, mode);
 
     let take_count = std::cmp::min(capacity, orders.len());
     orders.drain(..take_count).collect()
@@ -267,12 +295,17 @@ mod tests {
     fn prioritize_commitment_orders(
         mut orders: Vec<Arc<OrderRequest>>,
         priority_mode: OrderCommitmentPriority,
-        priority_addresses: Option<&[alloy::primitives::Address]>,
+        priority_levels: Option<&HashMap<Address, i32>>,
         peak_prove_khz: Option<u64>,
     ) -> Vec<Arc<OrderRequest>> {
         let mode = UnifiedPriorityMode::from_commitment_priority(priority_mode, peak_prove_khz);
-        sort_orders_by_priority_and_mode(&mut orders, priority_addresses, mode);
+        sort_orders_by_priority_and_mode(&mut orders, priority_levels, mode);
         orders
+    }
+
+    /// Builds a priority-levels map from `(address, level)` pairs for tests.
+    fn levels(entries: impl IntoIterator<Item = (Address, i32)>) -> HashMap<Address, i32> {
+        entries.into_iter().collect()
     }
     use alloy::primitives::U256;
     use tracing_test::traced_test;
@@ -845,7 +878,7 @@ mod tests {
 
         let regular_addr = alloy::primitives::Address::from([0x42; 20]);
         let priority_addr = alloy::primitives::Address::from([0x99; 20]);
-        let priority_addresses = vec![priority_addr];
+        let priority_levels = levels([(priority_addr, DEFAULT_PRIORITY_LEVEL)]);
 
         // Test shortest expiry mode without priority addresses
         let mut regular_order_1 = ctx
@@ -907,7 +940,7 @@ mod tests {
         let selected_orders = prioritize_orders_to_evaluate(
             &mut test_orders,
             OrderPricingPriority::ShortestExpiry,
-            Some(&priority_addresses),
+            Some(&priority_levels),
             1,
         );
         let selected_order = selected_orders.into_iter().next().unwrap();
@@ -932,7 +965,7 @@ mod tests {
         // Switch the signer address to a new one.
         ctx.signer = alloy::signers::local::PrivateKeySigner::random();
         let priority_addr = ctx.signer.address();
-        let priority_addresses = vec![priority_addr];
+        let priority_levels = levels([(priority_addr, DEFAULT_PRIORITY_LEVEL)]);
 
         // Priority order with long expiry (should be selected first with priority)
         // Note: The order is created with the default signer address (ctx.signer.address())
@@ -957,7 +990,7 @@ mod tests {
         let prioritized_orders = prioritize_commitment_orders(
             test_orders,
             OrderCommitmentPriority::ShortestExpiry,
-            Some(&priority_addresses),
+            Some(&priority_levels),
             None,
         );
 
@@ -965,6 +998,68 @@ mod tests {
         assert_eq!(prioritized_orders[0].request.lock_expires_at(), current_timestamp + 500);
         assert_eq!(prioritized_orders[0].request.client_address(), priority_addr);
         assert_eq!(prioritized_orders[1].request.lock_expires_at(), current_timestamp + 100);
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_priority_level_outranks_lower_level() {
+        let ctx = PricerTestCtxBuilder::default().build().await;
+        let base_time = now_timestamp();
+
+        let high_addr = alloy::primitives::Address::from([0xAA; 20]);
+        let low_addr = alloy::primitives::Address::from([0xBB; 20]);
+        let regular_addr = alloy::primitives::Address::from([0x42; 20]);
+
+        // high_addr is level 100; low_addr carries the default level.
+        let priority_levels = levels([(high_addr, 100), (low_addr, DEFAULT_PRIORITY_LEVEL)]);
+
+        // Regular order: shortest expiry — would rank first under ShortestExpiry mode.
+        let mut regular_order = ctx
+            .generate_next_order(OrderParams {
+                order_index: 0,
+                bidding_start: base_time,
+                lock_timeout: 100,
+                ..Default::default()
+            })
+            .await;
+        regular_order.request.id =
+            boundless_market::contracts::RequestId::new(regular_addr, 0).into();
+
+        // Low-level priority order: medium expiry.
+        let mut low_order = ctx
+            .generate_next_order(OrderParams {
+                order_index: 1,
+                bidding_start: base_time,
+                lock_timeout: 300,
+                ..Default::default()
+            })
+            .await;
+        low_order.request.id = boundless_market::contracts::RequestId::new(low_addr, 1).into();
+
+        // High-level priority order: longest expiry — the mode alone would rank it last.
+        let mut high_order = ctx
+            .generate_next_order(OrderParams {
+                order_index: 2,
+                bidding_start: base_time,
+                lock_timeout: 900,
+                ..Default::default()
+            })
+            .await;
+        high_order.request.id = boundless_market::contracts::RequestId::new(high_addr, 2).into();
+
+        let mut test_orders = vec![regular_order, low_order, high_order];
+        let selected = prioritize_orders_to_evaluate(
+            &mut test_orders,
+            OrderPricingPriority::ShortestExpiry,
+            Some(&priority_levels),
+            3,
+        );
+
+        // Level wins over the mode: the level-100 requestor is first despite the
+        // longest expiry, the level-50 requestor second, the regular order last.
+        assert_eq!(selected[0].request.client_address(), high_addr);
+        assert_eq!(selected[1].request.client_address(), low_addr);
+        assert_eq!(selected[2].request.client_address(), regular_addr);
     }
 
     #[tokio::test]
@@ -1368,7 +1463,7 @@ mod tests {
 
         let priority_addr = alloy::primitives::Address::from([0x99; 20]);
         let regular_addr = alloy::primitives::Address::from([0x42; 20]);
-        let priority_addresses = vec![priority_addr];
+        let priority_levels = levels([(priority_addr, DEFAULT_PRIORITY_LEVEL)]);
 
         let mut regular_chain1 = *ctx
             .generate_next_order(OrderParams {
@@ -1398,7 +1493,7 @@ mod tests {
         let selected = prioritize_orders_to_evaluate(
             &mut orders,
             OrderPricingPriority::ShortestExpiry,
-            Some(&priority_addresses),
+            Some(&priority_levels),
             2,
         );
 

--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -67,6 +67,9 @@
       "description": "",
       "tags": [],
       "extensions": {
+        "priority": {
+          "level": 100
+        },
         "requestEstimates": {
           "estimatedMcycleCountMin": 170,
           "estimatedMcycleCountMax": 10000,
@@ -81,6 +84,9 @@
       "description": "",
       "tags": [],
       "extensions": {
+        "priority": {
+          "level": 100
+        },
         "requestEstimates": {
           "estimatedMcycleCountMin": 170,
           "estimatedMcycleCountMax": 10000,


### PR DESCRIPTION
Priority requestors were treated as a single flat tier — ordering within the tier came only from the configured priority mode. This wires up the `PriorityExtension.level` field (already in the requestor-list schema, parsed but ignored until now) so a higher level outranks a lower one under every priority mode.

Sets `level: 100` for requestor `0x64e356256d87e5f7b36eb35eb62442386591c294` in the large priority list, ranking it above the rest of the list.