### PR TITLE
Fix Apache license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ The following `broker.toml` config field names have been removed. Update your co
 
 The [Boundless Contracts](./contracts), Boundless Assessor Library (./crates/assessor) and Boundless Assessor Guest (./crates/guest/assessor) in this repository are licensed under the Business Source License, with conversion to Apache-2.0 at a future date. See [LICENSE-BSL](./LICENSE-BSL) for a copy of the license.
 
-Other source code within this repository is licensed under the Apache-2.0 license, unless otherwise stated at the file header. See [LICENSE-Apache-2.0][./LICENSE-Apache-2.0] for a copy of the license.
+Other source code within this repository is licensed under the Apache-2.0 license, unless otherwise stated at the file header. See [LICENSE-Apache-2.0](./LICENSE-Apache-2.0) for a copy of the license.


### PR DESCRIPTION

The previous link used reference-style Markdown without a matching reference definition, so it may not render as a clickable link on GitHub. This updates it to an inline link that points directly to `LICENSE-Apache-2.0`.
