### PR TITLE
BM-3026: Persist Prover object store across container recreation

### DIFF
--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -243,6 +243,10 @@ services:
 
     environment:
       <<: *base-environment
+      STORAGE_DIR: /app/data/object_store
+
+    volumes:
+      - object-store-data:/app/data/object_store
 
     ports:
       - "8081:8081"
@@ -348,4 +352,5 @@ volumes:
   broker-data:
   caddy-data:
   caddy-config:
+  object-store-data:
   # broker2-data:


### PR DESCRIPTION
In the redis-only prover stack (`prover-compose.yml`), the object store (`--storage-dir`) lived in the `rest_api` container's ephemeral layer with no volume. Any recreation of `rest_api` (`down`, `up --force-recreate`, redeploy) silently wiped it — including PoVW **work receipts** not yet consumed by the mining-submit flow. 