### PR TITLE
BM-3086: fix(examples): repair nightly examples — missing bytes-compat remapping

### DIFF
--- a/.github/workflows/nightly-examples.yml
+++ b/.github/workflows/nightly-examples.yml
@@ -169,7 +169,7 @@ jobs:
           echo "BLAKE3_GROTH16_SETUP_DIR=$HOME/.risc0/blake3_groth16" >> "$GITHUB_ENV"
 
           mkdir -p "$BLAKE3_GROTH16_SETUP_DIR"
-          curl -L -o /tmp/blake3_groth16_artifacts.tar.xz \
+          curl -fL -o /tmp/blake3_groth16_artifacts.tar.xz \
             "https://staging-signal-artifacts.beboundless.xyz/v3/proving/blake3_groth16_artifacts.tar.xz"
           tar -xJf /tmp/blake3_groth16_artifacts.tar.xz \
             -C "$BLAKE3_GROTH16_SETUP_DIR" --strip-components=1

--- a/examples/smart-contract-requestor/remappings.txt
+++ b/examples/smart-contract-requestor/remappings.txt
@@ -2,4 +2,5 @@ forge-std/=lib/forge-std/src/
 openzeppelin/=lib/openzeppelin-contracts/
 risc0/=lib/risc0-ethereum/contracts/src/
 boundless-market/=../../contracts/src/
+bytes-compat/=../../lib/openzeppelin-contracts/contracts/utils/
 


### PR DESCRIPTION
## Summary

The last two nightly examples runs failed ([2026-07-08](https://github.com/boundless-xyz/boundless/actions/runs/28914585920), [2026-07-07](https://github.com/boundless-xyz/boundless/actions/runs/28838757981)). This fixes the code regression behind one of the two failures and makes the other fail loudly at its actual source.

## Changes

- **Add `bytes-compat/` remapping to `examples/smart-contract-requestor/remappings.txt`.** #2044 added `import {Bytes} from "bytes-compat/Bytes.sol"` to `contracts/src/types/Predicate.sol` and the matching remapping to the root `foundry.toml`, but the example keeps its own `remappings.txt`, which was not updated. Since the example imports `boundless-market/types/Predicate.sol` (directly and via `ProofRequest.sol`), its forge build broke in the first nightly run on that commit. The new remapping points at the root OpenZeppelin checkout, matching how the rest of `contracts/src` resolves OZ imports in this build. Verified locally with `forge build` and `forge test` in the example.

- **Use `curl --fail` for the blake3 groth16 artifact download in `nightly-examples.yml`.** The blake3-groth16 job failed both nights because `blake3_groth16_artifacts.tar.xz` is gone from the staging signal-artifacts bucket — the URL now serves a Cloudflare 404 HTML page, which curl happily saved and tar then rejected with a confusing "File format not recognized". With `--fail`, the download step itself fails on HTTP errors.

Note: this PR does **not** fix the blake3-groth16 job — the artifact needs to be re-uploaded to the bucket (likely deleted by the R2 retention policy; `docker-services.yml` bakes in the same URL and is affected too). That is an ops action tracked separately.