### PR TITLE
BM-3044: fix(kailua-batch): bound task runtime with timeout so hung tasks crash instead of looping forever

### DIFF
--- a/infra/kailua-batch/index.ts
+++ b/infra/kailua-batch/index.ts
@@ -243,7 +243,10 @@ export = () => {
         'START_BLOCK=$((FINALIZED - START_BLOCK_OFFSET))',
         'echo "KAILUA_RUNNING finalized=${FINALIZED} start_block=${START_BLOCK} offset=${START_BLOCK_OFFSET} block_count=${BLOCK_COUNT}"',
         `cd ${kailuaWorkdir}`,
-        'just prove "$START_BLOCK" "$BLOCK_COUNT" "$L1_RPC" "$L1_BEACON" "$L2_RPC" "$OP_NODE" "$DATA_REL" "$MODE" "$SEQ_WINDOW" "$LOG_VERBOSITY" 1 || [ $? -eq 111 ]',
+        // kailua retries RPC/contract calls forever on persistent errors, so a misconfig or stuck
+        // endpoint runs indefinitely and saturates MAX_RUNNING_TASKS. timeout kills it so the task
+        // exits non-zero and frees its slot. Override via ENV stack config (KAILUA_TASK_TIMEOUT_SECONDS).
+        'timeout -k 30 "${KAILUA_TASK_TIMEOUT_SECONDS:-1800}" just prove "$START_BLOCK" "$BLOCK_COUNT" "$L1_RPC" "$L1_BEACON" "$L2_RPC" "$OP_NODE" "$DATA_REL" "$MODE" "$SEQ_WINDOW" "$LOG_VERBOSITY" 1 || [ $? -eq 111 ]',
     ].join("\n");
 
     const containerCommand = config.get("KAILUA_COMMAND") ?? [


### PR DESCRIPTION
## Problem

kailua retries RPC/contract calls forever on persistent errors (the retry macros use unbounded backoff; `retry_res_timeout` only bounds per-attempt time, not retry count). A misconfigured market address, a wrong-chain RPC, or a rate-limiting L2 RPC causes a task to loop indefinitely, consuming one `MAX_RUNNING_TASKS` slot for hours. With `MAX_RUNNING_TASKS=4` on staging, 4 stuck tasks block all new launches — observed twice:
- Tasks stuck **19h** after a config error caused `requestIsFulfilled` to return `0x` (market address not a contract on that RPC chain).
- Tasks stuck **6h** due to L2 RPC rate-limiting (429s from trace endpoint).