### PR TITLE
INF-51: infra: point kailua-batch pipeline at main branch

### DIFF
--- a/infra/pipelines/pipelines/l-kailua-batch.ts
+++ b/infra/pipelines/pipelines/l-kailua-batch.ts
@@ -16,8 +16,7 @@ const config: LaunchPipelineConfig = {
     appName: "kailua-batch",
     buildTimeout: 75,
     computeType: "BUILD_GENERAL1_MEDIUM",
-    // TODO: switch back to "main" after INF-51 merges
-    branchName: "zeroecco/INF-51",
+    branchName: "main",
 };
 
 /** Staging/prod env stacks (Pulumi.staging.yaml, Pulumi.prod.yaml) — not per-chain. */


### PR DESCRIPTION
## Summary
- Switch the kailua-batch CodePipeline source branch from `zeroecco/INF-51` back to `main` now that INF-51 has merged
- Remove the temporary TODO comment
