### PR TITLE
BM-3087: chore(deployment): staging router deployments (Base Sepolia + Taiko) and upgrade-script reference override

### DIFF
--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -262,8 +262,8 @@ verifier = "0x607d196b43abc5d9BE3c7Fb8e336Ca82fec18C45"
 application-verifier = "0x6E96201D39CE861c7DCeDC56CdB937a9A880Eb73"
 set-verifier = "0x6135DC08D14EF8a44496B009e2181426628B8ebd"
 boundless-market = "0x60d11ef5d4608bab18a663fd486d3b9f162172cf"
-boundless-market-impl = "0x7d27d73368c9cece5bc25d9b4c9d912de5af9db1"
-boundless-market-old-impl = "0x0000000000000000000000000000000000000000"
+boundless-market-impl = "0xad9af87319e744c62f33e05bb2a2cb9f20c7a358"
+boundless-market-old-impl = "0x7d27d73368c9cece5bc25d9b4c9d912de5af9db1"
 collateral-token = "0xC284A781072442cC1882a8Db4573990B7B49DaC4"
 
 # Guests info
@@ -272,6 +272,7 @@ assessor-image-id = "0x6c5a03c0785e91bc0ad0db486004116010680a03af4e712bcca3188e5
 assessor-guest-url = "https://gateway.beboundless.cloud/ipfs/bafybeiauvbhinz2yqm2vbgpl2njgoyaxhuwa2vbv6gts2ajcjfkw5m4ejq"
 deprecated-assessor-duration = 0
 boundless-market-deployment-commit = "901097a54"
+boundless-router = "0xd2a01b63bf9d08d31fb11ba81825624c6484453f"
 
 #################################################################################
 #                               QUICK EPOCH                                     #

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -235,7 +235,7 @@ application-verifier = "0xA326b2eb45A5C3C206dF905A58970DcA57B8719e"
 set-verifier = "0x1Ab08498CfF17b9723ED67143A050c8E8c2e3104"
 # deployed at block 26370829
 boundless-market = "0x7abb16522f4599481361d318b765af988bfcca8e"
-boundless-market-impl = "0xd60e833ea8ff4e44222e15df4db7c043b9748664"
+boundless-market-impl = "0x1de3eacc02f263b666e2251ff6167cecbf51e3b6"
 boundless-market-old-impl = "0x4896bb4e1fb52ed283d505de79532e2b01e2a066"
 boundless-market-deployment-commit = "bda3b118"
 collateral-token = "0xCBA5Fd30105984125395c18B6E6b1bf603408629"
@@ -245,7 +245,7 @@ deployment-commit = "bda3b118" # v0.15.0 main
 assessor-image-id = "0x6c5a03c0785e91bc0ad0db486004116010680a03af4e712bcca3188e56694100"
 assessor-guest-url = "https://gateway.beboundless.cloud/ipfs/bafybeiauvbhinz2yqm2vbgpl2njgoyaxhuwa2vbv6gts2ajcjfkw5m4ejq"
 deprecated-assessor-duration = 1296000  # 15 days
-boundless-router = "0x9045fa3c9ad018cef3d185b1e275af100fe6915c"
+boundless-router = "0x6f4523fd85fa19bf469d4f804a55e0d5e73efef4"
 
 [deployment.taiko-staging]
 name = "Taiko Staging"

--- a/contracts/deployment.toml
+++ b/contracts/deployment.toml
@@ -62,8 +62,9 @@ application-verifier = "0xA326b2eb45A5C3C206dF905A58970DcA57B8719e"
 set-verifier = "0x1Ab08498CfF17b9723ED67143A050c8E8c2e3104"
 # deployed at block 31134603
 boundless-market = "0xfd152dadc5183870710fe54f939eae3ab9f0fe82"
-boundless-market-impl = "0x22bb6bbe5d221ef3e738029dab4d1d27ec725cd3"
-boundless-market-old-impl = "0xc2127560e3bb6d368124718a17969c90f39fde61"
+boundless-market-impl = "0xbf3b740faf258f8e4ab214702a96918ab739a686"
+boundless-market-old-impl = "0x22bb6bbe5d221ef3e738029dab4d1d27ec725cd3"
+boundless-router = "0x7d4bb6295e56ba3e93f51f44598310539cd783a2"
 collateral-token = "0xAA61bB7777bD01B684347961918f1E07fBbCe7CF"
 
 # Guests info
@@ -135,8 +136,9 @@ verifier = "0x607d196b43abc5d9BE3c7Fb8e336Ca82fec18C45"
 application-verifier = "0x607d196b43abc5d9BE3c7Fb8e336Ca82fec18C45"
 set-verifier = "0x6135DC08D14EF8a44496B009e2181426628B8ebd"
 boundless-market = "0xb3f5c7b4379052eade8c7f3fa6da37fb871da28b"
-boundless-market-impl = "0x6c2d2c33e9a7cd0e1b39dc218f472e4bf534523b"
-boundless-market-old-impl = "0x0000000000000000000000000000000000000000"
+boundless-market-impl = "0x0824b650350cc2f510aa22e061a917524945b78c"
+boundless-market-old-impl = "0x6c2d2c33e9a7cd0e1b39dc218f472e4bf534523b"
+boundless-router = "0x8a4beac3b253c65868f091f87e56d4bafaabef22"
 collateral-token = "0xC284A781072442cC1882a8Db4573990B7B49DaC4"
 
 # Guests info

--- a/contracts/scripts/Manage.s.sol
+++ b/contracts/scripts/Manage.s.sol
@@ -211,6 +211,14 @@ contract UpgradeBoundlessMarket is BoundlessScriptBase {
         if (skipSafetyChecks) {
             console2.log("WARNING: Skipping all upgrade safety checks and reference build!");
             opts.unsafeSkipAllChecks = true;
+        } else if (bytes(vm.envOr("REFERENCE_CONTRACT", string(""))).length != 0) {
+            // REFERENCE_CONTRACT overrides the layout reference with a contract from the CURRENT
+            // build — e.g. "BoundlessMarketLegacy.sol:BoundlessMarket" under FOUNDRY_PROFILE=shanghai,
+            // the frozen Taiko legacy whose bytecode parity with the deployed impl is enforced by
+            // `just check-legacy-bytecode-shanghai`. Use it when the deployed commit cannot provide
+            // a reference build at the default path below. No external build-info dir is wired: an
+            // in-build reference resolves against this build's artifacts.
+            opts.referenceContract = vm.envString("REFERENCE_CONTRACT");
         } else {
             // Only set reference contract when doing safety checks. The file-qualified name is
             // required: the legacy fallback source (BoundlessMarketLegacy.sol) also declares a


### PR DESCRIPTION
## Summary

Staging deployments of the BoundlessRouter market upgrade from `main@9f2470ab`, plus a small upgrade-script extension the Taiko flow required.

## Base Sepolia staging — deployed, Safe txs pending

Fresh bring-up redone from main; the earlier deployment (router `0x9045fa3c…`, impl `0xd60e833e…`, from `jonas/adopt-router-in-broker@b04705a`) was abandoned before the Safe txs executed and its queued upgrade tx has been rejected.

`[deployment.base-sepolia-staging]`:
- `boundless-router` → `0x6f4523fd85fa19bf469d4f804a55e0d5e73efef4` — freshly deployed, Safe holds ADMIN_ROLE from the deploy tx
- `boundless-market-impl` → `0x1de3eacc02f263b666e2251ff6167cecbf51e3b6` — new router-aware impl (`ROUTER`/`LEGACY_IMPL`/collateral immutables verified on-chain)

Two Safe txs are pending: the router bootstrap batch (must execute first) and `upgradeToAndCall` on the market proxy. Upgrade guide: https://docs.google.com/document/d/1yNDBqafT9pOgbSfxNRYjPGbU1ZSrIXTMJICeZLED6lo/edit

## Taiko staging — deployed and executed

EOA-admin flow (no Safe), everything built under `FOUNDRY_PROFILE=shanghai`. Live on Taiko (chain 167000), verified on-chain:

`[deployment.taiko-staging]`:
- `boundless-router` → `0xd2a01b63bf9d08d31fb11ba81825624c6484453f` — bootstrapped (4 classes, 5 entries); every adapter wraps exactly the verifier the legacy market resolved for its selector
- `boundless-market-impl` → `0xad9af87319e744c62f33e05bb2a2cb9f20c7a358` — the shanghai-variant router market, upgraded in place
- `boundless-market-old-impl` → `0x7d27d73368c9cece5bc25d9b4c9d912de5af9db1` — the previous impl, now serving the legacy ABI via the delegatecall fallback (`LEGACY_IMPL`)

## Upgrade script: REFERENCE_CONTRACT override

`UpgradeBoundlessMarket` hardcoded its OZ storage-layout reference to `build-info-reference:contracts/src/BoundlessMarket.sol:BoundlessMarket`, which cannot resolve for the Taiko upgrade: the deployed commit (`901097a54`) predates the shared-tree shanghai profile, so no reference build exists at that path.

New optional `REFERENCE_CONTRACT` env var points the validation at a contract from the **current** build instead — for Taiko, the frozen legacy `BoundlessMarketLegacy.sol:BoundlessMarket` under `contracts/shanghai/legacy/`, whose bytecode parity with the deployed impl is CI-enforced (`just check-legacy-bytecode-shanghai`). This keeps the layout safety checks on (no `SKIP_SAFETY_CHECKS`) with a reference that is provably the deployed code. Default behavior is unchanged when the variable is unset.