### PR TITLE
BM-3091: feat(cli): default prover fulfill to the on-chain assessor

### DIFF
--- a/crates/boundless-cli/src/bin/boundless-ffi.rs
+++ b/crates/boundless-cli/src/bin/boundless-ffi.rs
@@ -25,7 +25,7 @@ use alloy::{
     sol_types::SolValue,
 };
 use anyhow::{bail, ensure, Context, Result};
-use boundless_cli::{OrderFulfilled, OrderFulfiller};
+use boundless_cli::{AssessorMode, OrderFulfilled, OrderFulfiller};
 use boundless_market::contracts::{eip712_domain, ProofRequest};
 use boundless_market::storage::StandardDownloader;
 use broker::provers::{DefaultProver as BrokerDefaultProver, Prover};
@@ -136,10 +136,10 @@ async fn main() -> Result<()> {
         prover,
         Arc::new(StandardDownloader::new().await),
         set_builder_image_id,
-        assessor_image_id,
+        Some(assessor_image_id),
         args.prover_address,
         domain.clone(),
-        args.assessor_selector,
+        AssessorMode::R0 { selector: args.assessor_selector },
     )?;
     let request = <ProofRequest>::abi_decode(&hex::decode(args.request.trim_start_matches("0x"))?)
         .map_err(|_| anyhow::anyhow!("Failed to decode ProofRequest from input"))?;

--- a/crates/boundless-cli/src/commands/prover/fulfill.rs
+++ b/crates/boundless-cli/src/commands/prover/fulfill.rs
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{OrderFulfilled, OrderFulfiller};
-use alloy::primitives::{FixedBytes, B256, U256};
-use anyhow::{bail, Context, Result};
-use boundless_market::contracts::boundless_market::{FulfillmentTx, UnlockedRequest};
+use crate::{AssessorMode, OrderFulfilled, OrderFulfiller};
+use alloy::primitives::{Address, FixedBytes, B256, U256};
+use anyhow::{bail, ensure, Context, Result};
+use boundless_market::contracts::{
+    boundless_market::{FulfillmentTx, UnlockedRequest},
+    ONCHAIN_ASSESSOR_SELECTOR,
+};
 use clap::Args;
 
 use crate::config::{GlobalConfig, ProverConfig};
@@ -41,8 +44,10 @@ pub struct ProverFulfill {
     #[arg(long, default_value = "false")]
     pub withdraw: bool,
 
-    /// The 4-byte BoundlessRouter assessor selector to prepend to the assessor seal (hex, e.g. 0x00000022)
-    #[arg(long)]
+    /// The 4-byte BoundlessRouter assessor selector to prepend to the assessor seal. Defaults to
+    /// the on-chain assessor (an EIP-712 batch signature, no assessor guest proof); pass the R0
+    /// assessor selector (e.g. 0x00000024) to prove the assessor guest instead.
+    #[arg(long, default_value_t = ONCHAIN_ASSESSOR_SELECTOR)]
     pub assessor_selector: FixedBytes<4>,
 
     /// Lower bound: search events backwards down to this block
@@ -89,12 +94,35 @@ impl ProverFulfill {
 
         display.header("Fulfilling Proof Requests");
         display.item_colored("Request IDs", &request_ids_string, "cyan");
+        display.item_colored("Assessor", self.assessor_selector.to_string(), "cyan");
         display.status("Status", "Initializing prover and fetching images", "yellow");
+
+        let assessor_mode = if self.assessor_selector == ONCHAIN_ASSESSOR_SELECTOR {
+            // The adapter address is the EIP-712 verifying contract of the batch signature;
+            // discover it behind the selector via the market's router.
+            let adapter =
+                client
+                    .boundless_market
+                    .router_entry_impl(self.assessor_selector)
+                    .await
+                    .context("failed to resolve the OnChainAssessor adapter from the router")?;
+            ensure!(
+                adapter != Address::ZERO,
+                "the on-chain assessor is not registered in this market's router; pass \
+                 --assessor-selector with the R0 assessor selector (e.g. 0x00000024) instead"
+            );
+            AssessorMode::Onchain {
+                selector: self.assessor_selector,
+                adapter,
+                signer: prover_config.require_private_key_with_help()?,
+            }
+        } else {
+            AssessorMode::R0 { selector: self.assessor_selector }
+        };
 
         // Initialize fulfiller with prover setup and image uploads
         let fulfiller =
-            OrderFulfiller::initialize_from_config(&prover_config, &client, self.assessor_selector)
-                .await?;
+            OrderFulfiller::initialize_from_config(&prover_config, &client, assessor_mode).await?;
 
         let fetch_order_jobs = self.request_ids.iter().enumerate().map(|(i, request_id)| {
             let client = client.clone();

--- a/crates/boundless-cli/src/lib.rs
+++ b/crates/boundless-cli/src/lib.rs
@@ -30,7 +30,10 @@ pub mod contracts;
 pub mod display;
 pub mod price_oracle_helper;
 
-use alloy::primitives::{Address, Bytes, FixedBytes};
+use alloy::{
+    primitives::{Address, Bytes, FixedBytes},
+    signers::local::PrivateKeySigner,
+};
 use anyhow::{bail, Context, Result};
 use blake3_groth16::Blake3Groth16Receipt;
 use boundless_assessor::{AssessorInput, Fulfillment};
@@ -51,14 +54,35 @@ use std::sync::Arc;
 
 use boundless_market::{
     contracts::{
-        EIP712DomainSaltless, Fulfillment as BoundlessFulfillment, FulfillmentBatch,
-        FulfillmentData, PredicateType, RequestInputType, SlimRequest,
+        build_onchain_assessor_seal, EIP712DomainSaltless, Fulfillment as BoundlessFulfillment,
+        FulfillmentBatch, FulfillmentData, PredicateType, RequestInputType, SlimRequest,
     },
     input::GuestEnv,
     selector::{is_blake3_groth16_selector, is_groth16_selector, SupportedSelectors},
     storage::StorageDownloader,
     NotProvided, ProofRequest,
 };
+
+/// How the assessor seal for a fulfillment batch is produced.
+#[derive(Clone)]
+pub enum AssessorMode {
+    /// Prove the R0 assessor guest and aggregate it with the order claims; the seal is the guest
+    /// receipt's set-inclusion proof framed behind `selector`.
+    R0 {
+        /// The 4-byte router entry selector of the deployed `R0BoundlessAssessorAdapter`.
+        selector: FixedBytes<4>,
+    },
+    /// Skip the assessor guest; the seal is an EIP-712 `FulfillmentBatchAuth` signature framed
+    /// behind `selector`, verified by the `OnChainAssessor` adapter deployed at `adapter`.
+    Onchain {
+        /// The 4-byte router entry selector of the deployed `OnChainAssessor` adapter.
+        selector: FixedBytes<4>,
+        /// The deployed `OnChainAssessor` adapter (the EIP-712 `verifyingContract`).
+        adapter: Address,
+        /// Signs the batch authorization; must control the prover address credited on-chain.
+        signer: PrivateKeySigner,
+    },
+}
 
 /// Default URL for assessor image - matches broker config defaults. The assessor guest currently
 /// deployed on-chain (image id 0x6c5a03c0…56694100), matching the market `imageInfo()` and the
@@ -212,12 +236,13 @@ pub struct OrderFulfiller {
     prover: Arc<dyn Prover + Send + Sync>,
     downloader: Arc<dyn StorageDownloader + Send + Sync>,
     set_builder_image_id: Digest,
-    assessor_image_id: Digest,
+    /// The R0 assessor guest image id; only set in [AssessorMode::R0].
+    assessor_image_id: Option<Digest>,
     address: Address,
     domain: EIP712DomainSaltless,
     supported_selectors: SupportedSelectors,
-    /// The 4-byte router assessor selector prepended to the assessor seal.
-    assessor_selector: FixedBytes<4>,
+    /// How the batch assessor seal is produced.
+    assessor_mode: AssessorMode,
 }
 
 impl OrderFulfiller {
@@ -226,10 +251,10 @@ impl OrderFulfiller {
         prover: Arc<dyn Prover + Send + Sync>,
         downloader: Arc<dyn StorageDownloader>,
         set_builder_image_id: Digest,
-        assessor_image_id: Digest,
+        assessor_image_id: Option<Digest>,
         address: Address,
         domain: EIP712DomainSaltless,
-        assessor_selector: FixedBytes<4>,
+        assessor_mode: AssessorMode,
     ) -> Result<Self> {
         let supported_selectors =
             SupportedSelectors::default().with_set_builder_image_id(set_builder_image_id);
@@ -241,14 +266,14 @@ impl OrderFulfiller {
             address,
             domain,
             supported_selectors,
-            assessor_selector,
+            assessor_mode,
         })
     }
 
     pub(crate) async fn initialize_from_config<P, St, D, R, Si>(
         prover_config: &config::ProverConfig,
         client: &boundless_market::Client<NotProvided, P, St, D, R, Si>,
-        assessor_selector: FixedBytes<4>,
+        assessor_mode: AssessorMode,
     ) -> Result<Self>
     where
         P: alloy::providers::Provider + Clone + 'static,
@@ -284,19 +309,20 @@ impl OrderFulfiller {
             )?)
         };
 
-        Self::initialize(prover, client, assessor_selector, ASSESSOR_DEFAULT_IMAGE_URL).await
+        Self::initialize(prover, client, assessor_mode, ASSESSOR_DEFAULT_IMAGE_URL).await
     }
 
     /// Initialize an OrderFulfiller from a provided Prover instance.
     ///
-    /// `assessor_image_url` is the source for the assessor guest ELF; its image id must match the
-    /// one the deployed `R0BoundlessAssessorAdapter` verifies against. Production passes
-    /// [ASSESSOR_DEFAULT_IMAGE_URL]; tests point it at the locally-built guest so the proven image
-    /// matches the image deployed by the test harness.
+    /// In [AssessorMode::R0], `assessor_image_url` is the source for the assessor guest ELF; its
+    /// image id must match the one the deployed `R0BoundlessAssessorAdapter` verifies against.
+    /// Production passes [ASSESSOR_DEFAULT_IMAGE_URL]; tests point it at the locally-built guest
+    /// so the proven image matches the image deployed by the test harness. In
+    /// [AssessorMode::Onchain] no assessor guest is proven and the URL is unused.
     pub async fn initialize<P, St, D, R, Si>(
         prover: Arc<dyn Prover + Send + Sync>,
         client: &boundless_market::Client<NotProvided, P, St, D, R, Si>,
-        assessor_selector: FixedBytes<4>,
+        assessor_mode: AssessorMode,
         assessor_image_url: &str,
     ) -> Result<Self>
     where
@@ -310,24 +336,31 @@ impl OrderFulfiller {
             client.set_verifier.image_info().await?;
         let set_builder_image_id = Digest::try_from(set_builder_image_id_bytes.as_slice())?;
 
-        // The market no longer exposes the assessor image info; derive it from the configured ELF.
-        let assessor_program = downloader
-            .download(assessor_image_url)
-            .await
-            .context("Failed to download assessor image")?;
-        let assessor_image_id =
-            compute_image_id(&assessor_program).context("Failed to compute assessor image ID")?;
+        let assessor_image_id = match &assessor_mode {
+            AssessorMode::Onchain { .. } => None,
+            AssessorMode::R0 { .. } => {
+                // The market no longer exposes the assessor image info; derive it from the
+                // configured ELF.
+                let assessor_program = downloader
+                    .download(assessor_image_url)
+                    .await
+                    .context("Failed to download assessor image")?;
+                let assessor_image_id = compute_image_id(&assessor_program)
+                    .context("Failed to compute assessor image ID")?;
 
-        tracing::debug!("Fetching Assessor program (ID: {})", assessor_image_id);
-        ensure_prover_has_image(
-            &prover,
-            "assessor",
-            assessor_image_id,
-            assessor_image_url,
-            assessor_image_url,
-            &downloader,
-        )
-        .await?;
+                tracing::debug!("Fetching Assessor program (ID: {})", assessor_image_id);
+                ensure_prover_has_image(
+                    &prover,
+                    "assessor",
+                    assessor_image_id,
+                    assessor_image_url,
+                    assessor_image_url,
+                    &downloader,
+                )
+                .await?;
+                Some(assessor_image_id)
+            }
+        };
 
         tracing::debug!("Fetching SetBuilder program (ID: {})", set_builder_image_id);
         ensure_prover_has_image(
@@ -347,7 +380,7 @@ impl OrderFulfiller {
             assessor_image_id,
             client.boundless_market.caller(),
             domain,
-            assessor_selector,
+            assessor_mode,
         )
     }
 
@@ -409,8 +442,9 @@ impl OrderFulfiller {
 
         let stdin = GuestEnv::builder().write_frame(&assessor_input.encode()).stdin;
 
-        let image_id_str = self.assessor_image_id.to_string();
-        self.prove_stark(&image_id_str, stdin, assumption_ids).await
+        let image_id =
+            self.assessor_image_id.context("assessor image id is only set in R0 assessor mode")?;
+        self.prove_stark(&image_id.to_string(), stdin, assumption_ids).await
     }
 
     /// Fulfills a list of orders, returning the relevant data:
@@ -518,28 +552,38 @@ impl OrderFulfiller {
             }
         }
 
-        tracing::debug!("Proving assessor");
-        let assessor_receipt_id = self.assessor(fills.clone(), proof_ids.clone()).await?;
-        let assessor_receipt = self
-            .prover
-            .get_receipt(&assessor_receipt_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Assessor receipt not found"))?;
-        let assessor_journal = assessor_receipt.journal.bytes.clone();
-        let assessor_claim = prune_receipt_claim_journal(ReceiptClaim::ok(
-            self.assessor_image_id,
-            assessor_journal.clone(),
-        ));
-        claims.push(assessor_claim.clone());
-        claim_digests.push(assessor_claim.digest());
+        anyhow::ensure!(!fills.is_empty(), "no orders were successfully proven");
+
+        // The R0 assessor guest is only proven (and aggregated with the order claims) when it
+        // seals the batch; the on-chain assessor replaces it with an EIP-712 batch signature.
+        let assessor_r0 = match &self.assessor_mode {
+            AssessorMode::Onchain { .. } => None,
+            AssessorMode::R0 { .. } => {
+                tracing::debug!("Proving assessor");
+                let assessor_receipt_id = self.assessor(fills.clone(), proof_ids.clone()).await?;
+                let assessor_receipt = self
+                    .prover
+                    .get_receipt(&assessor_receipt_id)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("Assessor receipt not found"))?;
+                let assessor_journal = assessor_receipt.journal.bytes.clone();
+                let assessor_claim = prune_receipt_claim_journal(ReceiptClaim::ok(
+                    self.assessor_image_id
+                        .context("assessor image id is only set in R0 assessor mode")?,
+                    assessor_journal.clone(),
+                ));
+                claims.push(assessor_claim.clone());
+                claim_digests.push(assessor_claim.digest());
+                Some((assessor_receipt_id, assessor_claim))
+            }
+        };
 
         tracing::debug!("Finalizing");
-        let root_receipt_id = self
-            .finalize(
-                claims.clone(),
-                [proof_ids.as_slice(), std::slice::from_ref(&assessor_receipt_id)].concat(),
-            )
-            .await?;
+        let mut assumption_ids = proof_ids.clone();
+        if let Some((assessor_receipt_id, _)) = &assessor_r0 {
+            assumption_ids.push(assessor_receipt_id.clone());
+        }
+        let root_receipt_id = self.finalize(claims.clone(), assumption_ids).await?;
         let compressed_receipt_bytes = self
             .prover
             .get_compressed_receipt(&root_receipt_id)
@@ -616,18 +660,41 @@ impl OrderFulfiller {
             boundless_fills.push(fulfillment);
         }
 
-        let assessor_inclusion_receipt = SetInclusionReceipt::from_path_with_verifier_params(
-            assessor_claim,
-            merkle_path(&claim_digests, claim_digests.len() - 1),
-            verifier_parameters.digest(),
-        );
-
-        // The on-chain assessor seal is `router assessor selector ++ inner seal`. Callbacks and
-        // selectors are no longer submitted; they are derived on-chain from the signed SlimRequest.
-        let assessor_seal = boundless_market::contracts::assessor_seal(
-            self.assessor_selector,
-            assessor_inclusion_receipt.abi_encode_seal()?,
-        );
+        // The assessor seal is `router assessor selector ++ inner seal`. Callbacks and selectors
+        // are no longer submitted; they are derived on-chain from the signed SlimRequest.
+        let assessor_seal = match &self.assessor_mode {
+            AssessorMode::R0 { selector } => {
+                let (_, assessor_claim) =
+                    assessor_r0.context("the R0 assessor mode proves the assessor guest")?;
+                let assessor_inclusion_receipt =
+                    SetInclusionReceipt::from_path_with_verifier_params(
+                        assessor_claim,
+                        merkle_path(&claim_digests, claim_digests.len() - 1),
+                        verifier_parameters.digest(),
+                    );
+                boundless_market::contracts::assessor_seal(
+                    *selector,
+                    assessor_inclusion_receipt.abi_encode_seal()?,
+                )
+            }
+            AssessorMode::Onchain { selector, adapter, signer } => {
+                // The signed batch authorization must cover exactly the fills being submitted.
+                let requests: Vec<ProofRequest> =
+                    successful_indices.iter().map(|&idx| orders[idx].0.clone()).collect();
+                build_onchain_assessor_seal(
+                    signer,
+                    *selector,
+                    *adapter,
+                    self.domain.chain_id,
+                    &self.domain.alloy_struct(),
+                    self.address,
+                    &requests,
+                    &boundless_fills,
+                )
+                .await
+                .context("Failed to build the on-chain assessor seal")?
+            }
+        };
 
         Ok((boundless_fills, root_receipt, assessor_seal))
     }
@@ -657,7 +724,7 @@ mod tests {
     };
     use boundless_test_utils::{
         guests::{ASSESSOR_GUEST_PATH, ECHO_ID, ECHO_PATH},
-        market::{create_test_ctx, ASSESSOR_R0_SELECTOR},
+        market::{create_test_ctx, ASSESSOR_ONCHAIN_SELECTOR, ASSESSOR_R0_SELECTOR},
     };
     use std::sync::Arc;
 
@@ -703,7 +770,7 @@ mod tests {
         let mut fulfiller = OrderFulfiller::initialize(
             prover,
             &client,
-            ASSESSOR_R0_SELECTOR,
+            AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
             &format!("file://{ASSESSOR_GUEST_PATH}"),
         )
         .await
@@ -730,7 +797,7 @@ mod tests {
         let mut fulfiller = OrderFulfiller::initialize(
             prover,
             &client,
-            ASSESSOR_R0_SELECTOR,
+            AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
             &format!("file://{ASSESSOR_GUEST_PATH}"),
         )
         .await
@@ -738,6 +805,68 @@ mod tests {
         fulfiller.domain = eip712_domain(Address::ZERO, 1);
 
         fulfiller.fulfill(&[(request, signature.as_bytes().into())]).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "test-r0vm"), ignore = "runs a proof; slow without RISC0_DEV_MODE=1")]
+    async fn test_fulfill_onchain_assessor() {
+        use alloy::sol_types::SolStruct;
+        use boundless_market::contracts::{
+            fulfillment_batch_auth_signing_hash, onchain_assessor_eip712_domain,
+        };
+
+        let anvil = Anvil::new().spawn();
+        let ctx = create_test_ctx(&anvil).await.unwrap();
+        let client = boundless_market::Client::new(
+            ctx.customer_market.clone(),
+            ctx.set_verifier.clone(),
+            StandardDownloader::new().await,
+        );
+
+        let signer = PrivateKeySigner::random();
+        let (request, signature) = setup_proving_request_and_signature(&signer, None).await;
+
+        let adapter =
+            ctx.customer_market.router_entry_impl(ASSESSOR_ONCHAIN_SELECTOR).await.unwrap();
+        assert_ne!(adapter, Address::ZERO);
+
+        let prover: Arc<dyn Prover + Send + Sync> = Arc::new(BrokerDefaultProver::default());
+        let mut fulfiller = OrderFulfiller::initialize(
+            prover,
+            &client,
+            AssessorMode::Onchain {
+                selector: ASSESSOR_ONCHAIN_SELECTOR,
+                adapter,
+                signer: ctx.customer_signer.clone(),
+            },
+            &format!("file://{ASSESSOR_GUEST_PATH}"),
+        )
+        .await
+        .unwrap();
+        fulfiller.domain = eip712_domain(Address::ZERO, 1);
+
+        let (fills, _root_receipt, assessor_seal) =
+            fulfiller.fulfill(&[(request.clone(), signature.as_bytes().into())]).await.unwrap();
+
+        // The seal is the 4-byte on-chain assessor selector followed by a 65-byte ECDSA
+        // signature that recovers to the prover over the hash `OnChainAssessor` reconstructs.
+        assert_eq!(fills.len(), 1);
+        assert_eq!(assessor_seal.len(), 69);
+        assert_eq!(&assessor_seal[..4], ASSESSOR_ONCHAIN_SELECTOR.as_slice());
+
+        let prover_address = ctx.customer_signer.address();
+        let market_domain = eip712_domain(Address::ZERO, 1).alloy_struct();
+        let hash = fulfillment_batch_auth_signing_hash(
+            &onchain_assessor_eip712_domain(adapter, 1),
+            prover_address,
+            &[request.eip712_signing_hash(&market_domain)],
+            &[fills[0].claimDigest],
+        );
+        let recovered = Signature::try_from(&assessor_seal[4..])
+            .unwrap()
+            .recover_address_from_prehash(&hash)
+            .unwrap();
+        assert_eq!(recovered, prover_address);
     }
 
     #[tokio::test]
@@ -774,7 +903,7 @@ mod tests {
         let mut fulfiller = OrderFulfiller::initialize(
             prover,
             &client,
-            ASSESSOR_R0_SELECTOR,
+            AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
             &format!("file://{ASSESSOR_GUEST_PATH}"),
         )
         .await

--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -903,8 +903,11 @@ impl<P: Provider> BoundlessMarketService<P> {
     /// Records a fulfillment commitment for the open path (front-running guard, #2052).
     ///
     /// The market requires the commitment to have been recorded in a strictly earlier block
-    /// than the reveal, so callers must await this receipt before broadcasting the `fulfill`:
-    /// awaiting it guarantees the reveal is mined at least one block later.
+    /// than the reveal. Awaiting the commit receipt guarantees the reveal is *mined* at least
+    /// one block later, but not that it is *broadcast*: the reveal's gas estimation simulates
+    /// against the current head, and on nodes where the pending tag aliases latest (op-geth)
+    /// that is the commit's own block, where the age check reverts. This method therefore also
+    /// waits for the head to pass the commit block before returning.
     pub async fn commit_fulfillment(&self, commitment: B256) -> Result<(), MarketError> {
         tracing::trace!("Calling commitFulfillment({commitment:x})");
         let call = self.instance.commitFulfillment(commitment).from(self.caller);
@@ -912,6 +915,27 @@ impl<P: Provider> BoundlessMarketService<P> {
         tracing::debug!("Broadcasting commit tx {}", pending_tx.tx_hash());
         let receipt = self.get_receipt_with_retry(pending_tx).await?;
         tracing::debug!("Fulfillment commitment recorded in tx {}", receipt.transaction_hash);
+
+        // The reveal must execute in a strictly later block, and the caller's next step is a
+        // `send()` whose gas estimation simulates against the current head: on nodes that
+        // estimate against the latest block (e.g. op-geth, where the pending tag aliases
+        // latest), estimating in the commit's own block reverts `MissingFulfillmentCommitment`
+        // before the reveal is ever broadcast. Wait for the head to pass the commit block.
+        // Bounded: chains that only mine on demand (anvil) never advance here, but their
+        // estimation runs on a next-block env and passes anyway.
+        if let Some(commit_block) = receipt.block_number {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+            while self.get_latest_block_number().await? <= commit_block {
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::debug!(
+                        "Chain head did not pass the commit block within the grace period; \
+                         proceeding to the reveal"
+                    );
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
         Ok(())
     }
 

--- a/crates/boundless-market/src/contracts/boundless_market.rs
+++ b/crates/boundless-market/src/contracts/boundless_market.rs
@@ -904,10 +904,8 @@ impl<P: Provider> BoundlessMarketService<P> {
     ///
     /// The market requires the commitment to have been recorded in a strictly earlier block
     /// than the reveal. Awaiting the commit receipt guarantees the reveal is *mined* at least
-    /// one block later, but not that it is *broadcast*: the reveal's gas estimation simulates
-    /// against the current head, and on nodes where the pending tag aliases latest (op-geth)
-    /// that is the commit's own block, where the age check reverts. This method therefore also
-    /// waits for the head to pass the commit block before returning.
+    /// one block later; whether its gas estimation also sees a later block depends on the
+    /// node — see the reveal retry in [`BoundlessMarketService::fulfill`].
     pub async fn commit_fulfillment(&self, commitment: B256) -> Result<(), MarketError> {
         tracing::trace!("Calling commitFulfillment({commitment:x})");
         let call = self.instance.commitFulfillment(commitment).from(self.caller);
@@ -915,27 +913,6 @@ impl<P: Provider> BoundlessMarketService<P> {
         tracing::debug!("Broadcasting commit tx {}", pending_tx.tx_hash());
         let receipt = self.get_receipt_with_retry(pending_tx).await?;
         tracing::debug!("Fulfillment commitment recorded in tx {}", receipt.transaction_hash);
-
-        // The reveal must execute in a strictly later block, and the caller's next step is a
-        // `send()` whose gas estimation simulates against the current head: on nodes that
-        // estimate against the latest block (e.g. op-geth, where the pending tag aliases
-        // latest), estimating in the commit's own block reverts `MissingFulfillmentCommitment`
-        // before the reveal is ever broadcast. Wait for the head to pass the commit block.
-        // Bounded: chains that only mine on demand (anvil) never advance here, but their
-        // estimation runs on a next-block env and passes anyway.
-        if let Some(commit_block) = receipt.block_number {
-            let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
-            while self.get_latest_block_number().await? <= commit_block {
-                if tokio::time::Instant::now() >= deadline {
-                    tracing::debug!(
-                        "Chain head did not pass the commit block within the grace period; \
-                         proceeding to the reveal"
-                    );
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(500)).await;
-            }
-        }
         Ok(())
     }
 
@@ -987,64 +964,104 @@ impl<P: Provider> BoundlessMarketService<P> {
             self.commit_fulfillment(commitment).await?;
         }
 
-        match root {
-            None => match (price, withdraw) {
-                (false, false) => {
-                    tracing::debug!("Fulfilling requests {:?} with fulfill", request_ids);
-                    self._fulfill(fulfillment_batches).await
-                }
-                (false, true) => {
-                    tracing::debug!(
-                        "Fulfilling requests {:?} with fulfill and withdraw",
-                        request_ids
-                    );
-                    self.fulfill_and_withdraw(fulfillment_batches).await
-                }
-                (true, false) => {
-                    tracing::debug!("Fulfilling requests {:?} with price and fulfill", request_ids);
-                    self.price_and_fulfill(request_batches, fulfillment_batches).await
-                }
-                (true, true) => {
-                    tracing::debug!(
-                        "Fulfilling requests {:?} with price and fulfill and withdraw",
-                        request_ids
-                    );
-                    self.price_and_fulfill_and_withdraw(request_batches, fulfillment_batches).await
-                }
-            },
-            Some(root) => match (price, withdraw) {
-                (false, false) => {
-                    tracing::debug!(
-                        "Fulfilling requests {:?} with submitting root and fulfill",
-                        request_ids
-                    );
-                    self.submit_root_and_fulfill(root, fulfillment_batches).await
-                }
-                (false, true) => {
-                    tracing::debug!(
-                        "Fulfilling requests {:?} with submitting root and fulfill and withdraw",
-                        request_ids
-                    );
-                    self.submit_root_and_fulfill_and_withdraw(root, fulfillment_batches).await
-                }
-                (true, false) => {
-                    tracing::debug!(
-                        "Fulfilling requests {:?} with submitting root and price and fulfill",
-                        request_ids
-                    );
-                    self.submit_root_and_price_fulfill(root, request_batches, fulfillment_batches)
+        // The reveal must land in a strictly later block than the commit, and its gas
+        // estimation simulates against the current head: on nodes where the pending tag
+        // aliases latest (op-geth), that is the commit's own block, where the age check still
+        // fails and estimation reverts `MissingFulfillmentCommitment` before the reveal is
+        // ever broadcast. Retry until the head passes the commit block (bounded); nodes that
+        // estimate on a next-block env (anvil, L1 geth) pass on the first attempt.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            let result = match &root {
+                None => match (price, withdraw) {
+                    (false, false) => {
+                        tracing::debug!("Fulfilling requests {:?} with fulfill", request_ids);
+                        self._fulfill(fulfillment_batches.clone()).await
+                    }
+                    (false, true) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with fulfill and withdraw",
+                            request_ids
+                        );
+                        self.fulfill_and_withdraw(fulfillment_batches.clone()).await
+                    }
+                    (true, false) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with price and fulfill",
+                            request_ids
+                        );
+                        self.price_and_fulfill(request_batches.clone(), fulfillment_batches.clone())
+                            .await
+                    }
+                    (true, true) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with price and fulfill and withdraw",
+                            request_ids
+                        );
+                        self.price_and_fulfill_and_withdraw(
+                            request_batches.clone(),
+                            fulfillment_batches.clone(),
+                        )
                         .await
+                    }
+                },
+                Some(root) => match (price, withdraw) {
+                    (false, false) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with submitting root and fulfill",
+                            request_ids
+                        );
+                        self.submit_root_and_fulfill(root.clone(), fulfillment_batches.clone())
+                            .await
+                    }
+                    (false, true) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with submitting root and fulfill and withdraw",
+                            request_ids
+                        );
+                        self.submit_root_and_fulfill_and_withdraw(
+                            root.clone(),
+                            fulfillment_batches.clone(),
+                        )
+                        .await
+                    }
+                    (true, false) => {
+                        tracing::debug!(
+                            "Fulfilling requests {:?} with submitting root and price and fulfill",
+                            request_ids
+                        );
+                        self.submit_root_and_price_fulfill(
+                            root.clone(),
+                            request_batches.clone(),
+                            fulfillment_batches.clone(),
+                        )
+                        .await
+                    }
+                    (true, true) => {
+                        tracing::debug!("Fulfilling requests {:?} with submitting root and price and fulfill and withdraw", request_ids);
+                        self.submit_root_and_price_fulfill_and_withdraw(
+                            root.clone(),
+                            request_batches.clone(),
+                            fulfillment_batches.clone(),
+                        )
+                        .await
+                    }
+                },
+            };
+            match result {
+                Err(err)
+                    if price
+                        && format!("{err:?}").contains("MissingFulfillmentCommitment")
+                        && tokio::time::Instant::now() < deadline =>
+                {
+                    tracing::debug!(
+                        "Reveal was estimated in the commit's own block; retrying once the \
+                         head advances"
+                    );
+                    tokio::time::sleep(Duration::from_millis(500)).await;
                 }
-                (true, true) => {
-                    tracing::debug!("Fulfilling requests {:?} with submitting root and price and fulfill and withdraw", request_ids);
-                    self.submit_root_and_price_fulfill_and_withdraw(
-                        root,
-                        request_batches,
-                        fulfillment_batches,
-                    )
-                    .await
-                }
-            },
+                result => return result,
+            }
         }
     }
 

--- a/crates/indexer/src/market/caching/file.rs
+++ b/crates/indexer/src/market/caching/file.rs
@@ -251,7 +251,7 @@ mod tests {
         let prover = OrderFulfiller::initialize(
             Arc::new(DefaultProver::default()),
             &client,
-            ASSESSOR_R0_SELECTOR,
+            boundless_cli::AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
             &format!("file://{ASSESSOR_GUEST_PATH}"),
         )
         .await

--- a/crates/indexer/tests/market/common.rs
+++ b/crates/indexer/tests/market/common.rs
@@ -73,7 +73,7 @@ pub async fn new_market_test_fixture(
     let prover = OrderFulfiller::initialize(
         Arc::new(BrokerDefaultProver::default()),
         &client,
-        ASSESSOR_R0_SELECTOR,
+        boundless_cli::AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
         &format!("file://{ASSESSOR_GUEST_PATH}"),
     )
     .await

--- a/crates/slasher/tests/basic.rs
+++ b/crates/slasher/tests/basic.rs
@@ -274,7 +274,7 @@ async fn test_slash_fulfilled(pool: sqlx::PgPool) {
     let fulfiller = OrderFulfiller::initialize(
         prover,
         &client,
-        ASSESSOR_R0_SELECTOR,
+        boundless_cli::AssessorMode::R0 { selector: ASSESSOR_R0_SELECTOR },
         &format!("file://{ASSESSOR_GUEST_PATH}"),
     )
     .await


### PR DESCRIPTION
## Summary

`boundless prover fulfill` was hardwired to the R0 zkVM assessor: `--assessor-selector` was a required flag and the assessor guest was always proven, even though the router-native market ships a cheaper native assessor. The flag now defaults to the on-chain assessor (`0x00000022`), bringing the CLI in line with the broker's preferred path (#2005, #2040). Any other selector (e.g. `0x00000024`) keeps the previous guest-based flow, so the old behavior remains one flag away.

## Main changes

- **`AssessorMode` enum on `OrderFulfiller`** (`crates/boundless-cli/src/lib.rs`): `R0 { selector }` proves the assessor guest and seals with its set-inclusion proof (unchanged behavior); `Onchain { selector, adapter, signer }` skips the assessor guest entirely — no ELF download, no proof, order claims only in the set-builder aggregation — and seals the batch with an EIP-712 `FulfillmentBatchAuth` signature via the SDK's `build_onchain_assessor_seal`.
- **`prover fulfill`** (`commands/prover/fulfill.rs`): `--assessor-selector` defaults to `ONCHAIN_ASSESSOR_SELECTOR`; on the default the `OnChainAssessor` adapter address is discovered through the market's router (`router_entry_impl`), with a clear error pointing at the R0 selector when the market has no on-chain assessor registered. The selected assessor is shown in the command output.
- **Mechanical call-site adaptations**: `boundless-ffi` (unchanged behavior — its Forge deployment test pins the R0 selector explicitly), slasher and indexer test helpers.
- **New test** `test_fulfill_onchain_assessor`: asserts the seal is `selector ‖ 65-byte signature` recovering to the prover over the exact hash `OnChainAssessor` reconstructs, and covers the single-leaf aggregation with the assessor guest skipped.

## Seal construction per mode

```
orders ──► prove order guests ──► set-builder aggregation ──► per-fill set-inclusion seals
                │
                ├─ R0 (override):  prove assessor guest ──► include in aggregation ──► assessorSeal = 0x00000024 ‖ set-inclusion proof
                │
                └─ Onchain (default):  sign FulfillmentBatchAuth(prover, requestDigests, claimDigests)
                                       ──► assessorSeal = 0x00000022 ‖ 65-byte ECDSA sig
```

## Commit-reveal fix (SDK)

Live testing on Base Sepolia staging surfaced a client-side race in the open-path commit-reveal flow, fixed here in `boundless-market`: the reveal's gas estimation simulates against the current head, and on nodes where the pending tag aliases latest (op-geth) that is the commit's own block — `committedBlock + COMMIT_REVEAL_MIN_BLOCKS > block.number` holds and the estimation reverts `MissingFulfillmentCommitment` before the reveal is ever broadcast. The fix retries the reveal dispatch (bounded, 15s) when its estimation reverts `MissingFulfillmentCommitment`: nodes that estimate on a next-block env (anvil, L1 geth) pass on the first attempt with no added latency, while op-geth-style nodes retry until the head passes the commit block. Verified live on Base staging (estimation revert observed, one 500ms retry, reveal landed two blocks after the commit) and against the anvil test suite (no timing impact — an earlier pre-wait variant of this fix deterministically lost the `test_slash_fulfilled` race to the slasher's poll loop, which is why the retry design won). This affects every open-path submitter — the CLI fulfiller and the broker alike.

## Live validation (Base Sepolia staging, market `0x7abb…ca8e`)

Ran the T6 cells of `docs/2026-07-09_staging-router-proof-matrix-runbook.md` against the shared staging market:

| Cell | Assessor | Commit | Reveal | Checks |
|---|---|---|---|---|
| T6a never-locked, CLI default | `00000022` (sig) | [`0x8319…0823`](https://sepolia.basescan.org/tx/0x8319691c1668ab191948e8a9dd62ce6d6d86887ac1587393f48a6d484dcd0823) | [`0x1723…b756`](https://sepolia.basescan.org/tx/0x172329177872e651bc7466c2060b5789e83b472c1f77cc0912cc70f42b39b756) | fulfilled ✓ seal prefix ✓ commitment consumed ✓ replay reverts ✓ |
| T6a never-locked, CLI `--assessor-selector 0x00000024` | `00000024` (STARK guest) | [`0xc8d0…27ad`](https://sepolia.basescan.org/tx/0xc8d0a4547989cbc78e05f303cc5915eb06a6026e09cf7cba3881571bc1d227ad) | [`0xdead…e0fd`](https://sepolia.basescan.org/tx/0xdead8f25fd6574d4fd6ba7d627db4780cd3fb11c10bde5ef523621e831fbe0fd) | same, incl. deployed-assessor-guest proving (#2060) ✓ |
| T6b lock-expired, broker | `00000022` (sig) | [`0xac3e…f907`](https://sepolia.basescan.org/tx/0xac3eea6f3d463e5e2189bf3c3776bf25ca5e9211efd7df10cb0a933f1700f907) | [`0x2b42…29a1`](https://sepolia.basescan.org/tx/0x2b429bfba2ed5ae3af717704a44eb5fbed56ae8ccf5d19aa04898a791b4829a1) | fulfilled after lock expiry ✓ commit from broker ≠ locker ✓ replay reverts ✓ |

Every reveal landed ≥ 1 block after its commit, and replaying any reveal's exact calldata reverts `MissingFulfillmentCommitment` (`0x4b46580b`).

Related: #1982 (router decoupling, migrated the CLI to the batched ABI), #2005 (OnChainAssessor), #2040 (broker assessor selection), #2060 (Digest wire format, validated live by the second cell).
