### PR TITLE
BM-3017: Add market-price buffer to requestor auto-pricing

### DIFF
--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -705,14 +705,16 @@ impl<U, D, S> ClientBuilder<U, D, S> {
 
     /// Set a custom price provider for fetching market prices.
     ///
-    /// If provided, the [OfferLayer] will use market prices (p10 and p99 percentiles)
+    /// If provided, the [OfferLayer] will use market prices (p50 and p99 percentiles)
     /// when [`OfferParams`](crate::request_builder::OfferParams) doesn't explicitly set min_price or max_price.
     ///
     /// This method allows you to use any implementation of [`PriceProvider`](crate::price_provider::PriceProvider), not just [IndexerClient].
     /// This is useful for testing with mock providers or using alternative price data sources.
     ///
-    /// If not set, the indexer URL from the [Deployment] will be used to create an [IndexerClient].
-    /// The price provider takes precedence over the deployment's indexer URL.
+    /// If not set, a provider is built from the [Deployment]'s indexer URL, or a built-in
+    /// market-pricing fallback when no indexer URL is configured — so market-based defaults
+    /// (and the market-price buffer) apply unless an explicit price is set. An explicitly set
+    /// provider takes precedence over the deployment's indexer URL.
     ///
     /// ```rust
     /// # use boundless_market::client::ClientBuilder;

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -131,6 +131,18 @@ pub(crate) fn resolve_max_price(
     })
 }
 
+/// Applies the market-price buffer to a per-cycle market price and scales by the cycle count.
+///
+/// `buffer_percentage` is a multiplier where `100` = no buffer and `115` = +15%. Multiplies
+/// before dividing to avoid truncation; any sub-wei fraction rounds down.
+pub(crate) fn buffered_market_max(
+    max_per_cycle: U256,
+    cycle_count: u64,
+    buffer_percentage: u64,
+) -> U256 {
+    max_per_cycle * U256::from(cycle_count) * U256::from(buffer_percentage) / U256::from(100)
+}
+
 struct CollateralRecommendation {
     default: U256,
     large: U256,
@@ -300,6 +312,16 @@ pub struct OfferLayerConfig {
     /// Supported proof types and their corresponding selectors.
     #[builder(setter(into), default)]
     pub supported_selectors: SupportedSelectors,
+
+    /// Multiplier applied to the market-derived max price to add headroom for
+    /// per-cycle price drift between request submission and prover lock-in.
+    ///
+    /// Expressed as a percentage where `100` = no buffer and `115` = +15%. Applied only when
+    /// `maxPrice` is sourced from the price provider — not for an explicit `max_price` in
+    /// [OfferParams], the configured [`max_price_per_cycle`](Self::max_price_per_cycle), or the
+    /// static default. The gas portion of the price is buffered separately and is unaffected.
+    #[builder(setter(strip_option), default = "Some(115)")]
+    pub market_price_buffer_multiplier_percentage: Option<u64>,
 }
 
 #[non_exhaustive]
@@ -407,6 +429,15 @@ pub struct OfferParams {
     #[clap(long)]
     #[builder(setter(strip_option, into), default)]
     pub lock_collateral: Option<Amount>,
+
+    /// Override the market-price buffer multiplier for this request.
+    ///
+    /// Expressed as a percentage where 100 = no buffer and 115 = +15%. Takes priority over the
+    /// client-wide OfferLayerConfig default. Only affects requests whose max_price is
+    /// auto-derived from the price provider.
+    #[clap(long)]
+    #[builder(setter(strip_option), default)]
+    pub market_price_buffer_multiplier_percentage: Option<u64>,
 }
 
 impl From<OfferParamsBuilder> for OfferParams {
@@ -445,6 +476,8 @@ impl OfferParams {
             lock_timeout: Some(offer.lockTimeout),
             bidding_start: Some(offer.rampUpStart),
             ramp_up_period: Some(offer.rampUpPeriod),
+            // Reconstructing an existing on-chain offer must not re-apply the buffer.
+            market_price_buffer_multiplier_percentage: None,
         }
     }
 
@@ -701,14 +734,19 @@ where
                 if let Some(cycle_count) = cycle_count {
                     match price_provider.price_percentiles().await {
                         Ok(percentiles) => {
+                            let buffer = params
+                                .market_price_buffer_multiplier_percentage
+                                .or(self.config.market_price_buffer_multiplier_percentage)
+                                .unwrap_or(100);
                             let min = U256::ZERO;
                             let max_per_cycle =
                                 percentiles.p99.min(percentiles.p50 * U256::from(2));
-                            let max = max_per_cycle * U256::from(cycle_count);
+                            let max = buffered_market_max(max_per_cycle, cycle_count, buffer);
                             tracing::debug!(
-                                "Using market prices from price provider to set max price: p50_per_cycle: {} p99_per_cycle: {} min price: {} max price: {}",
+                                "Using market prices from price provider to set max price: p50_per_cycle: {} p99_per_cycle: {} buffer: {}% min price: {} max price: {}",
                                 percentiles.p50,
                                 percentiles.p99,
+                                buffer,
                                 format_units(min, "ether")?,
                                 format_units(max, "ether")?,
                             );
@@ -1115,6 +1153,23 @@ mod tests {
                 default_max_price_per_cycle() * u(10)
             );
         }
+
+        #[test]
+        fn buffer_default_115_adds_15_percent() {
+            // 100 wei/cycle * 10 cycles * 1.15 = 1150
+            assert_eq!(buffered_market_max(u(100), 10, 115), u(1150));
+        }
+
+        #[test]
+        fn buffer_100_is_noop() {
+            assert_eq!(buffered_market_max(u(100), 10, 100), u(1000));
+        }
+
+        #[test]
+        fn buffer_rounds_down() {
+            // 10 * 1 * 115 / 100 = 11.5 -> 11 (sub-wei fraction truncated)
+            assert_eq!(buffered_market_max(u(10), 1, 115), u(11));
+        }
     }
 
     mod offer_params_into_offer {
@@ -1144,6 +1199,7 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
+                market_price_buffer_multiplier_percentage: None,
             };
             let offer = params.into_offer(None).await.unwrap();
             assert_eq!(offer.minPrice, U256::from(1_000));
@@ -1170,6 +1226,7 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
+                market_price_buffer_multiplier_percentage: None,
             };
             let offer = params.into_offer(Some(&manager)).await.unwrap();
 
@@ -1189,6 +1246,7 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
+                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(
@@ -1208,6 +1266,7 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
+                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(
@@ -1227,6 +1286,7 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
+                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -133,14 +133,18 @@ pub(crate) fn resolve_max_price(
 
 /// Applies the market-price buffer to a per-cycle market price and scales by the cycle count.
 ///
-/// `buffer_percentage` is a multiplier where `100` = no buffer and `115` = +15%. Multiplies
-/// before dividing to avoid truncation; any sub-wei fraction rounds down.
+/// `buffer_percentage` is a multiplier where `100` = no change and `115` = +15%; values below
+/// `100` reduce the price. Multiplies before dividing to avoid truncation; any sub-wei fraction
+/// rounds down.
 pub(crate) fn buffered_market_max(
     max_per_cycle: U256,
     cycle_count: u64,
-    buffer_percentage: u64,
+    buffer_percentage: u16,
 ) -> U256 {
-    max_per_cycle * U256::from(cycle_count) * U256::from(buffer_percentage) / U256::from(100)
+    max_per_cycle
+        .saturating_mul(U256::from(cycle_count))
+        .saturating_mul(U256::from(buffer_percentage))
+        / U256::from(100)
 }
 
 struct CollateralRecommendation {
@@ -313,15 +317,13 @@ pub struct OfferLayerConfig {
     #[builder(setter(into), default)]
     pub supported_selectors: SupportedSelectors,
 
-    /// Multiplier applied to the market-derived max price to add headroom for
-    /// per-cycle price drift between request submission and prover lock-in.
+    /// Percentage multiplier applied to a price-provider-derived max price, adding headroom for
+    /// price drift before lock-in: `100` leaves it unchanged, `115` adds 15%.
     ///
-    /// Expressed as a percentage where `100` = no buffer and `115` = +15%. Applied only when
-    /// `maxPrice` is sourced from the price provider — not for an explicit `max_price` in
-    /// [OfferParams], the configured [`max_price_per_cycle`](Self::max_price_per_cycle), or the
-    /// static default. The gas portion of the price is buffered separately and is unaffected.
-    #[builder(setter(strip_option), default = "Some(115)")]
-    pub market_price_buffer_multiplier_percentage: Option<u64>,
+    /// Applies only when `maxPrice` comes from the price provider (the default when no explicit
+    /// price is set), not to a params, config, or static max price. Gas is added separately.
+    #[builder(default = "115")]
+    pub market_price_buffer_multiplier_percentage: u16,
 }
 
 #[non_exhaustive]
@@ -723,10 +725,7 @@ where
                 if let Some(cycle_count) = cycle_count {
                     match price_provider.price_percentiles().await {
                         Ok(percentiles) => {
-                            let buffer = self
-                                .config
-                                .market_price_buffer_multiplier_percentage
-                                .unwrap_or(100);
+                            let buffer = self.config.market_price_buffer_multiplier_percentage;
                             let min = U256::ZERO;
                             let max_per_cycle =
                                 percentiles.p99.min(percentiles.p50 * U256::from(2));

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -429,15 +429,6 @@ pub struct OfferParams {
     #[clap(long)]
     #[builder(setter(strip_option, into), default)]
     pub lock_collateral: Option<Amount>,
-
-    /// Override the market-price buffer multiplier for this request.
-    ///
-    /// Expressed as a percentage where 100 = no buffer and 115 = +15%. Takes priority over the
-    /// client-wide OfferLayerConfig default. Only affects requests whose max_price is
-    /// auto-derived from the price provider.
-    #[clap(long)]
-    #[builder(setter(strip_option), default)]
-    pub market_price_buffer_multiplier_percentage: Option<u64>,
 }
 
 impl From<OfferParamsBuilder> for OfferParams {
@@ -476,8 +467,6 @@ impl OfferParams {
             lock_timeout: Some(offer.lockTimeout),
             bidding_start: Some(offer.rampUpStart),
             ramp_up_period: Some(offer.rampUpPeriod),
-            // Reconstructing an existing on-chain offer must not re-apply the buffer.
-            market_price_buffer_multiplier_percentage: None,
         }
     }
 
@@ -734,9 +723,9 @@ where
                 if let Some(cycle_count) = cycle_count {
                     match price_provider.price_percentiles().await {
                         Ok(percentiles) => {
-                            let buffer = params
+                            let buffer = self
+                                .config
                                 .market_price_buffer_multiplier_percentage
-                                .or(self.config.market_price_buffer_multiplier_percentage)
                                 .unwrap_or(100);
                             let min = U256::ZERO;
                             let max_per_cycle =
@@ -1199,7 +1188,6 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
-                market_price_buffer_multiplier_percentage: None,
             };
             let offer = params.into_offer(None).await.unwrap();
             assert_eq!(offer.minPrice, U256::from(1_000));
@@ -1226,7 +1214,6 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
-                market_price_buffer_multiplier_percentage: None,
             };
             let offer = params.into_offer(Some(&manager)).await.unwrap();
 
@@ -1246,7 +1233,6 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
-                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(
@@ -1266,7 +1252,6 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
-                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(
@@ -1286,7 +1271,6 @@ mod tests {
                 lock_timeout: Some(120),
                 bidding_start: Some(100),
                 ramp_up_period: Some(60),
-                market_price_buffer_multiplier_percentage: None,
             };
             let err = params.into_offer(None).await.unwrap_err();
             assert!(

--- a/crates/boundless-market/tests/e2e.rs
+++ b/crates/boundless-market/tests/e2e.rs
@@ -728,7 +728,7 @@ async fn test_client_builder_with_price_provider() {
         .with_deployment(ctx.deployment.clone())
         .with_rpc_url(Url::parse(&anvil.endpoint()).unwrap())
         .with_uploader(Some(storage.clone()))
-        .with_price_provider(Some(price_provider))
+        .with_price_provider(Some(price_provider.clone()))
         .with_downloader(HttpDownloader::default())
         .build()
         .await
@@ -744,4 +744,25 @@ async fn test_client_builder_with_price_provider() {
     assert!(
         request.offer.maxPrice >= min(price_percentiles.p99, price_percentiles.p50 * U256::from(2))
     );
+
+    // Build the same request with the market-price buffer disabled (100% = no buffer) and
+    // confirm the default +15% buffer raises maxPrice. Gas is identical between the two builds
+    // (idle anvil mines no blocks on read-only calls), so the delta is purely the proof-portion
+    // buffer.
+    let client_no_buffer = ClientBuilder::new()
+        .with_signer(ctx.customer_signer.clone())
+        .with_deployment(ctx.deployment.clone())
+        .with_rpc_url(Url::parse(&anvil.endpoint()).unwrap())
+        .with_uploader(Some(storage.clone()))
+        .with_price_provider(Some(price_provider))
+        .with_downloader(HttpDownloader::default())
+        .config_offer_layer(|c| c.market_price_buffer_multiplier_percentage(100))
+        .build()
+        .await
+        .unwrap();
+    let request_no_buffer = client_no_buffer
+        .build_request(RequestParams::new().with_program(ECHO_ELF).with_stdin(b"test"))
+        .await
+        .unwrap();
+    assert!(request.offer.maxPrice > request_no_buffer.offer.maxPrice);
 }

--- a/crates/boundless-market/tests/e2e.rs
+++ b/crates/boundless-market/tests/e2e.rs
@@ -32,7 +32,7 @@ use boundless_market::{
     indexer_client::IndexerClient,
     input::GuestEnv,
     price_provider::{PricePercentiles, PriceProviderArc},
-    request_builder::{OfferParams, RequestParams},
+    request_builder::{OfferLayerConfigBuilder, OfferParams, RequestParams},
     storage::{HttpDownloader, MockStorageUploader},
     test_helpers::create_mock_indexer_client,
 };
@@ -722,6 +722,18 @@ async fn test_client_builder_with_price_provider() {
     let mock_indexer_client = IndexerClient::new(mock_indexer_url).unwrap();
     let price_provider: PriceProviderArc = Arc::new(mock_indexer_client);
 
+    // Zero the gas estimates on both builds so maxPrice is purely the (buffered) proof price.
+    // The gas portion is fetched fresh per build_request (the eth_feeHistory base-fee projection
+    // drifts even on an idle anvil) and dwarfs the buffer delta, so comparing gas-inclusive
+    // totals is non-deterministic. Isolating the proof portion makes the buffer's effect exact.
+    fn zero_gas(c: &mut OfferLayerConfigBuilder) -> &mut OfferLayerConfigBuilder {
+        c.lock_gas_estimate(0)
+            .fulfill_gas_estimate(0)
+            .fulfill_journal_gas_per_byte(0)
+            .groth16_verify_gas_estimate(0)
+            .smart_contract_sig_verify_gas_estimate(0)
+    }
+
     // Test that ClientBuilder accepts a price_provider parameter and uses it
     let client = ClientBuilder::new()
         .with_signer(ctx.customer_signer.clone())
@@ -730,6 +742,7 @@ async fn test_client_builder_with_price_provider() {
         .with_uploader(Some(storage.clone()))
         .with_price_provider(Some(price_provider.clone()))
         .with_downloader(HttpDownloader::default())
+        .config_offer_layer(zero_gas)
         .build()
         .await
         .unwrap();
@@ -745,10 +758,9 @@ async fn test_client_builder_with_price_provider() {
         request.offer.maxPrice >= min(price_percentiles.p99, price_percentiles.p50 * U256::from(2))
     );
 
-    // Build the same request with the market-price buffer disabled (100% = no buffer) and
-    // confirm the default +15% buffer raises maxPrice. Gas is identical between the two builds
-    // (idle anvil mines no blocks on read-only calls), so the delta is purely the proof-portion
-    // buffer.
+    // Build the same request with the market-price buffer disabled (100% = no buffer). With gas
+    // zeroed on both builds, maxPrice is exactly the proof portion, so the default +15% buffer
+    // makes the buffered maxPrice an exact 115/100 multiple of the no-buffer maxPrice.
     let client_no_buffer = ClientBuilder::new()
         .with_signer(ctx.customer_signer.clone())
         .with_deployment(ctx.deployment.clone())
@@ -756,7 +768,7 @@ async fn test_client_builder_with_price_provider() {
         .with_uploader(Some(storage.clone()))
         .with_price_provider(Some(price_provider))
         .with_downloader(HttpDownloader::default())
-        .config_offer_layer(|c| c.market_price_buffer_multiplier_percentage(100))
+        .config_offer_layer(|c| zero_gas(c).market_price_buffer_multiplier_percentage(100))
         .build()
         .await
         .unwrap();
@@ -764,5 +776,8 @@ async fn test_client_builder_with_price_provider() {
         .build_request(RequestParams::new().with_program(ECHO_ELF).with_stdin(b"test"))
         .await
         .unwrap();
-    assert!(request.offer.maxPrice > request_no_buffer.offer.maxPrice);
+    assert_eq!(
+        request.offer.maxPrice,
+        request_no_buffer.offer.maxPrice * U256::from(115) / U256::from(100),
+    );
 }


### PR DESCRIPTION
When a request is auto-priced (no explicit `max_price`), the gas part of `maxPrice` already gets a 2x cushion, but the proof part — `min(p99, 2·p50) × cycles` from the indexer — gets none. That's just a snapshot of recent fills, so if the per-cycle market drifts up between submitting and a prover actually locking, the request can sit there unlocked until it expires. Every comparable "set a max, let someone fill it" system keeps some headroom here (ethers does 2x on gas, 1inch Fusion ~2.3% on the swap); we had zero on the proof side.

This adds a configurable buffer on the market-derived max price, default +15%.

**Heads-up, this is the default path, not opt-in.** `ClientBuilder::build()` always attaches a price provider (deployment indexer, or a built-in market-pricing fallback), so any auto-priced request without an explicit price now authorizes ~15% more than before. That's the intent — it's what lets requests lock through price drift — but worth flagging for spend expectations on the CLI default and order-generators without a `--max-price` flag.

A few choices worth calling out:

- **Market price only.** Not applied to an explicit `--max-price` (taken verbatim, like today), the configured `max_price_per_cycle` (that's a deliberate ceiling — pushing it past what you said you'd pay is wrong), or the static fallback (already ~p99). The market estimate is the only piece that actually drifts.
- **15% rather than 10%.** Per-cycle proof prices swing more than ETH gas in % terms and a request can sit minutes before lock, so a bit more than the usual liquid-market cushion.
- **Lives on `OfferLayerConfig`,** next to `max_price_per_cycle`. It's a pricing-strategy knob, not an `Offer` field, so it stays off `OfferParams`.

Gas buffering, min price, timeouts and collateral are untouched.

Tests: unit tests for the buffer math, and the price-provider e2e asserts the default buffer makes `maxPrice` exactly 115/100 of the un-buffered price.
