### PR TITLE
BM-3084: fix(market): restore risc0 Digest wire format for deployed-guest inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,6 +2895,7 @@ dependencies = [
  "httpmock",
  "hyper-util",
  "moka",
+ "postcard",
  "rand 0.9.2",
  "reqwest 0.13.1",
  "risc0-aggregation",

--- a/crates/boundless-cli/src/lib.rs
+++ b/crates/boundless-cli/src/lib.rs
@@ -284,7 +284,12 @@ impl OrderFulfiller {
             )?)
         };
 
-        Self::initialize(prover, client, assessor_selector, ASSESSOR_DEFAULT_IMAGE_URL).await
+        // ASSESSOR_IMAGE_URL overrides the default assessor guest source (any downloader
+        // scheme, e.g. file://). The proven guest's image id must match the id pinned by the
+        // router assessor adapter that `assessor_selector` dispatches to.
+        let assessor_image_url = std::env::var("ASSESSOR_IMAGE_URL")
+            .unwrap_or_else(|_| ASSESSOR_DEFAULT_IMAGE_URL.to_string());
+        Self::initialize(prover, client, assessor_selector, &assessor_image_url).await
     }
 
     /// Initialize an OrderFulfiller from a provided Prover instance.

--- a/crates/boundless-market/Cargo.toml
+++ b/crates/boundless-market/Cargo.toml
@@ -106,6 +106,7 @@ serde_json = { workspace = true }
 alloy = { workspace = true, features = ["json-rpc"] }
 boundless-test-utils = { workspace = true }
 guest-util = { workspace = true }
+postcard = { workspace = true, features = ["alloc"] }
 temp-env = { version = "0.3.6", features = ["async_closure"] }
 tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/boundless-market/src/digest.rs
+++ b/crates/boundless-market/src/digest.rs
@@ -13,14 +13,40 @@
 // limitations under the License.
 
 use alloy_primitives::B256;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(not(target_os = "zkvm"))]
 use std::fmt;
 
 /// A 32-byte hash digest representing an image ID or journal digest.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct Digest([u8; 32]);
+
+/// Serde encodes as eight little-endian u32 words, wire-identical to
+/// `risc0_zkvm::sha::Digest`. Deployed guests (e.g. the on-chain assessor)
+/// decode their postcard inputs against that layout, so the encoding is a
+/// compatibility contract, not an implementation detail: a byte-array
+/// encoding here would silently break every host-to-deployed-guest boundary
+/// that embeds a digest.
+impl Serialize for Digest {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let words: [u32; 8] = core::array::from_fn(|i| {
+            u32::from_le_bytes(self.0[i * 4..i * 4 + 4].try_into().expect("4-byte chunk"))
+        });
+        words.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let words = <[u32; 8]>::deserialize(deserializer)?;
+        let mut bytes = [0u8; 32];
+        for (i, word) in words.iter().enumerate() {
+            bytes[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
+        }
+        Ok(Self(bytes))
+    }
+}
 
 impl Digest {
     /// The zero digest.
@@ -99,6 +125,17 @@ mod tests {
         let bytes = [1u8; 32];
         let d = Digest::from_bytes(bytes);
         assert_eq!(<[u8; 32]>::from(d), bytes);
+    }
+
+    #[test]
+    fn postcard_wire_format_matches_risc0_digest() {
+        // risc0's Digest is [u32; 8]; postcard varint-encodes each LE word.
+        // 0x42424242 -> varint c2 84 89 92 04, repeated for all 8 words.
+        let d = Digest::from_bytes([0x42; 32]);
+        let encoded = postcard::to_allocvec(&d).unwrap();
+        assert_eq!(encoded, [0xc2, 0x84, 0x89, 0x92, 0x04].repeat(8));
+        let decoded: Digest = postcard::from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, d);
     }
 
     #[cfg(not(target_os = "zkvm"))]


### PR DESCRIPTION
The SDK decoupling (#2039) replaced `risc0_zkvm::sha::Digest` with a boundless-native `Digest`, which silently changed the postcard wire format of every digest embedded in guest inputs: risc0's `Digest` is `[u32; 8]` (postcard: eight varint-encoded words), the new type was `[u8; 32]` (postcard: 32 raw bytes). Any host proving the **deployed** assessor guest (image `0x6c5a03c0…`) now feeds it undecodable `AssessorInput` — the guest panics with `PostcardDeserializeError(DeserializeUnexpectedEnd)`.

CI cannot see this class of drift: the in-repo assessor guest rebuilds with the same type, so host and guest move together and every test stays green. Only the boundary to **already-deployed** guests breaks. That boundary is load-bearing for the router migration: `R0BoundlessAssessorAdapter` deliberately pins the deployed guest image ("today's R0 STARK assessor proofs remain bit-identically verifiable through the router — no guest changes required"), so both the CLI fulfiller and the broker's STARK-assessor fallback depend on it. Surfaced during router-native market validation on Taiko, where the open-path fulfillment flow (#2052) proved the deployed assessor guest for the first time from this tree.

```
                        AssessorInput (postcard)
host ─────────────────────────────────────▶ deployed assessor guest (0x6c5a03c0…)
      before: Digest as 32 raw bytes    ✗    expects eight varint u32 words
      after:  Digest as 8 LE u32 words  ✓    decodes, proof verifies via the
                                             router assessor adapter
```

## Changes

- **`boundless-market/src/digest.rs`** — replace the derived serde with custom `Serialize`/`Deserialize` encoding eight little-endian `u32` words, wire-identical to `risc0_zkvm::sha::Digest`. The encoding is a compatibility contract with deployed guests, not an implementation detail; a comment on the impl says so. Verified byte-identical to the v2.0.2 encoder's output, and the deployed assessor guest ELF executes past input decode with an input encoded by this tree.
- **`boundless-market/src/digest.rs` (test)** — byte-exact regression test pinning the postcard encoding (`0x42424242` word → `c2 84 89 92 04`, ×8) plus roundtrip, so any future serde change on this type fails loudly instead of drifting.
- **`boundless-cli/src/lib.rs`** — `ASSESSOR_IMAGE_URL` env override for the fulfiller's assessor guest source (any downloader scheme, including `file://`), so a locally built guest can be proven against a router adapter that pins its image id in test deployments.

Related: #2039 (regression source), #2052 (open-path fulfillment flow that first exercised the deployed-guest boundary).
