### PR TITLE
BM-3081: Run staging indexer Aurora on Serverless v2 (drop replica)

### DIFF
--- a/infra/indexer/Pulumi.l-staging-11155111.yaml
+++ b/infra/indexer/Pulumi.l-staging-11155111.yaml
@@ -10,6 +10,10 @@ config:
   indexer:RUST_LOG_MONITOR: info,indexer_monitor=debug
   indexer:RUST_LOG_INDEXER: info,boundless_indexer=debug
   indexer:CHAIN_ID: "11155111"
+  indexer:DB_SERVERLESS: "true"
+  indexer:DB_MIN_ACU: "0.5"
+  indexer:DB_MAX_ACU: "4"
+  indexer:DB_ENABLE_REPLICA: "false"
   indexer:BLOCK_DELAY: "10"
   indexer:BACKFILL_CHAIN_DATA_BLOCKS: "10000"
   indexer:CHAIN_DATA_BATCH_DELAY_MS: "2500"

--- a/infra/indexer/Pulumi.l-staging-167000.yaml
+++ b/infra/indexer/Pulumi.l-staging-167000.yaml
@@ -12,6 +12,10 @@ config:
   indexer:BOUNDLESS_ADDRESS: 0x60d11ef5d4608bab18a663fd486d3b9f162172cf
   indexer:CHAIN_DATA_BATCH_DELAY_MS: "2500"
   indexer:CHAIN_ID: "167000"
+  indexer:DB_SERVERLESS: "true"
+  indexer:DB_MIN_ACU: "0.5"
+  indexer:DB_MAX_ACU: "4"
+  indexer:DB_ENABLE_REPLICA: "false"
   indexer:CI_CACHE_SECRET:
     secure: v1:uvdJMC0JsccdGluc:wTd+lZ8ChZwINpw2XJ6GGcEjhwXliGghZHXX2QXgSnKD8B6m6Ke1Ug5iKA6bb6zw3HVgEBbazeoPO0mYS0km1uzYnDqFRODhZuseViySdFyWKUSq4qFKqZ3amHgx2P8UpCHOsVIowCrl83NHnRCKdXrVz+CtabD0A+ixDCLirQ==
   indexer:DOCKER_DIR: ../../

--- a/infra/indexer/Pulumi.l-staging-84532.yaml
+++ b/infra/indexer/Pulumi.l-staging-84532.yaml
@@ -5,6 +5,10 @@ config:
   indexer:BASE_STACK: organization/bootstrap/services-staging
   indexer:BOUNDLESS_ADDRESS: 0x7abb16522f4599481361d318b765af988bfcca8e
   indexer:CHAIN_ID: "84532"
+  indexer:DB_SERVERLESS: "true"
+  indexer:DB_MIN_ACU: "0.5"
+  indexer:DB_MAX_ACU: "4"
+  indexer:DB_ENABLE_REPLICA: "false"
   indexer:DOCKER_DIR: ../../
   indexer:DOCKER_TAG: latest
   indexer:GH_TOKEN_SECRET:

--- a/infra/indexer/components/indexer-infra.ts
+++ b/infra/indexer/components/indexer-infra.ts
@@ -12,6 +12,14 @@ export interface IndexerInfraArgs {
   pubSubNetIds: pulumi.Output<string[]>;
   rdsPassword: pulumi.Output<string>;
   isDev: boolean;
+  /// Run Aurora on Serverless v2 (db.serverless) instead of a fixed instance
+  /// class. Defaults to false (provisioned).
+  dbServerless?: boolean;
+  /// Serverless v2 capacity range in ACUs (only used when dbServerless is true).
+  dbMinAcu?: number;
+  dbMaxAcu?: number;
+  /// Skip the Aurora read replica (writer only) when false. Defaults to true.
+  dbEnableReplica?: boolean;
   ciCacheSecret?: pulumi.Output<string>;
   githubTokenSecret?: pulumi.Output<string>;
   dockerDir: string;
@@ -46,7 +54,8 @@ export class IndexerShared extends pulumi.ComponentResource {
   constructor(name: string, args: IndexerInfraArgs, opts?: pulumi.ComponentResourceOptions) {
     super('indexer:infra', name, opts);
 
-    const { vpcId, privSubNetIds, pubSubNetIds, rdsPassword, isDev, ciCacheSecret, githubTokenSecret, dockerDir, dockerTag, dockerRemoteBuilder } = args;
+    const { vpcId, privSubNetIds, pubSubNetIds, rdsPassword, isDev, dbServerless, dbMinAcu, dbMaxAcu, dbEnableReplica, ciCacheSecret, githubTokenSecret, dockerDir, dockerTag, dockerRemoteBuilder } = args;
+    const enableReplica = dbEnableReplica ?? true;
     const serviceName = `${args.serviceName}-base`;
 
     // Note: changing this causes the database to be deleted, and then recreated from scratch, and indexing to restart.
@@ -168,6 +177,9 @@ export class IndexerShared extends pulumi.ComponentResource {
       storageEncrypted: true,
       monitoringInterval: 60,
       monitoringRoleArn: enhancedMonitoringRole.arn,
+      serverlessv2ScalingConfiguration: dbServerless
+        ? { minCapacity: dbMinAcu ?? 0.5, maxCapacity: dbMaxAcu ?? 4 }
+        : undefined,
     }, { parent: this, ignoreChanges: ['engineVersion'] /* protect: true */ });
 
     new aws.iam.RolePolicyAttachment(`${serviceName}-rds-mon-pol`, {
@@ -175,7 +187,7 @@ export class IndexerShared extends pulumi.ComponentResource {
       policyArn: 'arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole',
     }, { parent: this });
 
-    const instanceClass = isDev ? 'db.r6g.large' : 'db.r6g.xlarge';
+    const instanceClass = dbServerless ? 'db.serverless' : (isDev ? 'db.r6g.large' : 'db.r6g.xlarge');
 
     // engineVersion is a floor here too — see comment on auroraCluster above.
     new aws.rds.ClusterInstance(`${serviceName}-aurora-writer-${databaseVersion}`, {
@@ -193,20 +205,22 @@ export class IndexerShared extends pulumi.ComponentResource {
       applyImmediately: true,
     }, { parent: this, ignoreChanges: ['engineVersion'] /* protect: true */ });
 
-    new aws.rds.ClusterInstance(`${serviceName}-aurora-reader-${databaseVersion}`, {
-      clusterIdentifier: auroraCluster.id,
-      engine: 'aurora-postgresql',
-      engineVersion: '17.7',
-      instanceClass: instanceClass,
-      identifier: `${serviceName}-aurora-reader-${databaseVersion}`,
-      publiclyAccessible: false,
-      dbSubnetGroupName: dbSubnets.name,
-      performanceInsightsEnabled: true,
-      performanceInsightsRetentionPeriod: 7,
-      monitoringInterval: 60,
-      monitoringRoleArn: enhancedMonitoringRole.arn,
-      applyImmediately: true,
-    }, { parent: this, ignoreChanges: ['engineVersion'] /* protect: true */ });
+    if (enableReplica) {
+      new aws.rds.ClusterInstance(`${serviceName}-aurora-reader-${databaseVersion}`, {
+        clusterIdentifier: auroraCluster.id,
+        engine: 'aurora-postgresql',
+        engineVersion: '17.7',
+        instanceClass: instanceClass,
+        identifier: `${serviceName}-aurora-reader-${databaseVersion}`,
+        publiclyAccessible: false,
+        dbSubnetGroupName: dbSubnets.name,
+        performanceInsightsEnabled: true,
+        performanceInsightsRetentionPeriod: 7,
+        monitoringInterval: 60,
+        monitoringRoleArn: enhancedMonitoringRole.arn,
+        applyImmediately: true,
+      }, { parent: this, ignoreChanges: ['engineVersion'] /* protect: true */ });
+    }
 
     // Writer secret: direct connection to Aurora cluster endpoint (for ECS indexer)
     const dbUrlSecretValue = pulumi.interpolate`postgres://${rdsUser}:${rdsPassword}@${auroraCluster.endpoint}:${rdsPort}/${rdsDbName}?sslmode=require`;

--- a/infra/indexer/index.ts
+++ b/infra/indexer/index.ts
@@ -25,6 +25,12 @@ export = () => {
   const dockerDir = config.get('DOCKER_DIR') || '../../';
   const dockerTag = config.get('DOCKER_TAG') || 'latest';
   const ciCacheSecret = config.getSecret('CI_CACHE_SECRET');
+  // Aurora sizing. Defaults preserve provisioned r6g + read replica; staging
+  // stacks opt into Serverless v2 and drop the replica via config.
+  const dbServerless = config.getBoolean('DB_SERVERLESS') ?? false;
+  const dbMinAcu = config.getNumber('DB_MIN_ACU');
+  const dbMaxAcu = config.getNumber('DB_MAX_ACU');
+  const dbEnableReplica = config.getBoolean('DB_ENABLE_REPLICA') ?? true;
   const baseStackName = config.require('BASE_STACK');
   const boundlessAlertsTopicArn = config.get('SLACK_ALERTS_TOPIC_ARN');
   const boundlessPagerdutyTopicArn = config.get('PAGERDUTY_ALERTS_TOPIC_ARN');
@@ -75,6 +81,10 @@ export = () => {
     pubSubNetIds,
     rdsPassword,
     isDev,
+    dbServerless,
+    dbMinAcu,
+    dbMaxAcu,
+    dbEnableReplica,
     ciCacheSecret,
     githubTokenSecret,
     dockerDir,


### PR DESCRIPTION
## Why

The staging indexer Aurora clusters are a full clone of prod's footprint — **6× db.r6g.xlarge** (writer + reader across 3 chains, ~**$2,280/mo**) — but the databases are tiny and near-idle:

- ~2 GB of data per cluster, **100% buffer-cache hit**, ~0 read IOPS
- Writers ~4% CPU, readers ~4–9% CPU, a handful of connections

So they're provisioned like prod but serve trivial staging load.

## Change

Config-gated Aurora sizing on the shared indexer component, with defaults that **preserve current prod behavior** (provisioned `r6g` + read replica):

- `DB_SERVERLESS` (default false) → run the cluster on **Aurora Serverless v2** (`db.serverless` + `serverlessv2ScalingConfiguration`)
- `DB_MIN_ACU` / `DB_MAX_ACU` → the ACU range
- `DB_ENABLE_REPLICA` (default true) → when false, skip the read replica (writer only)

Enabled on the **three staging stacks only** (`l-staging-84532`, `l-staging-167000`, `l-staging-11155111`): Serverless v2 **min 0.5 / max 4 ACU**, **no replica**. Prod stacks are untouched.

## Savings

- Expected **~$150–270/mo** (staging sits near the 0.5-ACU floor almost always) vs **~$2,280/mo** today → **~$2,000/mo saved**.
- Worst case (all 3 writers pinned at max 4 ACU 24/7): ~$1,050/mo — still less than half of today. `max` is only a ceiling; you pay for ACU-seconds actually used.

## Data safety & apply behavior

- **No data loss** — the Aurora cluster volume is untouched (`databaseVersion`/cluster identifier unchanged). Only the compute (instance class) changes and the reader instance is removed.
- Applying converts the writer to `db.serverless` (a brief **failover/restart**) and deletes the reader — a short staging blip, not instant-and-invisible. If AWS won't modify the writer in place, it may need a manual two-step (add serverless reader → failover → drop provisioned).
- The indexer-api uses the Aurora **reader endpoint**, which falls back to the writer when no replica exists — still functional (staging gives up read-offload + HA, acceptable).

Prod is unaffected. Do **staging first** here (zero risk at ~2 GB); a selective prod downsize (keep the hot Base reader) is a separate follow-up.
