### PR TITLE
BM-3015: fix(indexer): match only ERROR-level logs in metric filters

### DIFF
--- a/infra/indexer/components/indexer-api.ts
+++ b/infra/indexer/components/indexer-api.ts
@@ -182,7 +182,7 @@ export class IndexerApi extends pulumi.ComponentResource {
         value: '1',
         defaultValue: '0',
       },
-      pattern: '?ERROR ?error ?Error',
+      pattern: '{ $.level = "ERROR" }',
     }, { dependsOn: [this.lambdaFunction], parent: this });
 
     const stackName = pulumi.getStack();

--- a/infra/indexer/components/monitor-lambda.ts
+++ b/infra/indexer/components/monitor-lambda.ts
@@ -145,7 +145,7 @@ export class MonitorLambda extends pulumi.ComponentResource {
         value: '1',
         defaultValue: '0',
       },
-      pattern: '?ERROR ?error ?Error',
+      pattern: '{ $.level = "ERROR" }',
     }, { dependsOn: [this.lambdaFunction] });
 
     const alarmActions = args.boundlessAlertsTopicArns ?? [];


### PR DESCRIPTION
Tightens the indexer-api and monitor-lambda CloudWatch metric filters to match only top-level `level=ERROR` log entries. The old `?ERROR ?error ?Error` pattern was a case-insensitive substring match and counted any log line containing the word "error" anywhere in the JSON — including INFO-level pool diagnostics like `ping on idle connection returned error`.


Changes
* `infra/indexer/components/indexer-api.ts`: filter pattern → `{ $.level = "ERROR" }`
* `infra/indexer/components/monitor-lambda.ts`: same