### PR TITLE
BM-3050: fix(kailua-batch): make task timeout actually bound runtime (process-group kill)

### DIFF
--- a/infra/kailua-batch/index.ts
+++ b/infra/kailua-batch/index.ts
@@ -243,10 +243,21 @@ export = () => {
         'START_BLOCK=$((FINALIZED - START_BLOCK_OFFSET))',
         'echo "KAILUA_RUNNING finalized=${FINALIZED} start_block=${START_BLOCK} offset=${START_BLOCK_OFFSET} block_count=${BLOCK_COUNT}"',
         `cd ${kailuaWorkdir}`,
-        // kailua retries RPC/contract calls forever on persistent errors, so a misconfig or stuck
-        // endpoint runs indefinitely and saturates MAX_RUNNING_TASKS. timeout kills it so the task
-        // exits non-zero and frees its slot. Override via ENV stack config (KAILUA_TASK_TIMEOUT_SECONDS).
-        'timeout -k 30 "${KAILUA_TASK_TIMEOUT_SECONDS:-1800}" just prove "$START_BLOCK" "$BLOCK_COUNT" "$L1_RPC" "$L1_BEACON" "$L2_RPC" "$OP_NODE" "$DATA_REL" "$MODE" "$SEQ_WINDOW" "$LOG_VERBOSITY" 1 || [ $? -eq 111 ]',
+        // Hard wall-clock cap on proving. A plain `timeout` does NOT bound this: `just`/the prover
+        // don't propagate the signal to the whole process tree, so orphaned proving processes keep
+        // running (observed: tasks ran ~52min under a 30min `timeout`, saturating MAX_RUNNING_TASKS).
+        // Run prove in its own process group (set -m) and have a watchdog SIGTERM/SIGKILL the WHOLE
+        // group on overrun, then exit so ECS tears the task down. Exit 111 stays the success/skip
+        // code. Override the limit via ENV stack config (KAILUA_TASK_TIMEOUT_SECONDS).
+        'set -m',
+        'just prove "$START_BLOCK" "$BLOCK_COUNT" "$L1_RPC" "$L1_BEACON" "$L2_RPC" "$OP_NODE" "$DATA_REL" "$MODE" "$SEQ_WINDOW" "$LOG_VERBOSITY" 1 &',
+        'KAILUA_PROVE_PID=$!',
+        '( sleep "${KAILUA_TASK_TIMEOUT_SECONDS:-1800}"; echo "KAILUA_TASK_TIMEOUT exceeded; killing prove process group"; kill -TERM -"$KAILUA_PROVE_PID" 2>/dev/null; sleep 30; kill -KILL -"$KAILUA_PROVE_PID" 2>/dev/null ) &',
+        'KAILUA_WATCHDOG_PID=$!',
+        'KAILUA_RC=0; wait "$KAILUA_PROVE_PID" || KAILUA_RC=$?',
+        'kill "$KAILUA_WATCHDOG_PID" 2>/dev/null || true',
+        'if [ "$KAILUA_RC" -eq 111 ]; then KAILUA_RC=0; fi',
+        'exit "$KAILUA_RC"',
     ].join("\n");
 
     const containerCommand = config.get("KAILUA_COMMAND") ?? [


### PR DESCRIPTION
## Problem

The task-timeout wrapper added in #2032 does **not** bound task runtime. `timeout -k 30 ... just prove` signals only its direct child (`just`), which doesn't propagate the kill to the underlying prover process tree — so orphaned proving processes keep running. During the weekend incident, prod tasks ran **~52 min under the 30-min cap**, holding `MAX_RUNNING_TASKS` slots and starving launches.

## Fix

Run `just prove` in its own process group (`set -m`) and use a watchdog that SIGTERM-then-SIGKILLs the **whole group** on overrun, then `exit` (so ECS tears the task down and reaps any stragglers):

```sh
set -m
just prove ... 1 &
KAILUA_PROVE_PID=$!
( sleep "${KAILUA_TASK_TIMEOUT_SECONDS:-1800}"; kill -TERM -"$KAILUA_PROVE_PID"; sleep 30; kill -KILL -"$KAILUA_PROVE_PID" ) &
KAILUA_WATCHDOG_PID=$!
KAILUA_RC=0; wait "$KAILUA_PROVE_PID" || KAILUA_RC=$?
kill "$KAILUA_WATCHDOG_PID" 2>/dev/null || true
if [ "$KAILUA_RC" -eq 111 ]; then KAILUA_RC=0; fi
exit "$KAILUA_RC"
```

- `kill -<pid>` targets the whole process group, so the prover and its descendants die — not just `just`.
- Exit `111` is still treated as success (the prove "skip" code), preserved unchanged.
- Limit overridable per-stack via `KAILUA_TASK_TIMEOUT_SECONDS` (default 1800s).

## Validation (local)

| scenario | result |
|---|---|
| normal completion (exit 0) | script exits 0 |
| skip code (exit 111) | script exits 0 |
| hard error (exit 1) | script exits 1 |
| overrun (timeout) | **whole prove tree incl. spawned grandchildren killed**; script exits non-zero |
| `bash -n` | OK |

## Note
This is a guardrail. It does **not** address the root cause of the weekend incident (L2-RPC trace throttling, mitigated separately by the traffic rollback in #2035) — it just ensures a hung/slow task can no longer occupy a slot indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)