### PR TITLE
BM-3080: feat(broker): router-policy-aware fulfillment cost estimation

### DIFF
--- a/crates/boundless-backend/src/router.rs
+++ b/crates/boundless-backend/src/router.rs
@@ -19,6 +19,7 @@ use std::{
 
 use alloy::primitives::FixedBytes;
 use anyhow::{Context, Result};
+use boundless_market::contracts::ProofRequest;
 use boundless_market::prover_utils::{
     EvaluationLimits, EvaluationRequest, OrderPricingError, RequestEvaluation,
 };
@@ -126,6 +127,18 @@ impl BackendRouter {
         selector: FixedBytes<4>,
     ) -> Result<Option<FixedBytes<4>>> {
         self.backend_for_id(backend_id)?.assessor_group(selector)
+    }
+
+    /// Estimated on-chain gas to fulfill `request`, resolved through the backend that serves its
+    /// selector (see [`Backend::fulfillment_gas`]). Excludes journal calldata and lock gas.
+    pub fn fulfillment_gas(&self, request: &ProofRequest) -> Result<u64> {
+        self.backend_for_selector(request.requirements.selector)?.fulfillment_gas(request)
+    }
+
+    /// Extra proving cycles beyond the order's own guest cycles for `request`'s fulfillment path,
+    /// resolved through the backend that serves its selector (see [`Backend::additional_proof_cycles`]).
+    pub fn additional_proof_cycles(&self, request: &ProofRequest) -> Result<u64> {
+        self.backend_for_selector(request.requirements.selector)?.additional_proof_cycles(request)
     }
 
     pub async fn evaluate_request(
@@ -380,6 +393,14 @@ mod tests {
             Ok(None)
         }
 
+        fn fulfillment_gas(&self, _request: &ProofRequest) -> Result<u64> {
+            Ok(500_000)
+        }
+
+        fn additional_proof_cycles(&self, _request: &ProofRequest) -> Result<u64> {
+            Ok(2_000_000 + 270_000)
+        }
+
         async fn evaluate_request(
             &self,
             _request: EvaluationRequest,
@@ -510,6 +531,23 @@ mod tests {
                 compressed: false,
             })
         );
+    }
+
+    #[test]
+    fn router_forwards_cost_queries_to_serving_backend() {
+        let backend = Arc::new(MockBackend::new("mock_a", vec![selector(1)]));
+        let router =
+            BackendRouter::new().register_backend(BackendEntry::new(backend.clone())).unwrap();
+
+        // Cost queries route to the backend that serves the request's selector, which here uses
+        // the `Backend` trait defaults (real backends resolve per-path via their router policy).
+        let request = test_request(selector(1));
+        assert_eq!(router.fulfillment_gas(&request).unwrap(), 500_000);
+        assert_eq!(router.additional_proof_cycles(&request).unwrap(), 2_000_000 + 270_000);
+
+        // A selector no backend serves is an error, not a silent default.
+        assert!(router.fulfillment_gas(&test_request(selector(9))).is_err());
+        assert!(router.additional_proof_cycles(&test_request(selector(9))).is_err());
     }
 
     #[tokio::test]

--- a/crates/boundless-backend/src/types.rs
+++ b/crates/boundless-backend/src/types.rs
@@ -401,6 +401,17 @@ pub trait Backend: Send + Sync {
     /// class) — such an order can never be sealed and must not be batched.
     fn assessor_group(&self, selector: FixedBytes<4>) -> Result<Option<FixedBytes<4>>>;
 
+    /// Estimated on-chain gas to fulfill `request` via the path and assessor this backend would
+    /// actually use, resolved from its router policy. Excludes journal calldata (added separately,
+    /// selector-agnostically, during pricing) and lock gas. Required: every backend models its own
+    /// cost — there is no safe default.
+    fn fulfillment_gas(&self, request: &ProofRequest) -> Result<u64>;
+
+    /// Extra proving cycles beyond the order's own guest cycles for the path this backend would
+    /// take to fulfill `request` (direct groth16 → its groth16 wrap only; batched → assessor STARK
+    /// + set builder). Required: every backend models its own cost — there is no safe default.
+    fn additional_proof_cycles(&self, request: &ProofRequest) -> Result<u64>;
+
     async fn evaluate_request(
         &self,
         request: EvaluationRequest,

--- a/crates/boundless-cli/src/lib.rs
+++ b/crates/boundless-cli/src/lib.rs
@@ -60,9 +60,11 @@ use boundless_market::{
     NotProvided, ProofRequest,
 };
 
-/// Default URL for assessor image - matches broker config defaults
+/// Default URL for assessor image - matches broker config defaults. The assessor guest currently
+/// deployed on-chain (image id 0x6c5a03c0…56694100), matching the market `imageInfo()` and the
+/// router R0 assessor adapter's pinned `ASSESSOR_IMAGE_ID`.
 pub const ASSESSOR_DEFAULT_IMAGE_URL: &str =
-    "https://signal-artifacts.beboundless.xyz/v3/assessor/assessor_guest.bin";
+    "https://gateway.beboundless.cloud/ipfs/bafybeiauvbhinz2yqm2vbgpl2njgoyaxhuwa2vbv6gts2ajcjfkw5m4ejq";
 
 /// Default URL for set builder image - matches broker config defaults
 pub const SET_BUILDER_DEFAULT_IMAGE_URL: &str =

--- a/crates/boundless-market/src/prover_utils/config.rs
+++ b/crates/boundless-market/src/prover_utils/config.rs
@@ -110,7 +110,13 @@ pub mod defaults {
     }
 
     pub fn assessor_default_image_url() -> String {
-        "https://signal-artifacts.beboundless.xyz/v3/assessor/assessor_guest.bin".to_string()
+        // The assessor guest currently deployed on-chain (image id
+        // 0x6c5a03c0785e91bc0ad0db486004116010680a03af4e712bcca3188e56694100): matches the market
+        // `imageInfo()` and the router R0 assessor adapter's pinned `ASSESSOR_IMAGE_ID`. The broker
+        // trusts this URL without verifying it against the chain so it must track the deployed
+        // assessor; in practice the R0 STARK assessor path is not exercised while the
+        // on-chain assessor is preferred.
+        "https://gateway.beboundless.cloud/ipfs/bafybeiauvbhinz2yqm2vbgpl2njgoyaxhuwa2vbv6gts2ajcjfkw5m4ejq".to_string()
     }
 
     pub const fn max_fetch_retries() -> Option<u8> {

--- a/crates/boundless-market/src/prover_utils/mod.rs
+++ b/crates/boundless-market/src/prover_utils/mod.rs
@@ -226,6 +226,11 @@ pub struct OrderRequest {
     /// Total gas units (lock + fulfill) estimated during pricing. Stored so the pre-lock
     /// check can simply re-multiply by the current gas price instead of re-computing.
     pub gas_estimate: Option<u64>,
+    /// Extra proving cycles beyond the order's own guest cycles for the fulfillment path this
+    /// order will take (direct groth16 → its groth16 wrap only; batched → assessor STARK +
+    /// set builder). Resolved by the backend during pricing; consumed by the capacity/timing
+    /// math. `None` falls back to the configured `additional_proof_cycles`.
+    pub additional_proof_cycles: Option<u64>,
     pub expected_reward_eth: Option<U256>,
     /// Unix timestamp (seconds since epoch) of when the broker first received this
     /// request from the network.
@@ -262,6 +267,7 @@ impl OrderRequest {
             target_timestamp: None,
             expire_timestamp: None,
             gas_estimate: None,
+            additional_proof_cycles: None,
             expected_reward_eth: None,
             received_at_timestamp: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -374,6 +380,29 @@ pub trait OrderPricingContext: RequestEvaluator {
     ) -> Result<Option<OrderPricingOutcome>, OrderPricingError>;
     #[cfg(feature = "prover_utils")]
     async fn estimate_gas_to_fulfill_pending(&self) -> Result<u64, OrderPricingError>;
+
+    /// Estimated on-chain gas to fulfill this order via the path/assessor that will actually be
+    /// used, **excluding** journal calldata and callback gas (both added separately during pricing,
+    /// selector-agnostically) and lock gas.
+    ///
+    /// The default is selector-agnostic (config base + groth16-verify for groth16 selectors). The
+    /// broker overrides it to delegate to its backend, which resolves the submission path and
+    /// assessor from the router policy and applies measured per-path costs.
+    async fn estimate_gas_to_fulfill(
+        &self,
+        request: &ProofRequest,
+    ) -> Result<u64, OrderPricingError> {
+        let config = self.market_config()?;
+        Ok(estimate_fulfill_gas_default(&config, self.supported_selectors(), request).await?)
+    }
+
+    /// Extra proving cycles beyond the order's own guest cycles for this order's fulfillment
+    /// path. The default returns the configured `additional_proof_cycles`; the broker overrides
+    /// it to delegate to its backend (direct → groth16 wrap only; batched → assessor + set builder).
+    fn additional_proof_cycles(&self, _request: &ProofRequest) -> Result<u64, OrderPricingError> {
+        Ok(self.market_config()?.additional_proof_cycles)
+    }
+
     fn is_priority_requestor(&self, client_addr: &Address) -> bool;
     async fn check_available_balances(
         &self,
@@ -504,23 +533,27 @@ pub trait OrderPricingContext: RequestEvaluator {
         // gas prices may go up (or down) by the time its time to fulfill. This does not aim to be
         // a tight estimate, although improving this estimate will allow for a more profit.
         let gas_price = self.current_gas_price().await?;
+        // The path-aware base (backend-resolved) plus the universal callback gas. Journal calldata
+        // is added later, once preflight reveals its size.
+        let fulfill_gas =
+            self.estimate_gas_to_fulfill(&order.request).await? + callback_gas(&order.request)?;
         let order_gas = if lock_expired {
             // No need to include lock gas if its a lock expired order
-            U256::from(
-                estimate_gas_to_fulfill(&config, self.supported_selectors(), &order.request)
-                    .await?,
-            )
+            U256::from(fulfill_gas)
         } else {
             U256::from(
-                config.lockin_gas_estimate
-                    + self.estimate_erc1271_gas(order).await
-                    + estimate_gas_to_fulfill(&config, self.supported_selectors(), &order.request)
-                        .await?,
+                config.lockin_gas_estimate + self.estimate_erc1271_gas(order).await + fulfill_gas,
             )
         };
         // Store the gas estimate on the order so the pre-lock check can re-use it
         // instead of re-computing.
         order.gas_estimate = Some(order_gas.saturating_to::<u64>());
+        // Resolve the path-dependent proving overhead once and carry it on the order. It is
+        // consumed by the OrderCommitter, a single scheduler shared across all chains that holds
+        // no backend handle (the per-chain locker recomputes its fulfill gas from its own backend
+        // instead). The value depends only on the request's selector and the cost-model constants
+        // — both uniform across chains — so computing it once here at pricing is sufficient.
+        order.additional_proof_cycles = Some(self.additional_proof_cycles(&order.request)?);
 
         let mut order_gas_cost = U256::from(gas_price) * order_gas;
         tracing::debug!(
@@ -1106,7 +1139,22 @@ fn format_expiries(request: &ProofRequest) -> String {
     format!("Lock expires {lock_expires_delta_str}, expires {expires_delta_str}")
 }
 
-async fn estimate_gas_to_fulfill(
+/// Gas the on-chain callback consumes for a request, or 0 if it has none. This is universal
+/// across backends and fulfillment paths — just the requestor-specified `callback.gasLimit` — so
+/// it is priced at the broker/market layer (here / `fulfill_gas_units`), not inside any backend's
+/// path-aware estimate.
+pub fn callback_gas(request: &ProofRequest) -> anyhow::Result<u64> {
+    Ok(u64::try_from(
+        request
+            .requirements
+            .callback
+            .as_option()
+            .map(|callback| callback.gasLimit)
+            .unwrap_or(alloy::primitives::aliases::U96::ZERO),
+    )?)
+}
+
+async fn estimate_fulfill_gas_default(
     config: &MarketConfig,
     supported_selectors: &SupportedSelectors,
     request: &ProofRequest,

--- a/crates/broker/src/batcher/service.rs
+++ b/crates/broker/src/batcher/service.rs
@@ -2050,6 +2050,12 @@ mod tests {
         fn assessor_group(&self, selector: FixedBytes<4>) -> Result<Option<FixedBytes<4>>> {
             Ok(self.groups.get(&selector).copied().flatten())
         }
+        fn fulfillment_gas(&self, _request: &ProofRequest) -> Result<u64> {
+            Ok(500_000)
+        }
+        fn additional_proof_cycles(&self, _request: &ProofRequest) -> Result<u64> {
+            Ok(2_000_000 + 270_000)
+        }
         async fn evaluate_request(
             &self,
             _request: boundless_market::prover_utils::EvaluationRequest,

--- a/crates/broker/src/broker.rs
+++ b/crates/broker/src/broker.rs
@@ -641,7 +641,7 @@ impl Broker {
             gas_priority_mode.clone(),
             gas_estimation_priority_mode,
             erc1271_gas_cache,
-            backend_router.supported_selectors(),
+            backend_router.clone(),
             self.args.listen_only,
             chain_id,
             proving_completion_tx.clone(),

--- a/crates/broker/src/order_committer/service.rs
+++ b/crates/broker/src/order_committer/service.rs
@@ -183,7 +183,6 @@ impl OrderCommitter {
     fn estimate_prover_available_at(
         in_flight: &HashMap<String, InFlightOrder>,
         peak_prove_khz: u64,
-        additional_proof_cycles: u64,
     ) -> u64 {
         let now = now_timestamp();
 
@@ -193,7 +192,7 @@ impl OrderCommitter {
 
         let total_committed_cycles: u64 = in_flight
             .values()
-            .filter_map(|o| o.total_cycles.map(|c| c + additional_proof_cycles))
+            .filter_map(|o| o.total_cycles.map(|c| c + o.additional_proof_cycles))
             .sum();
 
         let started_proving_at =
@@ -283,11 +282,8 @@ impl OrderCommitter {
         }
 
         if let Some(peak_prove_khz) = committer_config.peak_prove_khz {
-            let mut prover_available_at = Self::estimate_prover_available_at(
-                in_flight,
-                peak_prove_khz,
-                committer_config.additional_proof_cycles,
-            );
+            let mut prover_available_at =
+                Self::estimate_prover_available_at(in_flight, peak_prove_khz);
 
             let now = now_timestamp();
             let mut kept = Vec::with_capacity(selected.len());
@@ -297,7 +293,10 @@ impl OrderCommitter {
                     continue;
                 };
 
-                let total_cycles = order_cycles + committer_config.additional_proof_cycles;
+                let total_cycles = order_cycles
+                    + order
+                        .additional_proof_cycles
+                        .unwrap_or(committer_config.additional_proof_cycles);
                 let proof_time_seconds = total_cycles.div_ceil(1_000).div_ceil(peak_prove_khz);
                 let completion_time = prover_available_at + proof_time_seconds;
                 let expiration = order.expiry();
@@ -345,6 +344,8 @@ impl OrderCommitter {
             let order_id = order.id();
             let chain_id = order.chain_id;
             let total_cycles = order.total_cycles;
+            let additional_proof_cycles =
+                order.additional_proof_cycles.unwrap_or(committer_config.additional_proof_cycles);
 
             let Some(locker_tx) = self.locker_dispatchers.get(&chain_id) else {
                 tracing::warn!(
@@ -359,6 +360,7 @@ impl OrderCommitter {
                 InFlightOrder {
                     dispatched_at: Instant::now(),
                     total_cycles,
+                    additional_proof_cycles,
                     proving_started_at: Some(now_timestamp()),
                 },
             );
@@ -990,6 +992,7 @@ mod tests {
             InFlightOrder {
                 dispatched_at: Instant::now() - Duration::from_secs(8000),
                 total_cycles: Some(1_000_000),
+                additional_proof_cycles: 0,
                 proving_started_at: Some(now_timestamp().saturating_sub(8000)),
             },
         );
@@ -998,6 +1001,7 @@ mod tests {
             InFlightOrder {
                 dispatched_at: Instant::now(),
                 total_cycles: Some(1_000_000),
+                additional_proof_cycles: 0,
                 proving_started_at: Some(now_timestamp()),
             },
         );

--- a/crates/broker/src/order_committer/state.rs
+++ b/crates/broker/src/order_committer/state.rs
@@ -23,6 +23,9 @@ use crate::config::OrderCommitmentPriority;
 pub(super) struct InFlightOrder {
     pub(super) dispatched_at: Instant,
     pub(super) total_cycles: Option<u64>,
+    /// Path-aware proving overhead for this order, resolved during pricing (falls back to the
+    /// committer config default). Summed with `total_cycles` for capacity/timing estimates.
+    pub(super) additional_proof_cycles: u64,
     pub(super) proving_started_at: Option<u64>,
 }
 

--- a/crates/broker/src/order_locker/service.rs
+++ b/crates/broker/src/order_locker/service.rs
@@ -48,6 +48,7 @@ use alloy::{
     providers::{Provider, WalletProvider},
 };
 use anyhow::{Context, Result};
+use boundless_backend::BackendRouter;
 use boundless_market::{
     contracts::{
         boundless_market::{BoundlessMarketService, MarketError},
@@ -55,7 +56,6 @@ use boundless_market::{
         RequestStatus, TxnErr,
     },
     dynamic_gas_filler::PriorityMode,
-    selector::SupportedSelectors,
 };
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::mpsc;
@@ -66,11 +66,12 @@ use super::types::{CapacityResult, OrderCommitmentMeta, OrderLockerConfig, RpcRe
 
 fn estimate_proving_time_no_load(
     order_cycles: Option<u64>,
+    additional_proof_cycles: u64,
     config: &OrderLockerConfig,
 ) -> Option<u64> {
     let cycles = order_cycles?;
     let peak_prove_khz = config.peak_prove_khz?;
-    let total = cycles + config.additional_proof_cycles;
+    let total = cycles + additional_proof_cycles;
     Some(total.div_ceil(1_000).div_ceil(peak_prove_khz))
 }
 
@@ -89,7 +90,8 @@ pub struct OrderLocker<P> {
     provider: Arc<P>,
     prover_addr: Address,
     priced_order_rx: SharedReceiver<Box<OrderRequest>>,
-    supported_selectors: SupportedSelectors,
+    /// Resolves the path-aware fulfill-gas base per order (the broker stays selector-agnostic).
+    backend: Arc<BackendRouter>,
     erc1271_gas_cache: Erc1271GasCache,
     rpc_retry_config: RpcRetryConfig,
     gas_priority_mode: Arc<tokio::sync::RwLock<PriorityMode>>,
@@ -118,7 +120,7 @@ where
         gas_priority_mode: Arc<tokio::sync::RwLock<PriorityMode>>,
         gas_estimation_priority_mode: Arc<tokio::sync::RwLock<PriorityMode>>,
         erc1271_gas_cache: Erc1271GasCache,
-        supported_selectors: SupportedSelectors,
+        backend: Arc<BackendRouter>,
         listen_only: bool,
         chain_id: u64,
         proving_completion_tx: mpsc::Sender<CommitmentComplete>,
@@ -159,7 +161,7 @@ where
             provider,
             prover_addr,
             priced_order_rx: priced_orders_rx,
-            supported_selectors,
+            backend,
             erc1271_gas_cache,
             rpc_retry_config,
             gas_priority_mode,
@@ -366,7 +368,11 @@ where
             }
         };
 
-        let no_load = estimate_proving_time_no_load(order.total_cycles, config);
+        let no_load = estimate_proving_time_no_load(
+            order.total_cycles,
+            order.additional_proof_cycles.unwrap_or(config.additional_proof_cycles),
+            config,
+        );
         let monitor_wait =
             order.priced_at_timestamp.map(|t| now_timestamp().saturating_sub(t) * 1000);
         let pending = 0u32;
@@ -636,7 +642,15 @@ where
         order: &OrderRequest,
         gas_price: u128,
     ) -> Result<U256, OrderLockerErr> {
-        // Calculate gas units needed for this order (lock + fulfill)
+        // Calculate gas units needed for this order (lock + fulfill). The path-aware fulfill base
+        // is resolved by the backend that serves the order's selector.
+        let fulfill_base = self.backend.fulfillment_gas(&order.request)?;
+        let fulfill_gas = utils::fulfill_gas_units(
+            fulfill_base,
+            &self.config,
+            &order.request,
+            order.journal_bytes,
+        )?;
         let order_gas_units = if order.fulfillment_type == FulfillmentType::LockAndFulfill {
             U256::from(
                 utils::estimate_gas_to_lock(
@@ -647,25 +661,9 @@ where
                 )
                 .await?,
             )
-            .saturating_add(U256::from(
-                utils::estimate_gas_to_fulfill(
-                    &self.config,
-                    &self.supported_selectors,
-                    &order.request,
-                    order.journal_bytes,
-                )
-                .await?,
-            ))
+            .saturating_add(U256::from(fulfill_gas))
         } else {
-            U256::from(
-                utils::estimate_gas_to_fulfill(
-                    &self.config,
-                    &self.supported_selectors,
-                    &order.request,
-                    order.journal_bytes,
-                )
-                .await?,
-            )
+            U256::from(fulfill_gas)
         };
 
         let order_cost_wei = U256::from(gas_price) * order_gas_units;
@@ -692,17 +690,14 @@ where
         };
 
         let committed_orders = self.db.get_committed_orders().await?;
-        let committed_gas_units =
-            futures::future::try_join_all(committed_orders.iter().map(|order| {
-                utils::estimate_gas_to_fulfill(
-                    &self.config,
-                    &self.supported_selectors,
-                    &order.request,
-                    order.journal_bytes,
-                )
-            }))
-            .await?
+        let committed_gas_units = committed_orders
             .iter()
+            .map(|order| {
+                let base = self.backend.fulfillment_gas(&order.request)?;
+                utils::fulfill_gas_units(base, &self.config, &order.request, order.journal_bytes)
+            })
+            .collect::<Result<Vec<u64>>>()?
+            .into_iter()
             .sum::<u64>();
 
         let committed_cost_wei = U256::from(gas_price) * U256::from(committed_gas_units);
@@ -744,7 +739,11 @@ where
                 continue;
             }
 
-            let no_load = estimate_proving_time_no_load(order.total_cycles, config);
+            let no_load = estimate_proving_time_no_load(
+                order.total_cycles,
+                order.additional_proof_cycles.unwrap_or(config.additional_proof_cycles),
+                config,
+            );
             meta.insert(
                 order.id(),
                 OrderCommitmentMeta {
@@ -941,6 +940,7 @@ pub(crate) mod tests {
         node_bindings::{Anvil, AnvilInstance},
         primitives::{address, Address, Bytes, U256},
         providers::{
+            ext::AnvilApi,
             fillers::{
                 BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
                 WalletFiller,
@@ -983,6 +983,7 @@ pub(crate) mod tests {
         pub priced_order_tx: mpsc::Sender<Box<OrderRequest>>,
         pub signer: PrivateKeySigner,
         pub market_service: BoundlessMarketService<Arc<TestProvider>>,
+        pub backend: Arc<BackendRouter>,
         next_order_id: u32,
     }
 
@@ -1095,6 +1096,30 @@ pub(crate) mod tests {
 
         let (proving_completion_tx, _proving_completion_rx) = mpsc::channel(100);
 
+        // Backend router so the locker can resolve path-aware fulfill gas (RISC0 backend with an
+        // in-memory router fixture + stub provers; the gas tests only exercise cost resolution).
+        let router_policy = crate::backend::Risc0Backend::router_policy(
+            boundless_test_utils::market::test_router_registry(Default::default(), false),
+            boundless_test_utils::market::set_verifier_selector(Default::default()),
+            true,
+        );
+        let downloader = crate::ConfigurableDownloader::new(config.clone()).await.unwrap();
+        let priority_check: boundless_market::prover_utils::PriorityRequestorCheck =
+            Arc::new(|_| false);
+        let backend_router = Arc::new(
+            crate::backend::BackendRouter::new()
+                .register_backend(crate::backend::BackendEntry::new(Arc::new(
+                    crate::backend::Risc0Backend::with_provers(
+                        Arc::new(crate::provers::DefaultProver::new()),
+                        Arc::new(crate::provers::DefaultProver::new()),
+                        Arc::new(downloader),
+                        priority_check,
+                        router_policy,
+                    ),
+                )))
+                .unwrap(),
+        );
+
         let monitor = OrderLocker::new(
             db.clone(),
             provider.clone(),
@@ -1109,7 +1134,7 @@ pub(crate) mod tests {
             gas_priority_mode,
             gas_estimation_priority_mode,
             Arc::new(Cache::builder().build()),
-            SupportedSelectors::default(),
+            backend_router.clone(),
             false,
             anvil.chain_id(),
             proving_completion_tx,
@@ -1125,6 +1150,7 @@ pub(crate) mod tests {
             priced_order_tx,
             signer,
             market_service,
+            backend: backend_router,
             next_order_id: 1,
         }
     }
@@ -1374,16 +1400,25 @@ pub(crate) mod tests {
     async fn test_insufficient_balance_committed_orders() {
         let mut ctx = setup_oc_test_context().await;
 
-        let balance = ctx.monitor.provider.get_balance(ctx.signer.address()).await.unwrap();
-        let gas_price = ctx.monitor.chain_monitor.current_gas_price().await.unwrap();
-        let gas_remaining: u64 = (balance / U256::from(gas_price)).try_into().unwrap();
-        ctx.config.load_write().unwrap().market.fulfill_gas_estimate = gas_remaining / 2;
-        ctx.config.load_write().unwrap().market.lockin_gas_estimate = gas_remaining / 3;
-
-        let incoming_order =
+        // Per-order fulfill gas now comes from the backend (path-aware), not config. Compute it so
+        // we can size the balance precisely, and zero out the lock gas so each order's cost is
+        // exactly this fulfill cost.
+        let sample =
             ctx.create_test_order(FulfillmentType::LockAndFulfill, now_timestamp(), 100, 200).await;
+        let base = ctx.backend.fulfillment_gas(&sample.request).unwrap();
+        let per_order =
+            utils::fulfill_gas_units(base, &ctx.config, &sample.request, sample.journal_bytes)
+                .unwrap();
+        ctx.config.load_write().unwrap().market.lockin_gas_estimate = 0;
 
-        let mut orders = vec![Arc::from(incoming_order)];
+        // Fund the signer with exactly 1.5 orders' worth of gas: one candidate fits, a second does
+        // not, and the committed orders below push the total over the balance entirely.
+        let gas_price = ctx.monitor.chain_monitor.current_gas_price().await.unwrap();
+        let balance =
+            U256::from(per_order) * U256::from(gas_price) * U256::from(3u64) / U256::from(2u64);
+        ctx.monitor.provider.anvil_set_balance(ctx.signer.address(), balance).await.unwrap();
+
+        let mut orders = vec![Arc::from(sample)];
 
         let gas_result = ctx
             .monitor

--- a/crates/broker/src/order_pricer/helpers.rs
+++ b/crates/broker/src/order_pricer/helpers.rs
@@ -37,7 +37,9 @@ use boundless_market::prover_utils::{
     EvaluationLimits, EvaluationRequest, RequestEvaluation, RequestEvaluator,
 };
 use boundless_market::telemetry::EvalOutcome;
-use boundless_market::{prover_utils::estimate_erc1271_gas, selector::SupportedSelectors};
+use boundless_market::{
+    contracts::ProofRequest, prover_utils::estimate_erc1271_gas, selector::SupportedSelectors,
+};
 use tokio_util::sync::CancellationToken;
 
 use super::error::{
@@ -328,17 +330,21 @@ where
             .await
             .map_err(|err| OrderPricerErr::UnexpectedErr(Arc::new(err.into())))?
         {
-            let gas_estimate = utils::estimate_gas_to_fulfill(
-                config,
-                &self.supported_selectors,
-                &order.request,
-                order.journal_bytes,
-            )
-            .await?;
-            gas += gas_estimate;
+            let base = self.backend.fulfillment_gas(&order.request)?;
+            gas += utils::fulfill_gas_units(base, config, &order.request, order.journal_bytes)?;
         }
         tracing::debug!("Total gas estimate to fulfill pending orders: {}", gas);
         Ok(gas)
+    }
+
+    async fn estimate_gas_to_fulfill(&self, request: &ProofRequest) -> Result<u64, OrderPricerErr> {
+        // Delegate to the backend: it resolves the submission path and assessor from the router
+        // policy and applies the measured per-path gas. Journal calldata is added separately.
+        Ok(self.backend.fulfillment_gas(request)?)
+    }
+
+    fn additional_proof_cycles(&self, request: &ProofRequest) -> Result<u64, OrderPricerErr> {
+        Ok(self.backend.additional_proof_cycles(request)?)
     }
 
     fn is_priority_requestor(&self, client_addr: &Address) -> bool {

--- a/crates/broker/src/order_pricer/service.rs
+++ b/crates/broker/src/order_pricer/service.rs
@@ -748,7 +748,12 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn skip_price_less_than_gas_costs_groth16() {
+    async fn groth16_selector_prices_with_cheaper_direct_gas() {
+        // A groth16 selector takes the direct submission path (single on-chain verify + on-chain
+        // assessor, no set-builder root), which the backend's router-aware cost model prices below
+        // the batched set-inclusion path. So at a price that covers the batched base, the groth16
+        // order is *also* profitable — it is no longer penalized — and its stored fulfill-gas
+        // estimate is strictly lower than the batched order's.
         let config = ConfigLock::default();
         {
             config.load_write().unwrap().market.min_mcycle_price =
@@ -756,13 +761,12 @@ pub(crate) mod tests {
         }
         let mut ctx = PricerTestCtxBuilder::default().with_config(config).build().await;
 
-        // Compute a price between the base gas cost and the groth16 gas cost.
-        // Groth16 adds 250k gas units on top of the base 600k.
+        // A price comfortably above both the direct and batched gas bases, so both orders lock.
         let price = gas_midpoint_price(&ctx, 250_000).await;
         let min_price = price;
         let max_price = price;
 
-        // Order should have high enough price with the default selector.
+        // Default selector -> batched set-inclusion path.
         let order = ctx
             .generate_next_order(OrderParams {
                 order_index: 1,
@@ -779,10 +783,10 @@ pub(crate) mod tests {
         pin_base_fee(&ctx).await;
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
         assert!(locked);
-        let priced = ctx.priced_orders_rx.try_recv().unwrap();
-        assert_eq!(priced.target_timestamp, Some(0));
+        let priced_batched = ctx.priced_orders_rx.try_recv().unwrap();
+        assert_eq!(priced_batched.target_timestamp, Some(0));
 
-        // Order does not have high enough price when groth16 is used.
+        // Same price, but a groth16 selector -> direct path.
         let mut order = ctx
             .generate_next_order(OrderParams {
                 order_index: 2,
@@ -791,8 +795,6 @@ pub(crate) mod tests {
                 ..Default::default()
             })
             .await;
-
-        // set a Groth16 selector
         order.request.requirements.selector =
             FixedBytes::from(SelectorExt::groth16_latest() as u32);
 
@@ -801,13 +803,19 @@ pub(crate) mod tests {
             ctx.boundless_market.submit_request(&order.request, &ctx.signer(0)).await.unwrap();
 
         pin_base_fee(&ctx).await;
-        let order_id = order.id();
         let locked = ctx.pricer.price_order_and_update_state(order, CancellationToken::new()).await;
-        assert!(!locked);
+        assert!(locked, "direct-groth16 order is cheaper than batched and should lock");
+        let priced_groth16 = ctx.priced_orders_rx.try_recv().unwrap();
 
-        assert!(ctx.db.get_order(&order_id).await.unwrap().is_none());
-
-        assert!(logs_contain("estimated") && logs_contain("lock and fulfill order"));
+        // The feature: the direct path is estimated cheaper than the batched path. Both orders
+        // share the same lock gas, so the lower total gas estimate reflects the cheaper direct
+        // fulfill base (the backend's direct vs batched cost).
+        assert!(
+            priced_groth16.gas_estimate.unwrap() < priced_batched.gas_estimate.unwrap(),
+            "direct groth16 gas estimate ({:?}) should be below batched ({:?})",
+            priced_groth16.gas_estimate,
+            priced_batched.gas_estimate,
+        );
     }
 
     #[tokio::test]

--- a/crates/broker/src/utils/helpers.rs
+++ b/crates/broker/src/utils/helpers.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloy::{network::Ethereum, primitives::aliases::U96, providers::Provider};
+use alloy::{network::Ethereum, providers::Provider};
 use anyhow::{Context, Result};
 use boundless_market::{
     contracts::{PredicateType, ProofRequest},
-    prover_utils::{estimate_erc1271_gas, Erc1271GasCache},
-    selector::{ProofType, SupportedSelectors},
+    prover_utils::{callback_gas, estimate_erc1271_gas, Erc1271GasCache},
 };
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -78,54 +77,29 @@ pub(crate) async fn estimate_gas_to_lock<P: Provider<Ethereum> + 'static>(
     Ok(lockin_gas + erc1271_gas)
 }
 
-/// Estimate of gas for to fulfill a single order
-/// Currently just uses the config estimate but this may change in the future
-pub(crate) async fn estimate_gas_to_fulfill(
+/// Total on-chain gas to fulfill a single order (excluding lock gas): the path-aware `base`
+/// (verifier + assessor + settlement, resolved by the caller via the backend's `fulfillment_gas`)
+/// plus journal calldata and callback gas, both added here selector-agnostically.
+pub(crate) fn fulfill_gas_units(
+    base: u64,
     config: &ConfigLock,
-    supported_selectors: &SupportedSelectors,
     request: &ProofRequest,
     journal_bytes: Option<usize>,
 ) -> Result<u64> {
-    let (base, groth16, journal_gas_per_byte, max_journal_bytes) = {
+    let (journal_gas_per_byte, max_journal_bytes) = {
         let config = config.lock_all().context("Failed to read config")?;
-        (
-            config.market.fulfill_gas_estimate,
-            config.market.groth16_verify_gas_estimate,
-            config.market.fulfill_journal_gas_per_byte,
-            config.market.max_journal_bytes,
-        )
+        (config.market.fulfill_journal_gas_per_byte, config.market.max_journal_bytes)
     };
-
-    let journal_size = journal_bytes.unwrap_or(max_journal_bytes);
-
-    let mut estimate = base;
 
     // Add gas for journal calldata when the predicate requires journal submission.
-    if request.requirements.predicate.predicateType != PredicateType::ClaimDigestMatch {
-        estimate += journal_size as u64 * journal_gas_per_byte;
-    }
-
-    // Add gas for orders that make use of the callbacks feature.
-    estimate += u64::try_from(
-        request
-            .requirements
-            .callback
-            .as_option()
-            .map(|callback| callback.gasLimit)
-            .unwrap_or(U96::ZERO),
-    )?;
-
-    estimate += match supported_selectors
-        .proof_type(request.requirements.selector)
-        .context("unsupported selector")?
-    {
-        ProofType::Any | ProofType::Inclusion => 0,
-        ProofType::Groth16 | ProofType::Blake3Groth16 => groth16,
-        proof_type => {
-            tracing::warn!("Unknown proof type in gas cost estimation: {proof_type:?}");
+    let journal_gas =
+        if request.requirements.predicate.predicateType != PredicateType::ClaimDigestMatch {
+            journal_bytes.unwrap_or(max_journal_bytes) as u64 * journal_gas_per_byte
+        } else {
             0
-        }
-    };
+        };
 
-    Ok(estimate)
+    // Callback gas is universal across fulfillment paths and backends, so it is priced here on
+    // top of the backend-resolved base rather than inside the backend.
+    Ok(base + journal_gas + callback_gas(request)?)
 }

--- a/crates/broker/src/utils/mod.rs
+++ b/crates/broker/src/utils/mod.rs
@@ -24,7 +24,7 @@ pub mod sequential_fallback;
 pub(crate) mod storage;
 // Re-export the standalone helpers at the `crate::utils` root.
 pub(crate) use helpers::{
-    estimate_gas_to_fulfill, estimate_gas_to_lock, format_expiries, is_dev_mode, now_timestamp,
+    estimate_gas_to_lock, format_expiries, fulfill_gas_units, is_dev_mode, now_timestamp,
 };
 
 pub use crate::backend::prune_receipt_claim_journal;

--- a/crates/broker/src/utils/reaper.rs
+++ b/crates/broker/src/utils/reaper.rs
@@ -218,6 +218,14 @@ mod tests {
             Ok(None)
         }
 
+        fn fulfillment_gas(&self, _request: &ProofRequest) -> anyhow::Result<u64> {
+            Ok(500_000)
+        }
+
+        fn additional_proof_cycles(&self, _request: &ProofRequest) -> anyhow::Result<u64> {
+            Ok(2_000_000 + 270_000)
+        }
+
         async fn evaluate_request(
             &self,
             _request: boundless_market::prover_utils::EvaluationRequest,

--- a/crates/risc0-backend/src/lib.rs
+++ b/crates/risc0-backend/src/lib.rs
@@ -103,6 +103,58 @@ pub struct Risc0BackendConfig {
     pub txn_timeout: u64,
 }
 
+/// Measured per-path fulfillment cost constants the RISC0 backend uses to price orders.
+///
+/// The gas figures are all-in single-fill costs (settlement + verification + assessor),
+/// **excluding** journal calldata (added separately, selector-agnostically, during pricing) and
+/// lock gas. The cycle figures are the extra proving cycles beyond an order's own guest cycles.
+/// Defaults are benchmark-grounded; override via [`Risc0Backend::with_cost_model`].
+#[derive(Clone, Copy, Debug)]
+pub struct Risc0CostModel {
+    /// Direct submission **sealed by the on-chain assessor**: one groth16 verify (the proof
+    /// itself) + the on-chain assessor (ECDSA recover + predicate eval), no set-builder root.
+    /// Measured via `benchFulfillOnChainAssessor` (single proof) = 373,891; the default carries a
+    /// small safety margin.
+    ///
+    /// This is ~40% below the legacy direct cost (`fulfill_gas_estimate` 420k + `groth16_verify`
+    /// 250k = ~670k), which paid **two** groth16 verifies — the proof's plus the R0 STARK
+    /// assessor's — and a root submission. The on-chain assessor removes the second groth16 and
+    /// the root; the remaining ~250k is the proof's own (unavoidable) groth16 plus settlement, so
+    /// it cannot go much lower.
+    ///
+    /// NOTE: this assumes the direct path is sealed by the on-chain assessor (the broker's
+    /// preferred assessor). The model keys off the submission path, not the resolved assessor, so
+    /// a direct order sealed by the R0 STARK assessor instead would actually cost a second groth16
+    /// (~the legacy 670k) and would be under-estimated here.
+    pub direct_fulfill_gas: u64,
+    /// Batched submission: set-inclusion verify + R0 STARK assessor (amortized root). Mirrors the
+    /// historical `fulfill_gas_estimate` baseline and is left unchanged by the direct-path work.
+    pub batched_fulfill_gas: u64,
+    /// Direct-submission proving overhead beyond guest cycles. The only extra proving a direct
+    /// order does is its own groth16 wrap, but the batched path does not count its root's groth16
+    /// wrap either (amortized / uncounted in `batched_additional_proof_cycles`), so for consistency
+    /// this is 0 — direct orders are budgeted at their guest cycles only.
+    pub direct_additional_proof_cycles: u64,
+    /// Batched-submission proving overhead beyond guest cycles: assessor STARK + set builder.
+    pub batched_additional_proof_cycles: u64,
+}
+
+impl Default for Risc0CostModel {
+    fn default() -> Self {
+        Self {
+            // Measured 373,891 (1 groth16 + on-chain assessor, no root) + margin. See the field
+            // doc for the legacy-vs-now (2 groth16 -> 1) breakdown and the on-chain-assessor caveat.
+            direct_fulfill_gas: 400_000,
+            // Historical fulfill_gas_estimate (observed ~390k + margin).
+            batched_fulfill_gas: 420_000,
+            // 0: the per-order groth16 wrap is uncounted, mirroring the batched root wrap (see doc).
+            direct_additional_proof_cycles: 0,
+            // 2M assessor + 270k set builder.
+            batched_additional_proof_cycles: 2_000_000 + 270_000,
+        }
+    }
+}
+
 /// Live proving-retry policy: `() -> (retry_count, retry_sleep_ms)`, read per prove.
 pub type ProofRetryPolicy = Arc<dyn Fn() -> (u64, u64) + Send + Sync>;
 
@@ -189,6 +241,8 @@ pub struct Risc0Backend {
     /// Router snapshot + derived broker policy, resolved once at construction. Always present:
     /// production snapshots the on-chain registry, tests supply a fixture.
     router_policy: RouterPolicy,
+    /// Measured per-path fulfillment cost constants used to price orders.
+    cost_model: Risc0CostModel,
 }
 
 impl Risc0Backend {
@@ -392,7 +446,15 @@ impl Risc0Backend {
             prover_addr: None,
             chain_id: 0,
             router_policy,
+            cost_model: Risc0CostModel::default(),
         }
+    }
+
+    /// Overrides the measured per-path fulfillment cost constants (default
+    /// [`Risc0CostModel::default`]).
+    pub fn with_cost_model(mut self, cost_model: Risc0CostModel) -> Self {
+        self.cost_model = cost_model;
+        self
     }
 
     fn build_provers(
@@ -871,6 +933,30 @@ impl Backend for Risc0Backend {
                 )
             })?;
         Ok(Some(group))
+    }
+
+    fn fulfillment_gas(&self, request: &boundless_market::contracts::ProofRequest) -> Result<u64> {
+        // Direct selectors are fulfilled by a single groth16 verify + the on-chain assessor (no
+        // root); everything else takes the batched set-inclusion + STARK-assessor path. The path
+        // is keyed off the normalized selector, exactly as `process_order` does.
+        let selector = self.normalize_selector(request.requirements.selector);
+        // Path-aware base only. The universal callback gas is priced at the broker/market layer
+        // (`callback_gas` / `fulfill_gas_units` / `price_order`), not here.
+        Ok(match submission_path_for_risc0_selector(selector) {
+            SubmissionPath::Direct => self.cost_model.direct_fulfill_gas,
+            SubmissionPath::Batched => self.cost_model.batched_fulfill_gas,
+        })
+    }
+
+    fn additional_proof_cycles(
+        &self,
+        request: &boundless_market::contracts::ProofRequest,
+    ) -> Result<u64> {
+        let selector = self.normalize_selector(request.requirements.selector);
+        Ok(match submission_path_for_risc0_selector(selector) {
+            SubmissionPath::Direct => self.cost_model.direct_additional_proof_cycles,
+            SubmissionPath::Batched => self.cost_model.batched_additional_proof_cycles,
+        })
     }
 
     async fn evaluate_request(
@@ -1624,5 +1710,60 @@ mod tests {
         });
         let err = expect_build_fulfillments_err(&backend, cmd).await;
         assert!(err.to_string().contains("no assessor receipt"), "unexpected error: {err:#}");
+    }
+
+    fn cost_request(selector: FixedBytes<4>) -> boundless_market::contracts::ProofRequest {
+        use boundless_market::contracts::{
+            Offer, ProofRequest, RequestId, RequestInput, RequestInputType, Requirements,
+        };
+        let mut request = ProofRequest::new(
+            RequestId::new(Address::ZERO, 1),
+            Requirements::new(Predicate::prefix_match(
+                Risc0Digest::ZERO,
+                alloy::primitives::Bytes::default(),
+            )),
+            "test",
+            RequestInput { inputType: RequestInputType::Inline, data: Default::default() },
+            Offer {
+                minPrice: U256::from(1),
+                maxPrice: U256::from(10),
+                rampUpStart: 0,
+                timeout: 1000,
+                lockTimeout: 1000,
+                rampUpPeriod: 1,
+                lockCollateral: U256::ZERO,
+            },
+        );
+        request.requirements.selector = selector;
+        request
+    }
+
+    /// Direct-submission (groth16) orders price with the cheap on-chain-assessor path; the batched
+    /// set-inclusion path keeps the legacy base gas and the STARK-assessor + set-builder cycles.
+    #[tokio::test]
+    async fn fulfillment_cost_is_path_aware() {
+        let backend = guard_test_backend().await;
+        let cost = backend.cost_model;
+
+        // A groth16 selector takes the direct path.
+        let direct = cost_request(SELECTOR_GROTH16_V3_0);
+        assert_eq!(backend.fulfillment_gas(&direct).unwrap(), cost.direct_fulfill_gas);
+        assert_eq!(
+            backend.additional_proof_cycles(&direct).unwrap(),
+            cost.direct_additional_proof_cycles
+        );
+
+        // The set-inclusion entry selector normalizes to the aggregated seal -> batched path.
+        let set_inclusion = boundless_test_utils::market::set_verifier_selector(Risc0Digest::ZERO);
+        let batched = cost_request(set_inclusion);
+        assert_eq!(backend.fulfillment_gas(&batched).unwrap(), cost.batched_fulfill_gas);
+        assert_eq!(
+            backend.additional_proof_cycles(&batched).unwrap(),
+            cost.batched_additional_proof_cycles
+        );
+
+        // The whole point: direct submission is cheaper on both the gas and the proving axis.
+        assert!(cost.direct_fulfill_gas < cost.batched_fulfill_gas);
+        assert!(cost.direct_additional_proof_cycles < cost.batched_additional_proof_cycles);
     }
 }


### PR DESCRIPTION
## Summary

Make the broker price each order at the true cost of the fulfillment path it will actually take. Direct-submission groth16 orders (on-chain verifier + on-chain assessor) were being charged the legacy set-builder/assessor overhead; now they are priced at their real, much lower cost, so the broker bids on and locks orders it previously skipped.

Built on top of `jonas/adopt-router-in-broker` (the router-adoption work).

## How it works

```
price an order
   │
   ▼
OrderPricer / OrderLocker        (broker — selector-agnostic, just delegates)
   │  "what will this cost?"
   ▼
BackendRouter.fulfillment_gas(request)
   │  routes by selector → owning backend
   ▼
Risc0Backend
   │  submission_path_for(selector)
   ├── Direct  ──►  Risc0CostModel.direct_fulfill_gas    (~400k: 1 groth16 + on-chain assessor)
   └── Batched ──►  Risc0CostModel.batched_fulfill_gas   (~420k: set-inclusion + STARK assessor)

then the broker adds the universal extras on top:   + journal calldata   + callback gas
```

The backend is the only thing that knows the submission path/assessor for a given selector, so it owns the cost model. The broker stays selector-agnostic and just delegates, then adds the parts that are universal across backends/paths (journal calldata, callback gas).

## The savings

Before, a direct (groth16-selector) order was estimated at the *guest-worst* cost:

`fulfill_gas_estimate (420k) + groth16_verify (250k) ≈ 670k`

because the pre-router path implied **two** on-chain groth16 verifications — the proof itself **and** the STARK assessor / batch root — plus a `submitRoot`.

With the router's on-chain assessor, a direct fulfill is **one** groth16 (the proof) + a cheap ECDSA assessor signature check, **no root**:

`measured 373,891 gas` (`benchFulfillOnChainAssessor`)

So the broker now prices direct orders **~40% lower** and will lock/bid on ones it previously rejected as unprofitable. On the proving side, direct orders also drop the `2.27M` assessor + set-builder cycle overhead they never incur (the on-chain assessor needs no STARK proof).

| path | old estimate | new estimate |
|---|---|---|
| direct (groth16) | ~670k (2 groth16 + root) | ~400k (1 groth16 + on-chain assessor) |
| batched (set-inclusion) | ~420k | ~420k (unchanged) |

## Details

- **`Backend` trait** gains `fulfillment_gas(request)` and `additional_proof_cycles(request)` (required — every backend models its own cost), forwarded through `BackendRouter` by selector, alongside the existing `proof_type` / `assessor_group`.
- **`Risc0Backend`** resolves the submission path (`submission_path_for_risc0_selector`) and returns the matching `Risc0CostModel` constant. Direct proving overhead is `0` (its per-order groth16 wrap is uncounted, mirroring how the batched path does not count its root wrap).
- **Broker** delegates and stays selector-agnostic: the `OrderPricingContext::estimate_gas_to_fulfill` override and the per-chain `OrderLocker` resolve the path base via `backend.fulfillment_gas`; `fulfill_gas_units` adds journal calldata + callback gas on top.
- **Proving overhead** (`additional_proof_cycles`) is resolved once at pricing and carried on the order, because its consumer — the single, chain-agnostic `OrderCommitter` — holds no backend handle.

## Notes / follow-ups

- `Risc0CostModel` constants are measured-grounded but overridable. A follow-up should feed `MarketConfig` values into it and route the requestor/SDK pricing path through the backend too — it currently can't, since `boundless-backend` depends on `boundless-market`, so the SDK side keeps a config-based estimate. Tracked by a `TODO` on `estimate_gas_to_fulfill`.
- The direct-path proving-overhead constant (groth16-wrap cycles) is set to `0` for now; a benchmark could refine it.
