### PR TITLE
BM-3049: revert(kailua-batch): roll prod traffic back to 2 tasks/min (incident mitigation)

### DIFF
--- a/infra/kailua-batch/Pulumi.prod.yaml
+++ b/infra/kailua-batch/Pulumi.prod.yaml
@@ -5,7 +5,7 @@ config:
   kailua-batch:BASE_STACK: organization/bootstrap/services-prod
   kailua-batch:CHAIN_ID: "10"
   kailua-batch:KAILUA_IMAGE: ghcr.io/boundless-xyz/kailua:df322d3
-  # BLOCK_COUNT per launched task: task index 0 -> 1, task index 1 -> 2, task index 2 -> 3 (see trigger Lambda)
+  # BLOCK_COUNT per launched task: task index 0 -> 1, task index 1 -> 2 (see trigger Lambda)
   kailua-batch:TASK_CPU: "8"
   kailua-batch:TASK_MEMORY_MIB: "8192"
   kailua-batch:LOG_RETENTION_DAYS: "30"
@@ -13,8 +13,8 @@ config:
   kailua-batch:ASSIGN_PUBLIC_IP: "false"
   kailua-batch:SCHEDULE_COUNT: "20"
   kailua-batch:SCHEDULE_WINDOW_MINUTES: "20"
-  kailua-batch:TASKS_PER_MINUTE: "3"
-  kailua-batch:MAX_RUNNING_TASKS: "60"
+  kailua-batch:TASKS_PER_MINUTE: "2"
+  kailua-batch:MAX_RUNNING_TASKS: "40"
   kailua-batch:SKIP_AWAIT_PROOF: "true"
   kailua-batch:KAILUA_WORKDIR: /kailua
   kailua-batch:MODE: debug


### PR DESCRIPTION
## Incident mitigation (prod kailua-batch request volume collapse since Fri 06-05)

On-chain proof-request submissions from prod kailua-batch dropped from **~3,000/day to 47–232/day** over the weekend.

**Root cause:** the L2 RPC rate-limits trace requests at **100/sec**. The 1.5× traffic bump from #2027 (`TASKS_PER_MINUTE 2→3`, `MAX_RUNNING_TASKS 40→60`) pushed concurrent proving load past that ceiling. Combined with kailua's unbounded retry-on-429, trace-request volume exploded from **2.7K/day → 100M+/day**, proving slowed **~14× (3.8min → 52min/task)**, `MAX_RUNNING_TASKS` saturated, the trigger Lambda skipped **~2,700 launches/day**, and submissions starved.

| day | L2 429s | avg task | submissions |
|---|---|---|---|
| Thu 06-04 (pre) | 2.7K | 3.8 min | 3,035 |
| Sat 06-06 | 107M | — | 232 |
| Sun 06-07 | 105M | 52 min | 47 |

## Change
Revert prod `TASKS_PER_MINUTE` `3→2` and `MAX_RUNNING_TASKS` `60→40` (pre-#2027 values) to drop concurrent trace load back under the RPC's 100/sec limit and break the retry-storm feedback loop.

## Follow-ups (separate PRs)
- Make the kailua-batch task timeout actually bound runtime (it currently doesn't — tasks ran 52 min under a 30-min cap).
- Bound kailua's retries on 429 (kailua repo) so a rate limit degrades gracefully instead of storming.
- Raise the L2-RPC trace limit / dedicated endpoint (the underlying constraint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)