### PR TITLE
BM-3059: fix(kailua-batch): use bash over sh; sh requires tty for job control

### DIFF
--- a/infra/kailua-batch/index.ts
+++ b/infra/kailua-batch/index.ts
@@ -289,7 +289,7 @@ export = () => {
                 cpu: taskCpu,
                 memory: taskMemory,
                 essential: true,
-                entryPoint: ["/bin/sh", "-c"],
+                entryPoint: ["/bin/bash", "-c"],
                 command: [containerCommand],
                 environment,
                 secrets: ecsSecrets,


### PR DESCRIPTION
The previous change to try to kill tasks which have timed out wasn't working because `/bin/sh` seems to require a tty for job control. Local testing with bash seems to indicate it has no such requirement, so just switch the shell running the script to `bash` instead in hopes this fixes this once and for all.

e.g. task output:
```
2026-06-13T00:00:17.733Z /bin/sh: 10: set: can't access tty; job control turned off
```