### PR TITLE
BM-3045: Increase memory limit from 2G to 4G

### DIFF
--- a/prover-compose.yml
+++ b/prover-compose.yml
@@ -111,7 +111,7 @@ x-broker-common: &broker-common
     dockerfile: ${BROKER_DOCKERFILE:-dockerfiles/broker.dockerfile}
     args:
       RELEASE: ${BOUNDLESS_RELEASE:-true}
-  mem_limit: 2G
+  mem_limit: 4G
   cpus: 2
   stop_grace_period: 3h
   network_mode: host


### PR DESCRIPTION
running broker I have discovered that memory is contrained in 2.0+. Completely stock:
```
[739894.318728] Memory cgroup min protection 0kB -- low protection 0kB
...
[739894.318742] Memory cgroup out of memory: Killed process 2984896 (broker) total-vm:9147612kB, anon-rss:4133984kB, file-rss:32068kB, shmem-rss:0kB, UID:0 pgtables:16292kB oom_score_adj:0
```

This causes broker to oom and restart without logs potentially knocking off provers from the network silently.