### PR TITLE
BM-3101: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Note: Order is important; the last matching pattern takes the most
 # precedence.
 
-*                                      @boundless-xyz/maintainers @capossele @Wollac @zeroecco @willemolding @zeroecco @nahoc @unizarr @jonastheis @bobbobbio
+*                                      @boundless-xyz/maintainers @capossele @Wollac @zeroecco @willemolding @zeroecco @nahoc @unizarr @jonastheis @bobbobbio @emilianobonassi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # Note: Order is important; the last matching pattern takes the most
 # precedence.
 
-*                                      @boundless-xyz/maintainers @capossele @Wollac @zeroecco @willemolding @zeroecco @nahoc @unizarr @jonastheis @bobbobbio @emilianobonassi
+*                                      @boundless-xyz/maintainers @capossele @zeroecco @nahoc @unizarr @jonastheis @emilianobonassi


### PR DESCRIPTION
## Summary
- Add @emilianobonassi as a repo code owner.
- Remove @Wollac, @willemolding, and @bobbobbio.

## Test plan
- [ ] Confirm GitHub shows @emilianobonassi as a code owner.
- [ ] Confirm @Wollac, @willemolding, and @bobbobbio are no longer listed.