### PR TITLE
refactor(contracts): remove unused MismatchedRequestId error and Upgraded event

### DIFF
--- a/contracts/src/BoundlessMarket.sol
+++ b/contracts/src/BoundlessMarket.sol
@@ -40,7 +40,6 @@ error InvalidRouter();
 error InvalidCollateralToken();
 error InvalidLegacyImpl();
 error InvalidInitialOwner();
-error MismatchedRequestId(uint256 expected, uint256 received);
 
 contract BoundlessMarket is
     IBoundlessMarket,

--- a/contracts/src/IBoundlessMarket.sol
+++ b/contracts/src/IBoundlessMarket.sol
@@ -86,10 +86,6 @@ interface IBoundlessMarket {
     /// @param value The value of the withdrawal.
     event CollateralWithdrawal(address indexed account, uint256 value);
 
-    /// @notice Event when the contract is upgraded to a new version.
-    /// @param version The new version of the contract.
-    event Upgraded(uint64 indexed version);
-
     /// @notice Event emitted during fulfillment if a request was fulfilled, but payment was not
     /// transferred because at least one condition was not met. See the documentation on
     /// `IBoundlessMarket.fulfill` for more information.

--- a/crates/boundless-market/src/contracts/artifacts/IBoundlessMarket.sol
+++ b/crates/boundless-market/src/contracts/artifacts/IBoundlessMarket.sol
@@ -86,10 +86,6 @@ interface IBoundlessMarket {
     /// @param value The value of the withdrawal.
     event CollateralWithdrawal(address indexed account, uint256 value);
 
-    /// @notice Event when the contract is upgraded to a new version.
-    /// @param version The new version of the contract.
-    event Upgraded(uint64 indexed version);
-
     /// @notice Event emitted during fulfillment if a request was fulfilled, but payment was not
     /// transferred because at least one condition was not met. See the documentation on
     /// `IBoundlessMarket.fulfill` for more information.


### PR DESCRIPTION
## Summary

Addresses the **Unused Code** audit finding (Info / Maintainability). Removes two dead constructs from the market contracts that could drift from the implementation and mislead integrators.

## Changes

- **`contracts/src/BoundlessMarket.sol`** — remove `error MismatchedRequestId(uint256 expected, uint256 received)`. It was declared but never referenced anywhere in the codebase.
- **`contracts/src/IBoundlessMarket.sol`** — remove the custom `event Upgraded(uint64 indexed version)`. It was never emitted by the implementation: `BoundlessMarket` is UUPS and upgrades emit OpenZeppelin's standard ERC1967 `Upgraded(address indexed implementation)` event. The custom event was misleading for integrators and monitoring tools relying on an event that never fires.
- **`crates/boundless-market/src/contracts/artifacts/IBoundlessMarket.sol`** — regenerated (via `build.rs`) so the checked-in interface artifact stays in sync and passes the CI drift check.

## Out of scope (intentionally left unchanged)

- `contracts/shanghai/src/` — a separate, currently-lagging pre-router copy compiled under the shanghai EVM profile; not part of the finding's scope.
- `contracts/src/legacy/IBoundlessMarketLegacy.sol` — a frozen historical ABI snapshot kept for pre-router client compatibility; the `Upgraded` declaration is retained there for fidelity to the deployed legacy interface.

## Verification

- `forge build` (compiles src + scripts + tests): passes.
- `cargo build -p boundless-market`: passes; artifact regenerates with no additional drift.

Both removals are pure dead-code deletions with no behavioral change.
