### PR TITLE
BM-3058: fix(cli): list-staking-rewards shows full claimable history

### DIFF
--- a/crates/boundless-cli/src/commands/rewards/list_staking_rewards.rs
+++ b/crates/boundless-cli/src/commands/rewards/list_staking_rewards.rs
@@ -103,9 +103,18 @@ impl RewardsListStakingRewards {
             .context("Failed to query current epoch")?
             .to::<u64>();
 
-        // Set epoch range with defaults
+        // Set epoch range with defaults. Default the start to the address's first
+        // participating epoch so the full claimable history is shown rather than a
+        // recent window, which would understate unclaimed rewards.
         let end_epoch = self.end_epoch.unwrap_or(current_epoch);
-        let start_epoch = self.start_epoch.unwrap_or_else(|| end_epoch.saturating_sub(5));
+        let start_epoch = self.start_epoch.unwrap_or_else(|| {
+            delegation_history
+                .entries
+                .iter()
+                .filter_map(|entry| entry.epoch)
+                .min()
+                .unwrap_or_else(|| end_epoch.saturating_sub(5))
+        });
 
         // Create epoch data structures
         struct EpochRewardData {

--- a/crates/boundless-cli/src/indexer_client.rs
+++ b/crates/boundless-cli/src/indexer_client.rs
@@ -202,27 +202,56 @@ impl IndexerClient {
     }
 
     /// Get reward delegation history for a specific address
-    /// Returns the epochs where this address receives delegated reward power
+    /// Returns the epochs where this address receives delegated reward power.
+    ///
+    /// The endpoint returns epochs newest-first and caps `limit` at 100, so we
+    /// walk every page. Fetching only the default first page would silently drop
+    /// older epochs and understate the address's unclaimed rewards.
     pub async fn get_reward_delegation_history(
         &self,
         address: Address,
     ) -> Result<RewardDelegationHistoryResponse> {
-        let url = self
-            .base_url
-            .join(&format!("v1/delegations/rewards/addresses/{:#x}", address))
-            .context("Failed to build URL")?;
+        const PAGE_SIZE: u32 = 100;
 
-        let response =
-            self.client.get(url.clone()).send().await.with_context(|| {
+        let mut entries = Vec::new();
+        let mut offset = 0u32;
+
+        loop {
+            let url = self
+                .base_url
+                .join(&format!(
+                    "v1/delegations/rewards/addresses/{:#x}?limit={}&offset={}",
+                    address, PAGE_SIZE, offset
+                ))
+                .context("Failed to build URL")?;
+
+            let response = self.client.get(url.clone()).send().await.with_context(|| {
                 format!("Failed to fetch reward delegation history from {}", url)
             })?;
 
-        if !response.status().is_success() {
-            bail!("API error from {}: {}", url, response.status());
+            if !response.status().is_success() {
+                bail!("API error from {}: {}", url, response.status());
+            }
+
+            let page: RewardDelegationHistoryResponse =
+                response.json().await.with_context(|| {
+                    format!("Failed to parse reward delegation history response from {}", url)
+                })?;
+
+            let page_len = page.entries.len();
+            entries.extend(page.entries);
+
+            // A short (or empty) page means we've reached the end of the history.
+            if page_len < PAGE_SIZE as usize {
+                break;
+            }
+            offset += PAGE_SIZE;
         }
 
-        response.json().await.with_context(|| {
-            format!("Failed to parse reward delegation history response from {}", url)
+        let count = entries.len() as u32;
+        Ok(RewardDelegationHistoryResponse {
+            entries,
+            pagination: PaginationInfo { count, offset: 0, limit: count },
         })
     }
 }


### PR DESCRIPTION
  ### Problem
  `boundless rewards list-staking-rewards` under-reported unclaimed staking rewards because it only looked at a recent window:

  1. `start_epoch` defaulted to `end_epoch - 5`, so by default only the last 5 epochs were shown.
  2. `get_reward_delegation_history` fetched only the **first page** of the indexer's reward-delegation endpoint (default 50 entries, newest-first), so older epochs had no data even when a wider `--start-epoch` was passed.

  The claim command (`claim-staking-rewards`) was already correct — it scans the full epoch range — so this was a reporting-only bug (no stranded funds), but it could mislead users into thinking they have less to claim.

  ### Fix
  - `get_reward_delegation_history` now pages through the entire history instead of the default first page.
  - `start_epoch` defaults to the address's first participating epoch (from the delegation history) rather than `end − 5`.

  `claim-staking-rewards` is unaffected.

  ### Follow-up (out of scope)
  - The command fetches per-epoch staking summaries sequentially in two loops, so a full-history listing now makes more indexer calls. Could be sped up by fetching each epoch once into a map. Not required for correctness.