### PR TITLE
BM-3063: feat(monitoring): per-alarm opt-out for automatic alert investigation

### DIFF
--- a/infra/cw-monitoring/index.ts
+++ b/infra/cw-monitoring/index.ts
@@ -19,6 +19,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import { resolveNodes, NodeConfigEntry, MonitoredNode, AlarmConfig, LogPatternAlarmConfig } from "./nodeConfig";
 import { buildDashboardBody } from "./components/dashboard";
+import { withAutoInvestigate } from "../util";
 
 export = () => {
     const config = new pulumi.Config();
@@ -145,7 +146,7 @@ function createNodeMonitoring(node: MonitoredNode, opts: MonitoringOpts): void {
             statistic: "Minimum",
             period: ac.metricConfig.period,
             ...a,
-            alarmDescription: withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "bento-down"),
+            alarmDescription: withAutoInvestigate(withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "bento-down"), ac.autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             tags: alarmTags,
@@ -164,7 +165,7 @@ function createNodeMonitoring(node: MonitoredNode, opts: MonitoringOpts): void {
             statistic: "Minimum",
             period: ac.metricConfig.period,
             ...a,
-            alarmDescription: withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "no-containers"),
+            alarmDescription: withAutoInvestigate(withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "no-containers"), ac.autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             tags: alarmTags,
@@ -209,7 +210,7 @@ function createNodeMonitoring(node: MonitoredNode, opts: MonitoringOpts): void {
             ],
             ...a,
             treatMissingData: a.treatMissingData ?? "missing",
-            alarmDescription: withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "memory-high"),
+            alarmDescription: withAutoInvestigate(withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "memory-high"), ac.autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             tags: alarmTags,
@@ -254,7 +255,7 @@ function createNodeMonitoring(node: MonitoredNode, opts: MonitoringOpts): void {
             ],
             ...a,
             treatMissingData: a.treatMissingData ?? "missing",
-            alarmDescription: withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "disk-high"),
+            alarmDescription: withAutoInvestigate(withRunbook(`${ac.severity}: ${ac.description} on ${node.name}`, "disk-high"), ac.autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             tags: alarmTags,
@@ -312,7 +313,7 @@ function createNodeMonitoring(node: MonitoredNode, opts: MonitoringOpts): void {
                 alarmDescription: (() => {
                     const desc = `${lp.alarm.severity}: ${lp.alarm.description} on ${node.name}`;
                     const slug = getSlugFromPattern(lp.pattern);
-                    return slug ? withRunbook(desc, slug) : desc;
+                    return withAutoInvestigate(slug ? withRunbook(desc, slug) : desc, lp.alarm.autoInvestigate);
                 })(),
                 actionsEnabled: true,
                 alarmActions,

--- a/infra/cw-monitoring/nodeConfig.ts
+++ b/infra/cw-monitoring/nodeConfig.ts
@@ -19,6 +19,8 @@ import { buildProverLogPatterns, ProverType } from "./proverAlarms";
 export type AlarmConfig = {
     severity: Severity;
     description: string;
+    /** When false, suppress the automatic Ops Query investigation (default: on). */
+    autoInvestigate?: boolean;
     metricConfig: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric> & {
         /** Evaluation period in seconds. Required — no hidden defaults. */
         period: number;
@@ -46,6 +48,8 @@ export type LogPatternAlarmConfig = {
     alarm?: {
         severity: Severity;
         description: string;
+        /** When false, suppress the automatic Ops Query investigation (default: on). */
+        autoInvestigate?: boolean;
         metricConfig: { period: number };
         alarmConfig: {
             evaluationPeriods: number;

--- a/infra/cw-monitoring/proverAlarms.ts
+++ b/infra/cw-monitoring/proverAlarms.ts
@@ -63,6 +63,7 @@ export function buildProverLogPatterns(
             metricName: "low-balance-alert-eth",
             alarm: {
                 severity: Severity.SEV2,
+                autoInvestigate: false,
                 description: "low ETH balance warning in 1 hour",
                 metricConfig: { period: 3600 },
                 alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 1 },
@@ -73,6 +74,7 @@ export function buildProverLogPatterns(
             metricName: "low-balance-alert-stk",
             alarm: {
                 severity: Severity.SEV2,
+                autoInvestigate: false,
                 description: "low stake balance warning in 1 hour",
                 metricConfig: { period: 3600 },
                 alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 1 },
@@ -83,6 +85,7 @@ export function buildProverLogPatterns(
             metricName: "low-balance-alert-eth",
             alarm: {
                 severity: Severity.SEV2,
+                autoInvestigate: false,
                 description: "critical ETH balance error in 1 hour",
                 metricConfig: { period: 3600 },
                 alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 1 },
@@ -93,6 +96,7 @@ export function buildProverLogPatterns(
             metricName: "low-balance-alert-stk",
             alarm: {
                 severity: Severity.SEV2,
+                autoInvestigate: false,
                 description: "critical stake balance error in 1 hour",
                 metricConfig: { period: 3600 },
                 alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 1 },

--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -9,6 +9,8 @@ type ChainStageAlarms = {
 type AlarmConfig = {
   severity: Severity;
   description?: string;
+  /** When false, suppress the automatic Ops Query investigation (default: on). */
+  autoInvestigate?: boolean;
   metricConfig: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric> & {
     period: number;
   };

--- a/infra/indexer/components/alarms.ts
+++ b/infra/indexer/components/alarms.ts
@@ -1,5 +1,5 @@
 import * as aws from "@pulumi/aws";
-import { Severity } from "../../util";
+import { Severity, withAutoInvestigate } from "../../util";
 
 export const buildCreateMetricFns = (serviceName: string, namespace: string, alarmActions: string[]) => {
     const createMetricAlarm = ({
@@ -7,6 +7,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
         severity,
         target,
         description,
+        autoInvestigate,
         metricConfig,
         alarmConfig,
     }: {
@@ -17,6 +18,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
             address: string;
         },
         description?: string,
+        autoInvestigate?: boolean,
         metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
         alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
     }): void => {
@@ -51,7 +53,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             treatMissingData: 'notBreaching',
-            alarmDescription: `${severity}: ${description}`,
+            alarmDescription: withAutoInvestigate(`${severity}: ${description}`, autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             ...alarmConfig
@@ -67,6 +69,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
         description?: string,
         metricConfig?: Partial<aws.types.input.cloudwatch.MetricAlarmMetricQueryMetric>,
         alarmConfig?: Partial<aws.cloudwatch.MetricAlarmArgs>,
+        autoInvestigate?: boolean,
     ): void => {
         // Hash description to ensure unique alarm name
         const descriptionHash = (description ?? "")
@@ -115,7 +118,7 @@ export const buildCreateMetricFns = (serviceName: string, namespace: string, ala
             evaluationPeriods: 12,
             datapointsToAlarm: 1,
             treatMissingData: 'notBreaching',
-            alarmDescription: `${severity}: ${description}`,
+            alarmDescription: withAutoInvestigate(`${severity}: ${description}`, autoInvestigate),
             actionsEnabled: true,
             alarmActions,
             ...alarmConfig

--- a/infra/indexer/components/monitor-lambda.ts
+++ b/infra/indexer/components/monitor-lambda.ts
@@ -214,41 +214,45 @@ export class MonitorLambda extends pulumi.ComponentResource {
       const { createMetricAlarm, createSuccessRateAlarm } = buildCreateMetricFns(serviceName, marketMetricsNamespace, alarmActions);
       const { fulfilledRequests, submittedRequests, expiredRequests, slashedRequests } = chainStageAlarmConfig.topLevel;
 
-      fulfilledRequests.forEach(({ severity, description, metricConfig, alarmConfig }) => {
+      fulfilledRequests.forEach(({ severity, description, autoInvestigate, metricConfig, alarmConfig }) => {
         createMetricAlarm({
           metricName: "fulfilled_requests_number",
           severity,
           description,
+          autoInvestigate,
           metricConfig,
           alarmConfig,
         });
       });
 
-      submittedRequests.forEach(({ severity, description, metricConfig, alarmConfig }) => {
+      submittedRequests.forEach(({ severity, description, autoInvestigate, metricConfig, alarmConfig }) => {
         createMetricAlarm({
           metricName: "requests_number",
           severity,
           description,
+          autoInvestigate,
           metricConfig,
           alarmConfig,
         });
       });
 
-      expiredRequests.forEach(({ severity, description, metricConfig, alarmConfig }) => {
+      expiredRequests.forEach(({ severity, description, autoInvestigate, metricConfig, alarmConfig }) => {
         createMetricAlarm({
           metricName: "expired_requests_number",
           severity,
           description,
+          autoInvestigate,
           metricConfig,
           alarmConfig,
         });
       });
 
-      slashedRequests.forEach(({ severity, description, metricConfig, alarmConfig }) => {
+      slashedRequests.forEach(({ severity, description, autoInvestigate, metricConfig, alarmConfig }) => {
         createMetricAlarm({
           metricName: "slashed_requests_number",
           severity,
           description,
+          autoInvestigate,
           metricConfig,
           alarmConfig,
         });
@@ -260,12 +264,13 @@ export class MonitorLambda extends pulumi.ComponentResource {
         const { submissionRate, successRate, expiredRequests, name, address } = client;
         if (submissionRate != null) {
           submissionRate.forEach((cfg) => {
-            const { severity, description, metricConfig, alarmConfig } = cfg;
+            const { severity, description, autoInvestigate, metricConfig, alarmConfig } = cfg;
             createMetricAlarm({
               metricName: "requests_number_from",
               severity,
               target: { name, address },
               description,
+              autoInvestigate,
               metricConfig,
               alarmConfig,
             });
@@ -274,19 +279,20 @@ export class MonitorLambda extends pulumi.ComponentResource {
 
         if (successRate != null) {
           successRate.forEach((cfg) => {
-            const { severity, description, metricConfig, alarmConfig } = cfg;
-            createSuccessRateAlarm({ name, address }, severity, description, metricConfig, alarmConfig);
+            const { severity, description, autoInvestigate, metricConfig, alarmConfig } = cfg;
+            createSuccessRateAlarm({ name, address }, severity, description, metricConfig, alarmConfig, autoInvestigate);
           });
         };
 
         if (expiredRequests != null) {
           expiredRequests.forEach((cfg) => {
-            const { severity, description, metricConfig, alarmConfig } = cfg;
+            const { severity, description, autoInvestigate, metricConfig, alarmConfig } = cfg;
             createMetricAlarm({
               metricName: "expired_requests_number_from",
               severity,
               target: { name, address },
               description,
+              autoInvestigate,
               metricConfig,
               alarmConfig,
             });

--- a/infra/util/index.ts
+++ b/infra/util/index.ts
@@ -77,6 +77,20 @@ export enum Severity {
   SEV2 = 'SEV2',
 }
 
+// Opt-out marker for the automatic "Ops Query" Slack investigation. When an
+// alarm should NOT get an automatic first-pass investigation, this token is
+// appended to its CloudWatch alarm description. The alert-bot poller detects it
+// in the rendered Slack text and skips the investigation; the alarm still fires
+// to Slack as usual and humans can pull the bot in via @mention.
+export const NO_AUTO_INVESTIGATE_MARKER = '[no-auto-investigate]';
+
+// Appends the opt-out marker to an alarm description when autoInvestigate is
+// explicitly false. Undefined/true leaves the description unchanged, so alarms
+// are auto-investigated by default.
+export function withAutoInvestigate(description: string, autoInvestigate?: boolean): string {
+  return autoInvestigate === false ? `${description} ${NO_AUTO_INVESTIGATE_MARKER}` : description;
+}
+
 export const GHCR_IMAGE_PREFIX = 'ghcr.io/boundless-xyz/boundless';
 
 /**


### PR DESCRIPTION
## Summary

When an alarm fires, an automatic first-pass investigation runs against it. Today this is all-or-nothing — every alarm gets investigated. This PR lets an individual alarm opt out of that automatic investigation.

Setting `autoInvestigate: false` on an alarm config appends a marker to the alarm's CloudWatch description. The alert-investigation bot detects that marker in the Slack notification and skips the automatic first pass. The alarm still fires to Slack as normal.

The change is backward-compatible: alarms are investigated by default and only skip when explicitly opted out.

## Changes

- **`infra/util`** — shared `NO_AUTO_INVESTIGATE_MARKER` token and a `withAutoInvestigate(description, flag)` helper that appends the marker only when `autoInvestigate === false`.
- **cw-monitoring** — new optional `autoInvestigate` field on `AlarmConfig` / `LogPatternAlarmConfig`, wired into every alarm-description site (bento-down, no-containers, memory, disk, and the log-pattern alarms).
- **indexer** — same `autoInvestigate` field on the alarm config, threaded through `createMetricAlarm` / `createSuccessRateAlarm`.
- **Applied** — opted out the low ETH and low stake balance alarms. Their remediation is operational (top up the wallet), so there is nothing to diagnose.

## How it works

```
alarm fires ──▶ SNS ──▶ Slack notification
                          (alarm description carries the marker when opted out)
                                     │
                                     ▼
                      alert-investigation bot reads the notification
                                     │
                 marker present? ──yes──▶ skip the automatic first pass
                          │
                          no
                          ▼
                 run the automatic first-pass investigation
```

The marker is a shared contract: the same token string is hard-coded in the bot that reads alarm notifications, so the two must stay in sync.
