### PR TITLE
Backport BM-3017 + BM-2981 to release-2.0, bump to 2.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install nextest
         run: cargo binstall -y cargo-nextest@0.9.128
@@ -266,6 +269,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install lychee
         run: cargo binstall -y lychee@0.15.1
@@ -327,6 +333,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install dprint
         run: cargo binstall -y dprint@0.47.2

--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -107,6 +107,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: install cargo-sort
         run: cargo binstall -y cargo-sort@2

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -78,6 +78,9 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-binstall
+          # Pinned: cargo-binstall v1.19.x pulls cargo-platform 0.3.3 which requires rustc 1.91,
+          # but rust-toolchain.toml is on 1.89. Bump together with any toolchain bump.
+          version: "1.17.9"
 
       - name: Install cargo-sort
         run: cargo binstall -y cargo-sort@2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives 1.4.1",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-bench"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-distributor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-indexer"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-order-generator"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-povw"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-rewards"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2977,7 +2977,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-slasher"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -3001,7 +3001,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives 1.4.1",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "broker-stress"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5931,7 +5931,7 @@ checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
 name = "indexer-api"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5965,7 +5965,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-monitor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5984,7 +5984,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-redrive"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "lambda_runtime",
@@ -7433,7 +7433,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "order-stream"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -8404,7 +8404,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2 0.10.9",
  "siwe",
@@ -9834,6 +9835,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 exclude = ["examples/echo-unpinned"]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 homepage = "https://boundless.network/"
 repository = "https://github.com/boundless-xyz/boundless/"
@@ -57,9 +57,9 @@ bonsai-sdk = { git = "https://github.com/risc0/risc0", branch = "flaub/shrink-bi
     "shrink_bitvm2",
 ] }
 borsh = "1.5"
-boundless-assessor = { version = "2.0.0", path = "crates/assessor" }
+boundless-assessor = { version = "2.0.1", path = "crates/assessor" }
 boundless-cli = { path = "crates/boundless-cli" }
-boundless-market = { version = "2.0.0", path = "crates/boundless-market" }
+boundless-market = { version = "2.0.1", path = "crates/boundless-market" }
 boundless-povw = { path = "crates/povw" }
 boundless-rewards = { path = "crates/rewards" }
 boundless-test-utils = { path = "crates/test-utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ risc0-zkp = { version = "3.0.3" }
 risc0-zkvm = { version = "3.0.4", default-features = false }
 rmp-serde = { version = "1.3" }
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 serde_yaml = "0.9"
 sha2 = { version = "0.10" }

--- a/bento/Cargo.lock
+++ b/bento/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2071,6 +2071,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -6694,7 +6695,7 @@ dependencies = [
  "security-framework 3.3.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6991,6 +6992,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -34,6 +34,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true, optional = true }
 risc0-zkvm = { workspace = true, features = ["std"] }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/boundless-market/src/client.rs
+++ b/crates/boundless-market/src/client.rs
@@ -705,14 +705,16 @@ impl<U, D, S> ClientBuilder<U, D, S> {
 
     /// Set a custom price provider for fetching market prices.
     ///
-    /// If provided, the [OfferLayer] will use market prices (p10 and p99 percentiles)
+    /// If provided, the [OfferLayer] will use market prices (p50 and p99 percentiles)
     /// when [`OfferParams`](crate::request_builder::OfferParams) doesn't explicitly set min_price or max_price.
     ///
     /// This method allows you to use any implementation of [`PriceProvider`](crate::price_provider::PriceProvider), not just [IndexerClient].
     /// This is useful for testing with mock providers or using alternative price data sources.
     ///
-    /// If not set, the indexer URL from the [Deployment] will be used to create an [IndexerClient].
-    /// The price provider takes precedence over the deployment's indexer URL.
+    /// If not set, a provider is built from the [Deployment]'s indexer URL, or a built-in
+    /// market-pricing fallback when no indexer URL is configured — so market-based defaults
+    /// (and the market-price buffer) apply unless an explicit price is set. An explicitly set
+    /// provider takes precedence over the deployment's indexer URL.
     ///
     /// ```rust
     /// # use boundless_market::client::ClientBuilder;

--- a/crates/boundless-market/src/input.rs
+++ b/crates/boundless-market/src/input.rs
@@ -87,6 +87,7 @@ pub struct GuestEnv {
     /// be provided directly). When the guest calls `env::read_slice` these are the bytes that will
     /// be read. If the guest uses `env::read`, this should be encoded using the default RISC Zero
     /// codec. [GuestEnvBuilder::write] will encode the data given using the default codec.
+    #[serde(with = "serde_bytes")]
     pub stdin: Vec<u8>,
 }
 
@@ -270,6 +271,42 @@ mod tests {
 
         let decoded_env = GuestEnv::decode(&env.encode()?)?;
         assert_eq!(env, decoded_env);
+        Ok(())
+    }
+
+    #[test]
+    fn test_stdin_wire_compat() -> Result<(), Error> {
+        // Pre-patch shape of GuestEnv (no #[serde(with = "serde_bytes")]) with
+        // its own encode/decode mirroring GuestEnv's, so the test reads as a
+        // symmetric cross-decode.
+        #[derive(Serialize, Deserialize)]
+        struct LegacyGuestEnv {
+            stdin: Vec<u8>,
+        }
+        impl LegacyGuestEnv {
+            fn encode(&self) -> Result<Vec<u8>, Error> {
+                let mut encoded = Vec::<u8>::new();
+                encoded.push(Version::V1.into());
+                encoded.extend_from_slice(&rmp_serde::to_vec_named(&self)?);
+                Ok(encoded)
+            }
+            fn decode(bytes: &[u8]) -> Result<Self, Error> {
+                Ok(rmp_serde::from_read(&bytes[1..])?)
+            }
+        }
+
+        let payload: Vec<u8> = (0..=255u8).collect();
+
+        // Legacy wire -> current decoder.
+        let legacy_wire = LegacyGuestEnv { stdin: payload.clone() }.encode()?;
+        assert_eq!(legacy_wire[8], 0xdc, "legacy form: MessagePack array16 marker");
+        assert_eq!(GuestEnv::decode(&legacy_wire)?.stdin, payload);
+
+        // Current wire -> legacy decoder.
+        let current_wire = GuestEnv::builder().write_slice(&payload).build_vec()?;
+        assert_eq!(current_wire[8], 0xc5, "current form: MessagePack bin16 marker");
+        assert_eq!(LegacyGuestEnv::decode(&current_wire)?.stdin, payload);
+
         Ok(())
     }
 }

--- a/crates/boundless-market/src/request_builder/offer_layer.rs
+++ b/crates/boundless-market/src/request_builder/offer_layer.rs
@@ -131,6 +131,22 @@ pub(crate) fn resolve_max_price(
     })
 }
 
+/// Applies the market-price buffer to a per-cycle market price and scales by the cycle count.
+///
+/// `buffer_percentage` is a multiplier where `100` = no change and `115` = +15%; values below
+/// `100` reduce the price. Multiplies before dividing to avoid truncation; any sub-wei fraction
+/// rounds down.
+pub(crate) fn buffered_market_max(
+    max_per_cycle: U256,
+    cycle_count: u64,
+    buffer_percentage: u16,
+) -> U256 {
+    max_per_cycle
+        .saturating_mul(U256::from(cycle_count))
+        .saturating_mul(U256::from(buffer_percentage))
+        / U256::from(100)
+}
+
 struct CollateralRecommendation {
     default: U256,
     large: U256,
@@ -300,6 +316,14 @@ pub struct OfferLayerConfig {
     /// Supported proof types and their corresponding selectors.
     #[builder(setter(into), default)]
     pub supported_selectors: SupportedSelectors,
+
+    /// Percentage multiplier applied to a price-provider-derived max price, adding headroom for
+    /// price drift before lock-in: `100` leaves it unchanged, `115` adds 15%.
+    ///
+    /// Applies only when `maxPrice` comes from the price provider (the default when no explicit
+    /// price is set), not to a params, config, or static max price. Gas is added separately.
+    #[builder(default = "115")]
+    pub market_price_buffer_multiplier_percentage: u16,
 }
 
 #[non_exhaustive]
@@ -701,14 +725,16 @@ where
                 if let Some(cycle_count) = cycle_count {
                     match price_provider.price_percentiles().await {
                         Ok(percentiles) => {
+                            let buffer = self.config.market_price_buffer_multiplier_percentage;
                             let min = U256::ZERO;
                             let max_per_cycle =
                                 percentiles.p99.min(percentiles.p50 * U256::from(2));
-                            let max = max_per_cycle * U256::from(cycle_count);
+                            let max = buffered_market_max(max_per_cycle, cycle_count, buffer);
                             tracing::debug!(
-                                "Using market prices from price provider to set max price: p50_per_cycle: {} p99_per_cycle: {} min price: {} max price: {}",
+                                "Using market prices from price provider to set max price: p50_per_cycle: {} p99_per_cycle: {} buffer: {}% min price: {} max price: {}",
                                 percentiles.p50,
                                 percentiles.p99,
+                                buffer,
                                 format_units(min, "ether")?,
                                 format_units(max, "ether")?,
                             );
@@ -1114,6 +1140,23 @@ mod tests {
                 resolve_max_price(None, None, None, Some(10)),
                 default_max_price_per_cycle() * u(10)
             );
+        }
+
+        #[test]
+        fn buffer_default_115_adds_15_percent() {
+            // 100 wei/cycle * 10 cycles * 1.15 = 1150
+            assert_eq!(buffered_market_max(u(100), 10, 115), u(1150));
+        }
+
+        #[test]
+        fn buffer_100_is_noop() {
+            assert_eq!(buffered_market_max(u(100), 10, 100), u(1000));
+        }
+
+        #[test]
+        fn buffer_rounds_down() {
+            // 10 * 1 * 115 / 100 = 11.5 -> 11 (sub-wei fraction truncated)
+            assert_eq!(buffered_market_max(u(10), 1, 115), u(11));
         }
     }
 

--- a/crates/boundless-market/tests/e2e.rs
+++ b/crates/boundless-market/tests/e2e.rs
@@ -32,7 +32,7 @@ use boundless_market::{
     indexer_client::IndexerClient,
     input::GuestEnv,
     price_provider::{PricePercentiles, PriceProviderArc},
-    request_builder::{OfferParams, RequestParams},
+    request_builder::{OfferLayerConfigBuilder, OfferParams, RequestParams},
     storage::{HttpDownloader, MockStorageUploader},
     test_helpers::create_mock_indexer_client,
 };
@@ -722,14 +722,27 @@ async fn test_client_builder_with_price_provider() {
     let mock_indexer_client = IndexerClient::new(mock_indexer_url).unwrap();
     let price_provider: PriceProviderArc = Arc::new(mock_indexer_client);
 
+    // Zero the gas estimates on both builds so maxPrice is purely the (buffered) proof price.
+    // The gas portion is fetched fresh per build_request (the eth_feeHistory base-fee projection
+    // drifts even on an idle anvil) and dwarfs the buffer delta, so comparing gas-inclusive
+    // totals is non-deterministic. Isolating the proof portion makes the buffer's effect exact.
+    fn zero_gas(c: &mut OfferLayerConfigBuilder) -> &mut OfferLayerConfigBuilder {
+        c.lock_gas_estimate(0)
+            .fulfill_gas_estimate(0)
+            .fulfill_journal_gas_per_byte(0)
+            .groth16_verify_gas_estimate(0)
+            .smart_contract_sig_verify_gas_estimate(0)
+    }
+
     // Test that ClientBuilder accepts a price_provider parameter and uses it
     let client = ClientBuilder::new()
         .with_signer(ctx.customer_signer.clone())
         .with_deployment(ctx.deployment.clone())
         .with_rpc_url(Url::parse(&anvil.endpoint()).unwrap())
         .with_uploader(Some(storage.clone()))
-        .with_price_provider(Some(price_provider))
+        .with_price_provider(Some(price_provider.clone()))
         .with_downloader(HttpDownloader::default())
+        .config_offer_layer(zero_gas)
         .build()
         .await
         .unwrap();
@@ -743,5 +756,28 @@ async fn test_client_builder_with_price_provider() {
     assert!(request.offer.minPrice == U256::ZERO);
     assert!(
         request.offer.maxPrice >= min(price_percentiles.p99, price_percentiles.p50 * U256::from(2))
+    );
+
+    // Build the same request with the market-price buffer disabled (100% = no buffer). With gas
+    // zeroed on both builds, maxPrice is exactly the proof portion, so the default +15% buffer
+    // makes the buffered maxPrice an exact 115/100 multiple of the no-buffer maxPrice.
+    let client_no_buffer = ClientBuilder::new()
+        .with_signer(ctx.customer_signer.clone())
+        .with_deployment(ctx.deployment.clone())
+        .with_rpc_url(Url::parse(&anvil.endpoint()).unwrap())
+        .with_uploader(Some(storage.clone()))
+        .with_price_provider(Some(price_provider))
+        .with_downloader(HttpDownloader::default())
+        .config_offer_layer(|c| zero_gas(c).market_price_buffer_multiplier_percentage(100))
+        .build()
+        .await
+        .unwrap();
+    let request_no_buffer = client_no_buffer
+        .build_request(RequestParams::new().with_program(ECHO_ELF).with_stdin(b"test"))
+        .await
+        .unwrap();
+    assert_eq!(
+        request.offer.maxPrice,
+        request_no_buffer.offer.maxPrice * U256::from(115) / U256::from(100),
     );
 }

--- a/crates/guest/assessor/assessor-guest/Cargo.lock
+++ b/crates/guest/assessor/assessor-guest/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -1809,6 +1809,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -4361,7 +4362,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5105,7 +5106,7 @@ dependencies = [
  "security-framework 3.3.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5324,6 +5325,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6352,7 +6363,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/examples/blake3-groth16/Cargo.lock
+++ b/examples/blake3-groth16/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2156,6 +2156,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2175,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2196,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2209,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3862,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3880,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6113,7 +6114,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6867,7 +6868,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7183,6 +7184,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/composition/Cargo.lock
+++ b/examples/composition/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2169,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2203,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3864,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3882,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6125,7 +6126,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6879,7 +6880,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7195,6 +7196,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/counter-with-callback/Cargo.lock
+++ b/examples/counter-with-callback/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2169,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2203,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3862,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3880,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6123,7 +6124,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6877,7 +6878,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7193,6 +7194,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2169,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2203,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3862,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3880,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6123,7 +6124,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6877,7 +6878,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7193,6 +7194,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/request-stream/Cargo.lock
+++ b/examples/request-stream/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2078,6 +2078,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2097,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2118,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2131,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3566,7 +3567,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3584,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -5595,7 +5596,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6229,7 +6230,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6527,6 +6528,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/examples/smart-contract-requestor/Cargo.lock
+++ b/examples/smart-contract-requestor/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2150,6 +2150,7 @@ dependencies = [
  "s3s",
  "s3s-fs",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -2169,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-test-utils"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -2190,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-zkc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2203,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -3861,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "guest-assessor"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -3879,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "guest-util"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "hex",
  "risc0-build",
@@ -6122,7 +6123,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "requestor-lists"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "reqwest 0.13.1",
@@ -6876,7 +6877,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7192,6 +7193,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/justfile
+++ b/justfile
@@ -289,6 +289,7 @@ cargo-update:
 update-lockfiles:
     cargo fetch
     cd bento && cargo fetch
+    cd prover && cargo fetch
     cd crates/guest/assessor/assessor-guest && cargo fetch
     cd crates/guest/util/echo && cargo fetch
     cd crates/guest/util/identity && cargo fetch

--- a/prover/Cargo.lock
+++ b/prover/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "blake3_groth16"
-version = "1.5.0-alpha.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "boundless-market"
-version = "1.5.0-alpha.0"
+version = "2.0.1"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -2057,6 +2057,7 @@ dependencies = [
  "risc0-zkvm",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sha2",
  "siwe",
@@ -3835,7 +3836,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5339,7 +5340,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -5377,7 +5378,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6638,6 +6639,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]


### PR DESCRIPTION
  Backports two `boundless-market` fixes from `main` onto `release-2.0` and bumps the workspace version to `2.0.1`.

  | Commit | PR | Change |
  |--------|-----|--------|
  | BM-3017 | #2018 | Add market-price buffer to requestor auto-pricing |
  | BM-2981 | #1993 | Encode `GuestEnv::stdin` as MessagePack `bin` |
  | — | — | Bump workspace version `2.0.0` → `2.0.1` |
