### PR TITLE
BM-3070: feat(monitoring): opt out all balance alarms from auto-investigation

### DIFF
--- a/infra/cw-monitoring/proverAlarms.ts
+++ b/infra/cw-monitoring/proverAlarms.ts
@@ -312,6 +312,8 @@ export function buildProverLogPatterns(
             metricName: "order-locker-insufficient-balance",
             alarm: {
                 severity: Severity.SEV2,
+                // Balance alarm: remediation is to fund the prover's account, nothing to investigate.
+                autoInvestigate: false,
                 description: ">=2 insufficient balance for lock in 2 hours",
                 metricConfig: { period: 7200 },
                 alarmConfig: { evaluationPeriods: 1, datapointsToAlarm: 1, threshold: 2 },

--- a/infra/distributor/index.ts
+++ b/infra/distributor/index.ts
@@ -2,7 +2,7 @@ import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import * as pulumi from '@pulumi/pulumi';
 import * as docker_build from '@pulumi/docker-build';
-import { getServiceNameV1, getEnvVar, Severity, getGhcrImageUri } from '../util';
+import { getServiceNameV1, getEnvVar, Severity, getGhcrImageUri, withAutoInvestigate } from '../util';
 import * as crypto from 'crypto';
 require('dotenv').config();
 
@@ -595,7 +595,8 @@ export = () => {
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
     treatMissingData: 'notBreaching',
-    alarmDescription: `Distributor unable to send stake. Send stake to distributor: ${distributorAddress} on ${chainId}`,
+    // Balance alarm: remediation is to top up the distributor, nothing to investigate.
+    alarmDescription: withAutoInvestigate(`Distributor unable to send stake. Send stake to distributor: ${distributorAddress} on ${chainId}`, false),
     actionsEnabled: true,
     alarmActions,
   });
@@ -619,7 +620,8 @@ export = () => {
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
     treatMissingData: 'notBreaching',
-    alarmDescription: `Distributor unable to send ETH. Send ETH to distributor: ${distributorAddress} on ${chainId}`,
+    // Balance alarm: remediation is to top up the distributor, nothing to investigate.
+    alarmDescription: withAutoInvestigate(`Distributor unable to send ETH. Send ETH to distributor: ${distributorAddress} on ${chainId}`, false),
     actionsEnabled: true,
     alarmActions,
   });
@@ -643,7 +645,8 @@ export = () => {
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
     treatMissingData: 'notBreaching',
-    alarmDescription: `Distributor stake balance low. Send stake to distributor: ${distributorAddress} on ${chainId}`,
+    // Balance alarm: remediation is to top up the distributor, nothing to investigate.
+    alarmDescription: withAutoInvestigate(`Distributor stake balance low. Send stake to distributor: ${distributorAddress} on ${chainId}`, false),
     actionsEnabled: true,
     alarmActions,
   });
@@ -667,7 +670,8 @@ export = () => {
     evaluationPeriods: 1,
     datapointsToAlarm: 1,
     treatMissingData: 'notBreaching',
-    alarmDescription: `WARNING: Distributor ETH balance low. Send ETH to distributor: ${distributorAddress} on ${chainId}`,
+    // Balance alarm: remediation is to top up the distributor, nothing to investigate.
+    alarmDescription: withAutoInvestigate(`WARNING: Distributor ETH balance low. Send ETH to distributor: ${distributorAddress} on ${chainId}`, false),
     actionsEnabled: true,
     alarmActions,
   });
@@ -721,7 +725,8 @@ export = () => {
           evaluationPeriods: 1,
           datapointsToAlarm: 1,
           treatMissingData: 'notBreaching',
-          alarmDescription: `${level === 'CRIT' ? 'CRITICAL' : 'WARNING'}: monitored ${spec.label} ${spec.kind} balance below ${level.toLowerCase()} threshold on ${chainId}`,
+          // Balance alarm: remediation is to top up the monitored address, nothing to investigate.
+          alarmDescription: withAutoInvestigate(`${level === 'CRIT' ? 'CRITICAL' : 'WARNING'}: monitored ${spec.label} ${spec.kind} balance below ${level.toLowerCase()} threshold on ${chainId}`, false),
           actionsEnabled: true,
           alarmActions,
         });

--- a/infra/kailua-batch/index.ts
+++ b/infra/kailua-batch/index.ts
@@ -1,7 +1,7 @@
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
-import { getServiceNameV1, Severity } from "../util";
+import { getServiceNameV1, Severity, withAutoInvestigate } from "../util";
 
 require("dotenv").config();
 
@@ -487,7 +487,8 @@ export = () => {
             evaluationPeriods: 1,
             datapointsToAlarm: 1,
             treatMissingData: "notBreaching",
-            alarmDescription: `${Severity.SEV2}: Kailua emitted a low-funds log in 1 hour`,
+            // Balance alarm: remediation is to top up Kailua, nothing to investigate.
+            alarmDescription: withAutoInvestigate(`${Severity.SEV2}: Kailua emitted a low-funds log in 1 hour`, false),
             actionsEnabled: true,
             alarmActions,
         });

--- a/infra/order-generator/components/order-generator.ts
+++ b/infra/order-generator/components/order-generator.ts
@@ -1,7 +1,7 @@
 import * as aws from '@pulumi/aws';
 import * as awsx from '@pulumi/awsx';
 import * as pulumi from '@pulumi/pulumi';
-import { getServiceNameV1, Severity } from '../../util';
+import { getServiceNameV1, Severity, withAutoInvestigate } from '../../util';
 import * as crypto from 'crypto';
 
 const FARGATE_CPU = 512;
@@ -441,7 +441,8 @@ export class OrderGenerator extends pulumi.ComponentResource {
       evaluationPeriods: 60,
       datapointsToAlarm: 3,
       treatMissingData: 'notBreaching',
-      alarmDescription: `${name} ETH bal < ${args.warnBalanceBelow} ${Severity.SEV2}`,
+      // Balance alarm: remediation is to top up the order generator, nothing to investigate.
+      alarmDescription: withAutoInvestigate(`${name} ETH bal < ${args.warnBalanceBelow} ${Severity.SEV2}`, false),
       actionsEnabled: true,
       alarmActions,
     });
@@ -466,7 +467,8 @@ export class OrderGenerator extends pulumi.ComponentResource {
         evaluationPeriods: 60,
         datapointsToAlarm: 3,
         treatMissingData: 'notBreaching',
-        alarmDescription: `${name} ETH bal < ${args.errorBalanceBelow} ${Severity.SEV1}`,
+        // Balance alarm: remediation is to top up the order generator, nothing to investigate.
+        alarmDescription: withAutoInvestigate(`${name} ETH bal < ${args.errorBalanceBelow} ${Severity.SEV1}`, false),
         actionsEnabled: true,
         alarmActions,
       });


### PR DESCRIPTION
## Summary

Follow-up to #2047, which added the per-alarm opt-out for the automatic first-pass alert investigation and applied it to the prover `[B-BAL-*]` balance alarms. This PR extends the opt-out to **every remaining balance / top-up alarm**.

These alarms have a known operational remediation — fund the wallet — with nothing for the investigation to diagnose. They set `autoInvestigate: false`, which appends the `[no-auto-investigate]` marker to the alarm description so the alert-investigation bot skips the automatic first pass. The alarms still fire to Slack as usual, and a human can still pull the bot in via @mention.

## Alarms opted out

- **cw-monitoring** (`proverAlarms.ts`) — order-locker insufficient-balance-for-lock (`[B-OL-010]`). The prover `[B-BAL-ETH/STK]` alarms were already opted out in #2047.
- **distributor** — ETH-low, stake-low, unable-to-send ETH/stake, and the monitored balance alarms (KOG / Signal, LOW + CRIT).
- **order-generator** — low ETH balance (SEV2 + SEV1).
- **kailua-batch** — low-funds (ETH + stake).

I swept every infra stack; no other balance alarms exist. `price-oracle-insufficient-sources` is intentionally left investigated — it's about price-feed sources, not balance.

## Notes

- The opt-out is set in the alarm definitions (the data-driven config for cw-monitoring; inline at the alarm for the service stacks that have no config-data layer), never in the per-stack Pulumi config. The balance alarm configs are not stage-split, so a single setting applies to both staging and prod.
