### PR TITLE
BM-3071: Disable auto-investigation for staging expired request alarms

### DIFF
--- a/infra/indexer/alarmConfig.ts
+++ b/infra/indexer/alarmConfig.ts
@@ -91,6 +91,7 @@ export const alarmConfig: ChainStageAlarms = {
           expiredRequests: [{
             description: "greater than or equal to 3 expired orders for two consecutive hours from og_offchain",
             severity: Severity.SEV2,
+            autoInvestigate: false,
             metricConfig: {
               period: 3600,
             },
@@ -178,6 +179,7 @@ export const alarmConfig: ChainStageAlarms = {
           expiredRequests: [{
             description: "greater than or equal to 50 expired orders over 6 hours from og_onchain",
             severity: Severity.SEV2,
+            autoInvestigate: false,
             metricConfig: {
               period: 21600,
             },
@@ -233,6 +235,7 @@ export const alarmConfig: ChainStageAlarms = {
         expiredRequests: [{
           description: "greater than 15 expired orders in 60 minutes",
           severity: Severity.SEV2,
+          autoInvestigate: false,
           metricConfig: {
             period: 3600,
           },


### PR DESCRIPTION
Sets `autoInvestigate: false` on all expired request alarms for Base Sepolia staging. The alert bot will skip the automatic first pass on these — alarms still fire to Slack and you can @mention the bot manually.

Changes
* og_offchain expired orders alarm
* og_onchain expired orders alarm
* top-level market expired orders alarm

Needs indexer deploy to `l-staging-84532` to take effect.