### PR TITLE
BM-3016: infra(distributor): bump Taiko STAKE_THRESHOLD 100 → 200

### DIFF
--- a/infra/distributor/Pulumi.l-prod-167000.yaml
+++ b/infra/distributor/Pulumi.l-prod-167000.yaml
@@ -37,7 +37,7 @@ config:
   distributor:SLACK_ALERTS_TOPIC_ARN: arn:aws:sns:us-west-2:968153779208:boundless-alerts-topic-launch
   distributor:SLASHER_KEY:
     secure: v1:K0Af69eM3IjaBdfh:RVHWgyJGtJZ41nTwr7twWdYNwAXLvpLtbVQMmUrJcameCVxIt/IWH/uTxL/3IWaO5e/GhZoLSvqbnLXDKXyrSnGKcXU+WSnumcB/1gWxfzY=
-  distributor:STAKE_THRESHOLD: "100"
+  distributor:STAKE_THRESHOLD: "200"
   distributor:STAKE_TOP_UP_AMOUNT: "300"
   distributor:BOUNDLESS_MARKET_ADDR: 0xb3f5c7b4379052eade8c7f3fa6da37fb871da28b
   distributor:SET_VERIFIER_ADDR: 0x6135DC08D14EF8a44496B009e2181426628B8ebd


### PR DESCRIPTION
- Bump `STAKE_THRESHOLD` for the Taiko (chain 167000) distributor from `100` → `200` ZKC.
- This prevents Taiko stake balances from dropping too low, which triggers alerts

