### PR TITLE
BM-3018: Trim l-prod-8453 OGs + alarm tune

### DIFF
--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -297,11 +297,10 @@ export const alarmConfig: ChainStageAlarms = {
           ],
           successRate: [
             {
-              // Since current submit every 5 mins, this is >= 2 failures an hour
-              description: "less than 50% success rate for two 30 minute periods in 2 hours from og_offchain",
+              description: "less than 50% success rate for two 60 minute periods in 4 hours from og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
-                period: 1800
+                period: 3600
               },
               alarmConfig: {
                 threshold: 0.50,
@@ -332,10 +331,10 @@ export const alarmConfig: ChainStageAlarms = {
             //   }
             // },
             {
-              description: "no submitted orders in 30 minutes from og_onchain",
+              description: "no submitted orders in 60 minutes from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
-                period: 1800
+                period: 3600
               },
               alarmConfig: {
                 evaluationPeriods: 1,

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -281,10 +281,10 @@ export const alarmConfig: ChainStageAlarms = {
             //   }
             // },
             {
-              description: "no submitted orders in 60 minutes from og_offchain",
+              description: "no submitted orders in 4 hours from og_offchain",
               severity: Severity.SEV2,
               metricConfig: {
-                period: 3600
+                period: 14400
               },
               alarmConfig: {
                 evaluationPeriods: 1,
@@ -331,10 +331,10 @@ export const alarmConfig: ChainStageAlarms = {
             //   }
             // },
             {
-              description: "no submitted orders in 60 minutes from og_onchain",
+              description: "no submitted orders in 4 hours from og_onchain",
               severity: Severity.SEV2,
               metricConfig: {
-                period: 3600
+                period: 14400
               },
               alarmConfig: {
                 evaluationPeriods: 1,

--- a/infra/order-generator/Pulumi.l-prod-8453.yaml
+++ b/infra/order-generator/Pulumi.l-prod-8453.yaml
@@ -38,7 +38,7 @@ config:
   order-generator-offchain:INPUT_MAX_MCYCLES: "2000"
   order-generator-offchain:LOCK_TIMEOUT: "1500"
   order-generator-offchain:RAMP_UP: "600"
-  order-generator-offchain:INTERVAL: "257"
+  order-generator-offchain:INTERVAL: "343"
   order-generator-offchain:RAMP_UP_SECONDS_PER_MCYCLE: "2"
   order-generator-offchain:SECONDS_PER_MCYCLE: "7"
   order-generator-offchain:TIMEOUT: "1500"
@@ -48,7 +48,7 @@ config:
   order-generator-onchain:AUTO_DEPOSIT: "0.015"
   order-generator-onchain:ERROR_BALANCE_BELOW: "0.005"
   order-generator-onchain:EXEC_RATE_KHZ: "1000"
-  order-generator-onchain:INTERVAL: "314"
+  order-generator-onchain:INTERVAL: "419"
   order-generator-onchain:INPUT_MIN_MCYCLES: "1000"
   order-generator-onchain:INPUT_MAX_MCYCLES: "4000"
   order-generator-onchain:LOCK_TIMEOUT: "2100"
@@ -69,8 +69,9 @@ config:
   order-generator-random-requestor:SECONDS_PER_MCYCLE: "7"
   order-generator-random-requestor:WARN_BALANCE_BELOW: "0.01"
   order-generator-random-requestor:ERROR_BALANCE_BELOW: "0.005"
-  order-generator-random-requestor:PRIVATE_KEY:
-    secure: v1:ghvpsT1eWQ22F33+:EMpFbZJALPWfvZUYgN0L3my543BcCTMILXuwzZ4Zch0JYWyCwqLcWXa8sGXsNghlKQRWQwUQjo3gGFE1KACtPtum4iMZVeMbyvTIGXRBdis=
+  # Random requestor is disabled for now
+  # order-generator-random-requestor:PRIVATE_KEY:
+  #   secure: v1:ghvpsT1eWQ22F33+:EMpFbZJALPWfvZUYgN0L3my543BcCTMILXuwzZ4Zch0JYWyCwqLcWXa8sGXsNghlKQRWQwUQjo3gGFE1KACtPtum4iMZVeMbyvTIGXRBdis=
   order-generator-base:INDEXER_URL:
     secure: v1:3rJFVGvhgg2ISY0C:JxAroph0jMguR18XNxUkHwWtJn/Ynnglr4OKbbB5/rf6gZxAqXRxNEpki3eR5ZOh+0bIDLWf
   order-generator-evm-requestor:MAX_OUTSTANDING_REQUESTS: "30"
@@ -86,8 +87,9 @@ config:
   order-generator-evm-requestor:RAMP_UP_SECONDS_PER_MCYCLE: "2"
   order-generator-evm-requestor:SECONDS_PER_MCYCLE: "7"
   order-generator-evm-requestor:WARN_BALANCE_BELOW: "0.01"
-  order-generator-evm-requestor:PRIVATE_KEY:
-    secure: v1:+q8g0qby20fDIvXt:EuJ7qrjSDM+aAW2zYNwUzj2SKDV8oRuZv4REHXZY2lMPRiR9uP3zELb20x29dHrIKXsCwF+ZQs263ZarnvGxPSMEUhrg0P02U5GXa/a5i3NqHg==
+  # EVM requestor is disabled for now
+  # order-generator-evm-requestor:PRIVATE_KEY:
+  #   secure: v1:+q8g0qby20fDIvXt:EuJ7qrjSDM+aAW2zYNwUzj2SKDV8oRuZv4REHXZY2lMPRiR9uP3zELb20x29dHrIKXsCwF+ZQs263ZarnvGxPSMEUhrg0P02U5GXa/a5i3NqHg==
   order-generator:CI_CACHE_SECRET:
     secure: v1:5zmotA0iEUXyWxNQ:A8xd8X44V4tjVyxRR1r9PH+PhkACv6WxGdnt1B8Apk4IE/xyzm7eIS29qBKhyLiJQspuVyMYYrj7hRa3GhM0ncrHyQGk33LhOzy31O9hetxw65xd5Q9prTYj8LWh2LrIJQEf2slSzuGCkoaacEjcC0/ESWsQATyGCgJMvptEAw==
   order-generator-load-test:PRIVATE_KEY:


### PR DESCRIPTION
- Drop `random-requestor` and `evm-requestor` from `l-prod-8453` (commented out their `PRIVATE_KEY` configs).
- Cut onchain/offchain order generator rates by 25% (intervals 314→419s, 257→343s).
- Widen og_onchain `submissionRate` window 30min→60min for parity with og_offchain and more headroom.
- Widen og_offchain `successRate` window 30min→60min so the 50% threshold has enough samples per window.
- Remove stale "submit every 5 mins" comment.