### PR TITLE
BM-3090: Bump Kailua to `c003948`

### DIFF
--- a/infra/kailua-batch/Pulumi.prod.yaml
+++ b/infra/kailua-batch/Pulumi.prod.yaml
@@ -4,7 +4,7 @@ config:
   aws:region: us-west-2
   kailua-batch:BASE_STACK: organization/bootstrap/services-prod
   kailua-batch:CHAIN_ID: "10"
-  kailua-batch:KAILUA_IMAGE: ghcr.io/boundless-xyz/kailua:df322d3
+  kailua-batch:KAILUA_IMAGE: ghcr.io/boundless-xyz/kailua:c003948
   # BLOCK_COUNT per launched task: task index 0 -> 1, task index 1 -> 2, task index 2 -> 3 (see trigger Lambda)
   kailua-batch:TASK_CPU: "8"
   kailua-batch:TASK_MEMORY_MIB: "8192"

--- a/infra/kailua-batch/Pulumi.staging.yaml
+++ b/infra/kailua-batch/Pulumi.staging.yaml
@@ -4,7 +4,7 @@ config:
   aws:region: us-west-2
   kailua-batch:BASE_STACK: organization/bootstrap/services-staging
   kailua-batch:CHAIN_ID: "10"
-  kailua-batch:KAILUA_IMAGE: ghcr.io/boundless-xyz/kailua:df322d3
+  kailua-batch:KAILUA_IMAGE: ghcr.io/boundless-xyz/kailua:c003948
   kailua-batch:TASK_CPU: "8"
   kailua-batch:TASK_MEMORY_MIB: "8192"
   kailua-batch:LOG_RETENTION_DAYS: "30"


### PR DESCRIPTION
Bumps the kailua-batch image (prod + staging) from `df322d3` (kona v1.2.14, pre-Karst) to `c003948` (kona v1.6.0 + hint-fetch retry backoff, boundless-xyz/kailua#151).

Since Karst activated on OP mainnet (2026-07-08), the deployed image deterministically derives non-canonical blocks for ~3% of tasks; each stuck task then re-requests its own wrong block hash in a tight loop (~34 req/s for 20+ min), which rate-limited our RPC L1 endpoint (~31M 429s/day). The new image derives post-Karst blocks correctly, and the backoff patch caps retry pressure if a task ever gets stuck again.
