### PR TITLE
BM-3105: chore: rotate customer address

### DIFF
--- a/requestor-lists/boundless-allowed-list.json
+++ b/requestor-lists/boundless-allowed-list.json
@@ -259,7 +259,23 @@
       "extensions": {}
     },
     {
+      "address": "0xB183486bd8731703c246E2c27d3D7CBeDCb15e88",
+      "chainId": 8453,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
       "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Allowed Requestor",
+      "description": "",
+      "tags": [],
+      "extensions": {}
+    },
+    {
+      "address": "0xB183486bd8731703c246E2c27d3D7CBeDCb15e88",
       "chainId": 167000,
       "name": "Allowed Requestor",
       "description": "",

--- a/requestor-lists/boundless-priority-list.large.json
+++ b/requestor-lists/boundless-priority-list.large.json
@@ -78,7 +78,41 @@
       }
     },
     {
+      "address": "0xB183486bd8731703c246E2c27d3D7CBeDCb15e88",
+      "chainId": 8453,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "priority": {
+          "level": 100
+        },
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
+    },
+    {
       "address": "0x64e356256d87e5f7b36eb35eb62442386591c294",
+      "chainId": 167000,
+      "name": "Anonymous Customer (Papaya)",
+      "description": "",
+      "tags": [],
+      "extensions": {
+        "priority": {
+          "level": 100
+        },
+        "requestEstimates": {
+          "estimatedMcycleCountMin": 170,
+          "estimatedMcycleCountMax": 10000,
+          "estimatedMaxInputSizeMB": 550
+        }
+      }
+    },
+    {
+      "address": "0xB183486bd8731703c246E2c27d3D7CBeDCb15e88",
       "chainId": 167000,
       "name": "Anonymous Customer (Papaya)",
       "description": "",


### PR DESCRIPTION
Add 0xB183486bd8731703c246E2c27d3D7CBeDCb15e88 to the allowed list and large priority list alongside the existing address, on both Base (8453) and Taiko (167000). The previous address is left in place so requests from it keep being accepted during the rotation.